### PR TITLE
Migrate math routines to neko

### DIFF
--- a/examples/easy-E/heat_source.f90
+++ b/examples/easy-E/heat_source.f90
@@ -50,8 +50,8 @@ contains
 
   !> Heat source
   subroutine heat_source(rhs, t)
-    use math_ext, only: sub3_mask, cfill_mask
-    use device_math_ext, only: device_sub3_mask, device_cfill_mask
+    use math_ext, only: sub3_mask
+    use device_math_ext, only: device_sub3_mask
 
     class(scalar_user_source_term_t), intent(inout) :: rhs
     real(kind=rp), intent(in) :: t

--- a/sources/neko_ext/math/bcknd/device/cuda/math_ext.cu
+++ b/sources/neko_ext/math/bcknd/device/cuda/math_ext.cu
@@ -43,18 +43,6 @@ extern "C" {
 #include <math/bcknd/device/device_mpi_op.h>
 #include <math/bcknd/device/device_mpi_reduce.h>
 
-/** Fortran wrapper for cfill_mask
- * Fill a scalar to vector \f$ a_i = s, for i \in mask \f$
- */
-void cuda_cfill_mask(void* a, real* c, int* size, int* mask, int* mask_size) {
-
-    const dim3 nthrds(1024, 1, 1);
-    const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
-
-    cfill_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
-        (real*)a, *c, *size, mask, *mask_size);
-    CUDA_CHECK(cudaGetLastError());
-}
 /** Fortran wrapper for cadd_mask
  * Add a scalar to vector \f$ a_i = a_i + s, for i \in mask \f$
  */

--- a/sources/neko_ext/math/bcknd/device/cuda/math_ext_kernel.h
+++ b/sources/neko_ext/math/bcknd/device/cuda/math_ext_kernel.h
@@ -36,20 +36,6 @@
 #define __NEKO_CUDA_MATH_EXT_KERNELS__
 
 /**
- * Device kernel for cfill_mask
- */
-template <typename T>
-__global__ void cfill_mask_kernel(
-    T* __restrict__ a, const T c, const int size, int* __restrict__ mask,
-    const int mask_size) {
-
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const int str = blockDim.x * gridDim.x;
-
-    for (int i = idx; i < mask_size; i += str) { a[mask[i]-1] = c; }
-}
-
-/**
  * Device kernel for cadd_mask
  */
 template <typename T>

--- a/sources/neko_ext/math/bcknd/device_math_ext.f90
+++ b/sources/neko_ext/math/bcknd/device_math_ext.f90
@@ -42,18 +42,6 @@ module device_math_ext
 #elif HAVE_CUDA
 
   interface
-     subroutine cuda_cfill_mask(a_d, c, size, mask_d, mask_size) &
-       bind(c, name='cuda_cfill_mask')
-       use, intrinsic :: iso_c_binding
-       import c_rp
-       type(c_ptr), value :: a_d
-       real(c_rp) :: c
-       integer(c_int) :: size
-       type(c_ptr), value :: mask_d
-       integer(c_int) :: mask_size
-     end subroutine cuda_cfill_mask
-  end interface
-  interface
      subroutine cuda_cadd_mask(a_d, c, size, mask_d, mask_size) &
        bind(c, name='cuda_cadd_mask')
        use, intrinsic :: iso_c_binding
@@ -120,19 +108,6 @@ module device_math_ext
 #endif
 
 contains
-
-  subroutine device_cfill_mask(a_d, c, size, mask_d, mask_size)
-    type(c_ptr) :: a_d
-    real(kind=rp), intent(in) :: c
-    integer :: size
-    type(c_ptr) :: mask_d
-    integer :: mask_size
-#ifdef HAVE_CUDA
-    call cuda_cfill_mask(a_d, c, size, mask_d, mask_size)
-#else
-    call neko_error('No device backend configured')
-#endif
-  end subroutine device_cfill_mask
 
   subroutine device_cadd_mask(a_d, c, size, mask_d, mask_size)
     type(c_ptr) :: a_d

--- a/sources/neko_ext/math/math_ext.f90
+++ b/sources/neko_ext/math/math_ext.f90
@@ -4,22 +4,6 @@ module math_ext
 
 contains
 
-  !> @brief Fill a constant to a masked vector.
-  !! \f$ a_i = c, for i in mask \f$
-  subroutine cfill_mask(a, c, size, mask, mask_size)
-    real(kind=rp), dimension(size), intent(inout) :: a
-    real(kind=rp), intent(in) :: c
-    integer, intent(in) :: size
-    integer, dimension(mask_size), intent(in) :: mask
-    integer, intent(in) :: mask_size
-    integer :: i
-
-    do i = 1, mask_size
-       a(mask(i)) = c
-    end do
-
-  end subroutine cfill_mask
-
   !> @brief Add a constant to a masked vector.
   !! \f$ a_i = a_i + c, for i in mask \f$
   subroutine cadd_mask(a, c, size, mask, mask_size)


### PR DESCRIPTION
This pull request migrates some math routines to neko. 

The changes include updating the use statements in the `heat_source` subroutine and removing the `cuda_cfill_mask` function from the `device_math_ext` module.