### PR TITLE
Run compilation tests parallel to linting

### DIFF
--- a/.github/workflows/pr_develop.yml
+++ b/.github/workflows/pr_develop.yml
@@ -95,8 +95,6 @@ jobs:
     name: Compilation
     needs:
       - prepare
-      - check_lint
-      # - check_formatting
     uses: ./.github/workflows/check_neko-top.yml
     with:
       neko-version: ${{ needs.prepare.outputs.neko-version }}


### PR DESCRIPTION
This pull request updates the workflow to run compilation tests in parallel with linting. The previous workflow only ran linting and formatting checks. Now, the compilation tests will be executed alongside the linting process.