### PR TITLE
Fix issues with Neko tool accessibility and mesh generation

### DIFF
--- a/examples/mma/default.case
+++ b/examples/mma/default.case
@@ -1,7 +1,7 @@
 {
     "version": 1.0,
     "case": {
-        "mesh_file": "data/debugging_pipe.nmsh",
+        "mesh_file": "box.nmsh",
         "output_checkpoints": false,
         "output_at_end": true,
         "end_time": 1e-5,

--- a/examples/mma/mma_simcomp.f90
+++ b/examples/mma/mma_simcomp.f90
@@ -84,6 +84,8 @@ contains
     type(json_file), intent(inout) :: json
     class(case_t), intent(inout), target :: case
 
+    call this%init_base(json, case)
+
     call this%tmp%init(case%msh, case%fluid%Xh, "tmp")
     call this%designx%init(case%msh, case%fluid%Xh, "designx")
     call this%xmax%init(case%msh, case%fluid%Xh, "xmax")
@@ -98,7 +100,6 @@ contains
     call json_get_or_default(json, "d_const", this%d_const, 1.0_rp)
 
     call this%init_from_attributes()
-    call this%init_base(json, case)
   end subroutine simcomp_test_init_from_json
 
   ! Actual constructor.

--- a/examples/mma/prepare.sh
+++ b/examples/mma/prepare.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Use genmeshbox to generate a mesh box
+genmeshbox 0 4 0 1 0 1 64 4 4 .false. .false. .false.

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -63,6 +63,7 @@ function prepare {
     JSON_FORTRAN=$(find $JSON_FORTRAN_DIR -type d \
         -exec test -f '{}'/libjsonfortran.so \; -print)
     export LD_LIBRARY_PATH="$JSON_FORTRAN:$LD_LIBRARY_PATH"
+    export PATH="$NEKO_DIR/bin:$PATH"
 
     # Run preparation if it exists
     if [ -f "prepare.sh" ]; then
@@ -83,7 +84,7 @@ function prepare {
     # ------------------------------------------------------------------------ #
     # Find the Neko executable
 
-    if [ -f neko ]; then
+    if [ -f ./neko ]; then
         neko=$(realpath ./neko)
     elif [ ! -z "$(ls *.f90 2>/dev/null)" ]; then
         printf "=%.0s" {1..80} && printf "\n"


### PR DESCRIPTION
This pull request addresses two issues. Firstly, it ensures that the Neko tool is accessible from the examples. Secondly, it runs mesh generation in the preparation step. The changes include updating the mesh file path and adding using a Neko tool to generate a mesh box. Additionally, the initializer in the simcomp module has been moved.