### PR TITLE
Resolve incorrect usage of cmake dependent options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,12 @@ option(BUILD_TESTING "Build the tests" OFF)
 # Advanced options
 include(CMakeDependentOption)
 
-cmake_dependent_option(
-    ONLY_DOCS "Only build the documentation" OFF
-    "BUILD_DOCS" OFF
-)
+option(ONLY_DOCS "Only build the documentation" OFF)
+if (ONLY_DOCS)
+    set(BUILD_DOCS ON)
+    set(BUILD_EXAMPLES OFF)
+    set(BUILD_TESTING OFF)
+endif()
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build.")
 


### PR DESCRIPTION
This pull request resolves an issue where cmake dependent options were being used incorrectly. The `ONLY_DOCS` option was not properly setting the `BUILD_DOCS`, `BUILD_EXAMPLES`, and `BUILD_TESTING` options. This pull request fixes the issue by properly setting these options when `ONLY_DOCS` is enabled.