### PR TITLE
masks

### DIFF
--- a/examples/rugby_ball/README.md
+++ b/examples/rugby_ball/README.md
@@ -123,7 +123,7 @@ objective functions and constraints that we require a fluid simulation.
 This level of abstraction/objected oriented thinking is beyond me, but I'm 
 sure we'll require some refactoring to make this right.
 
-### Masks
+### Masks :white_check_mark:
 This one is rather simple, just including masks on objective functions and 
 masks on the optimization domain. We could then compute volume based on the 
 optimization domain, not the computation domain.
@@ -133,7 +133,7 @@ suggested Tim. In `Nek5000` we filled up arrays the size of the mesh with
 booleans. That's rather light, and we could still use all the point zone 
 functionality to initialize these masks.
 
-### incorporate the PDE filters
+### incorporate the PDE filters :white_check_mark:
 We already have a branch in Neko where we did the PDE filters. Either we PR 
 that in neko, so it can be used with the standard Brinkman term there, or we 
 just migrate everything to neko-top. 

--- a/examples/rugby_ball/driver.f90
+++ b/examples/rugby_ball/driver.f90
@@ -105,9 +105,11 @@ program usrneko
      ! Abbas, don't just mask the sensitivity like I'm doing here, make sure
      ! the only design variables entering MMA are those within the mask.
      ! This way you get the correct N etc.
-     call mask_exterior_const(&
-     problem%volume_constraint%sensitivity_to_coefficient, &
-     design%optimization_domain, 0.0_rp)
+     if (design%if_mask) then
+        call mask_exterior_const(&
+        problem%volume_constraint%sensitivity_to_coefficient, &
+        design%optimization_domain, 0.0_rp)
+     end if
 
      ! now we have the optimizer act on the design field.
 

--- a/examples/rugby_ball/driver.f90
+++ b/examples/rugby_ball/driver.f90
@@ -105,6 +105,10 @@ program usrneko
      ! Abbas, don't just mask the sensitivity like I'm doing here, make sure
      ! the only design variables entering MMA are those within the mask.
      ! This way you get the correct N etc.
+
+     ! Look into the `masked_red_copy` function that Martin implemented.
+     ! That function will copy from one array to another, but the target 
+     ! only have the size of the mask, not the full size.
      if (design%if_mask) then
         call mask_exterior_const(&
         problem%volume_constraint%sensitivity_to_coefficient, &

--- a/examples/rugby_ball/driver.f90
+++ b/examples/rugby_ball/driver.f90
@@ -21,6 +21,7 @@ program usrneko
   use mma, only: mma_t
   use neko_ext, only: reset
   use math, only: copy, cmult
+  use mask_ops, only: mask_exterior_const
 
 
   !> a problem type
@@ -100,6 +101,14 @@ program usrneko
      ! in this case it's MMA so we need gradient information
      call problem%compute_sensitivity()
 
+     ! TODO
+     ! Abbas, don't just mask the sensitivity like I'm doing here, make sure
+     ! the only design variables entering MMA are those within the mask.
+     ! This way you get the correct N etc.
+     call mask_exterior_const(&
+     problem%volume_constraint%sensitivity_to_coefficient, &
+     design%optimization_domain, 0.0_rp)
+
      ! now we have the optimizer act on the design field.
 
      fval(1) = problem%volume_constraint%objective_function_value
@@ -112,6 +121,7 @@ program usrneko
        ! TODO
        ! I'm CERTAIN the mass matrix comes in here, but I need to sit down
        ! with a pen and paper
+
 
        ! TODO
        ! for heuristic reasons, it's important to rescale the dfdx etc so

--- a/examples/rugby_ball/rugby_ball.case
+++ b/examples/rugby_ball/rugby_ball.case
@@ -62,6 +62,25 @@
                 "compute_control": "tsteps",
                 "compute_value": 1
             }
-        ]
+        ],
+     "point_zones": [
+            {
+                "name": "optimization_domain",
+                "geometry": "box",
+                "x_bounds": [
+                    0.2,
+                    0.8,
+                ],
+                "y_bounds": [
+                    0.2,
+                    0.8,
+                ],
+                "z_bounds": [
+                    -1.0,
+                     1.0,
+                ],
+           }
+                 ]
+
     }
 }

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -404,7 +404,7 @@ contains
     ! test something in the passive scalar.
     if (this%if_mask) then
        call mask_exterior_const(this%sensitivity, this%optimization_domain, &
-       0.0_rp)
+            0.0_rp)
     end if
 
     call neko_scratch_registry%relinquish_field(temp_indices)

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -280,7 +280,7 @@ contains
     ! Initialize the mask
     if (this%if_mask) then
        this%optimization_domain => &
-       neko_point_zone_registry%get_point_zone(optimization_domain_zone_name)
+            neko_point_zone_registry%get_point_zone(optimization_domain_zone_name)
     end if
 
 

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -393,12 +393,9 @@ contains
     this%filtered_design)
 
     ! TODO
-    ! oh oh... I don't know what to do here...
-    ! I'm just following the vibe of "everything in the adjoint happens in
-    ! reverse". So I'm masking at the end.
-    ! This could be wrong, talk to the big dogs.
+    ! DELETE THIS LATER
     !
-    ! Also, depending on how Abbas writes the interface for the optimization
+    ! When Abbas writes the interface for the optimization
     ! module this may be a moot point, because we would only really collect
     ! the sensitivity of the design variables inside the mask.
     !

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -197,10 +197,6 @@ module topopt_design
      type(field_t) :: filtered_design
 
 
-     !
-     ! TODO
-     ! you also had lots of masks etc that was a nice idea,
-     ! but we'll cross that bridge later
      !> A mask indicating the optimization domain
      class(point_zone_t), pointer :: optimization_domain
      !> A logical if we're restricting the optimization domain

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -316,7 +316,7 @@ contains
     ! if we mask first then filter, at least all the boundaries will be smooth.
     if (this%if_mask) then
        call mask_exterior_const(this%design_indicator, &
-       this%optimization_domain, 0.0_rp)
+            this%optimization_domain, 0.0_rp)
     end if
 
     ! TODO

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -41,6 +41,9 @@ module topopt_design
   use coefs, only: coef_t
   use scratch_registry, only: neko_scratch_registry
   use fld_file_output, only: fld_file_output_t
+  use point_zone_registry, only: neko_point_zone_registry
+  use point_zone, only: point_zone_t
+  use mask_ops, only: mask_exterior_const
 
   implicit none
   private

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -390,7 +390,7 @@ contains
     this%filtered_design)
 
     call this%filter%apply_backward(this%sensitivity, dF_dfiltered_design, &
-    this%filtered_design)
+         this%filtered_design)
 
     ! TODO
     ! DELETE THIS LATER

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -102,7 +102,9 @@ module topopt_design
   use linear_mapping, only: linear_mapping_t
   use RAMP_mapping, only: RAMP_mapping_t
   use PDE_filter, only: PDE_filter_t
+  use mask_ops, only: mask_exterior_const
   !use design_variable, only: design_variable_t
+  use point_zone, only: point_zone_t
   implicit none
   private
 
@@ -199,6 +201,10 @@ module topopt_design
      ! TODO
      ! you also had lots of masks etc that was a nice idea,
      ! but we'll cross that bridge later
+     !> A mask indicating the optimization domain
+     class(point_zone_t), pointer :: optimization_domain
+     !> A logical if we're restricting the optimization domain
+     logical :: if_mask
 
      ! TODO
      ! you also had logicals for convergence etc,
@@ -244,6 +250,7 @@ contains
     class(topopt_design_t), target, intent(inout) :: this
     type(json_file), intent(inout) :: json
     type(coef_t), intent(inout) :: coef
+    character(len=:), allocatable :: optimization_domain_zone_name
     integer :: n, i
     ! init the fields
     call this%design_indicator%init(coef%dof, "design_indicator")
@@ -266,6 +273,55 @@ contains
           this%design_indicator%x(i,1,1,1) = 1.0_rp
        end if
     end do
+
+    ! TODO, of course when we move all of Tim's stuff for initialization of
+    ! the initial design field we'll be reading things properly from the JSON.
+    ! call json_get(json, 'name', optimization_domain_zone_name)
+    ! Right now, I'm hardcoding the name of the point zone.
+    this%if_mask = .true.
+    optimization_domain_zone_name = "optimization_domain"
+
+    ! Initialize the mask
+    if (this%if_mask) then
+       this%optimization_domain => &
+       neko_point_zone_registry%get_point_zone(optimization_domain_zone_name)
+    end if
+
+
+
+
+    ! TODO
+    ! Regarding masks and filters, 
+    ! I suppose there are two ways of thinking about it:
+    ! 1) Mask first, then filter
+    ! 2) filter first, then mask
+    !
+    ! Each one can be used to achieve different results, and when we do complex
+    ! non-linear filter cascades the choice here has implications for exactly
+    ! how we define "minimum size control".
+    !
+    ! On top of this, I've only ever used spatial convolution filters before,
+    ! not PDE based filters.
+    ! With these filters you need to think of how your domain is "padded" when
+    ! you move the kernel over the boundary. Again, you can achieve different
+    ! effects depending on the choice of padding.
+    ! I don't really know if there's a similar implication for PDE based
+    ! based filters, I bet there is. (We should ask Niels and Casper) I bet it
+    ! means we need to consider the boundary of the mask as the boundary we
+    ! enforce to be Nuemann, not the boundary of the computational domain.
+    ! That sounds REALLY hard to implement...I hope it doesn't come down to
+    ! that.
+    !
+    ! We can always change this decision later, but I'm going with (1)
+    ! mask first, then filter.
+    ! The reason being, one of the purposes of the filtering is to avoid sharp
+    ! interfaces, if we filter first then mask there's a chance we have a sharp
+    ! interface on the boundary of the optimization domain.
+    ! if we mask first then filter, at least all the boundaries will be smooth.
+    if (this%if_mask) then
+       call mask_exterior_const(this%design_indicator, &
+       this%optimization_domain, 0.0_rp)
+    end if
 
     ! TODO
     ! we would also need to make a mapping type that reads in
@@ -301,6 +357,12 @@ contains
     class(topopt_design_t), target, intent(inout) :: this
 
 
+    ! TODO, see previous todo about mask first, then mapping
+    if (this%if_mask) then
+       call mask_exterior_const(this%design_indicator, &
+       this%optimization_domain, 0.0_rp)
+    end if
+
     ! TODO
     ! this should be somehow deffered so we can pick different mappings!!!
     ! so this would be:
@@ -334,6 +396,24 @@ contains
     call this%filter%apply_backward(this%sensitivity, dF_dfiltered_design, &
     this%filtered_design)
 
+    ! TODO
+    ! oh oh... I don't know what to do here...
+    ! I'm just following the vibe of "everything in the adjoint happens in
+    ! reverse". So I'm masking at the end.
+    ! This could be wrong, talk to the big dogs.
+    !
+    ! Also, depending on how Abbas writes the interface for the optimization
+    ! module this may be a moot point, because we would only really collect
+    ! the sensitivity of the design variables inside the mask.
+    !
+    ! Note for Abbas,
+    ! I'm NOT doing this because I'm too lazy and I just need masks so I can
+    ! test something in the passive scalar.
+    if (this%if_mask) then
+       call mask_exterior_const(this%sensitivity, this%optimization_domain, &
+       0.0_rp)
+    end if
+
     call neko_scratch_registry%relinquish_field(temp_indices)
 
   end subroutine topopt_design_map_backward
@@ -352,4 +432,5 @@ contains
     call this%output%sample(t)
 
   end subroutine topopt_design_sample
+
 end module topopt_design

--- a/sources/neko_ext/CMakeLists.txt
+++ b/sources/neko_ext/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/math)
 # Add the neko-ext library which collects all the extensions.
 target_sources(neko-top
     PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/mask_ops.f90
         ${CMAKE_CURRENT_SOURCE_DIR}/neko_ext.f90
         ${CMAKE_CURRENT_SOURCE_DIR}/develop.f90
         ${CMAKE_CURRENT_SOURCE_DIR}/json_utils_ext.f90

--- a/sources/neko_ext/mask_ops.f90
+++ b/sources/neko_ext/mask_ops.f90
@@ -69,7 +69,7 @@ contains
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call neko_error('GPU not supported for masks yet') 
     else
-    	do i = 1, mask%size
+       do i = 1, mask%size
           work%x(mask%mask(i), 1, 1, 1) = fld%x(mask%mask(i), 1, 1, 1)
        end do
     end if
@@ -102,7 +102,7 @@ contains
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call neko_error('GPU not supported for masks yet') 
     else
-    	do i = 1, mask%size
+       do i = 1, mask%size
           work%x(mask%mask(i), 1, 1, 1) = fld%x(mask%mask(i), 1, 1, 1)
        end do
     end if

--- a/sources/neko_ext/mask_ops.f90
+++ b/sources/neko_ext/mask_ops.f90
@@ -1,0 +1,136 @@
+! Copyright (c) 2024, The Neko Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+!
+!> Some common Masking operations we may need
+!! TODO
+!! I know I got outvoted on defining a mask as a field of booleans...
+!! You were right, `point_zones` are convenient, but I don't like that the
+!! `invert` is defined on initialization (maybe I'm misunderstanding)
+!! So we can chose either the interior or the exterior at the beginning.
+!!
+!! There's probably a smarter way of doing this, but if you want to zero the
+!! interior vs the exterior, one will involve some awkward memory shifting.
+module mask_ops
+  use field, only: field_t
+  use neko_config, only: NEKO_BCKND_DEVICE
+  use num_types, only: rp, xp
+  use utils, only: neko_error
+  use point_zone, only: point_zone_t
+  use scratch_registry, only : neko_scratch_registry
+  use field_math, only: field_cfill, field_copy
+  use comm
+  implicit none
+
+  private
+  public :: mask_exterior_const, mask_interior_const, masked_glsc2 
+
+contains
+
+  !> @brief Force everything outside the mask to be a constant value
+  !! @param[in,out] fld The field being masked
+  !! @param[in,out] The mask being applied.
+  !! @param[in] The value to be filled
+  !! NOTE! we always assume the incoming point zone describes the interior of
+  !! the mask, ie, `invert = .false.`
+  subroutine mask_exterior_const(fld, mask, const)
+    type(field_t), intent(inout) :: fld
+    class(point_zone_t), intent(inout) :: mask
+    real(kind=rp), intent(in) :: const
+    type(field_t), pointer :: work
+    integer :: temp_indices(1)
+    integer :: i
+
+    call neko_scratch_registry%request_field(work , temp_indices(1))
+
+    ! fill background fld
+    call field_cfill(work, const)
+
+    ! copy the fld in the masked region
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call neko_error('GPU not supported for masks yet')
+    else
+       do i = 1, mask%size
+          work%x(mask%mask(i), 1, 1, 1) = fld%x(mask%mask(i), 1, 1, 1)
+       end do
+    end if
+
+    ! copy over
+    call field_copy(fld, work)
+
+    call neko_scratch_registry%relinquish_field(temp_indices)
+
+  end subroutine mask_exterior_const
+
+  !> @brief Force everything inside the mask to be a constant value
+  !! @param[in,out] fld The field being masked
+  !! @param[in,out] The mask being applied.
+  !! @param[in] The value to be filled
+  !! NOTE! we always assume the incoming point zone describes the interior of
+  !! the mask, ie, `invert = .false.`
+  subroutine mask_interior_const(fld, mask, const)
+    type(field_t), intent(inout) :: fld
+    class(point_zone_t), intent(inout) :: mask
+    real(kind=rp), intent(in) :: const
+    integer :: i
+
+    ! copy the fld in the masked region
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call neko_error('GPU not supported for masks yet')
+    else
+       do i = 1, mask%size
+          fld%x(mask%mask(i), 1, 1, 1) = const 
+       end do
+    end if
+
+  end subroutine mask_interior_const
+
+  !> Weighted inner product \f$ a^T b \f$ masked
+  !! we probably don't need the n as an input..
+  function masked_glsc2(a, b, mask, n)
+    integer, intent(in) :: n
+    real(kind=rp), dimension(n), intent(in) :: a
+    real(kind=rp), dimension(n), intent(in) :: b
+    class(point_zone_t), intent(inout) :: mask
+    real(kind=rp) :: masked_glsc2
+    real(kind=xp) :: tmp
+    integer :: i, ierr
+
+    tmp = 0.0_xp
+    do i = 1, mask%size
+       tmp = tmp + a(mask%mask(i)) * b(mask%mask(i))
+    end do
+
+    call MPI_Allreduce(MPI_IN_PLACE, tmp, 1, &
+         MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
+    masked_glsc2 = tmp
+  end function masked_glsc2
+end module mask_ops

--- a/sources/neko_ext/math/math_ext.f90
+++ b/sources/neko_ext/math/math_ext.f90
@@ -1,5 +1,6 @@
 module math_ext
-  use num_types, only: rp
+  use num_types, only: rp, xp
+  use comm
   implicit none
 
 contains
@@ -93,4 +94,24 @@ contains
 
   end subroutine sub3_mask
 
+  !> @brief Weighted inner product 
+  !! \f$ a^T b \f$ for indices in the mask
+  function glsc2_mask(a, b, size, mask, mask_size)
+    integer, intent(in) :: size, mask_size
+    real(kind=rp), dimension(size), intent(in) :: a
+    real(kind=rp), dimension(size), intent(in) :: b
+    integer, dimension(mask_size), intent(in) :: mask
+    real(kind=rp) :: glsc2_mask
+    real(kind=xp) :: tmp
+    integer :: i, ierr
+
+    tmp = 0.0_xp
+    do i = 1, mask_size
+       tmp = tmp + a(mask(i)) * b(mask(i))
+    end do
+
+    call MPI_Allreduce(MPI_IN_PLACE, tmp, 1, &
+         MPI_EXTRA_PRECISION, MPI_SUM, NEKO_COMM, ierr)
+    glsc2_mask = tmp
+  end function glsc2_mask
 end module math_ext

--- a/sources/objectives/minimum_dissipation_objective_function.f90
+++ b/sources/objectives/minimum_dissipation_objective_function.f90
@@ -94,6 +94,8 @@ module minimum_dissipation_objective_function
   use math, only : glsc2
   use topopt_design, only: topopt_design_t
   use adjoint_lube_source_term, only: adjoint_lube_source_term_t
+  use point_zone, only: point_zone_t
+  use mask_ops, only: mask_exterior_const
   implicit none
   private
 
@@ -140,6 +142,8 @@ contains
     type(topopt_design_t), intent(inout) :: design
     type(adjoint_minimum_dissipation_source_term_t) :: adjoint_forcing
     type(adjoint_lube_source_term_t) :: lube_term
+    character(len=:), allocatable :: objective_location_zone_name
+    logical :: if_mask
 
     ! here we would read from the JSON (or have something passed in)
     ! about the lube term
@@ -149,7 +153,11 @@ contains
     !this%obj_scale = 0.00000001_rp
 
 
-    call this%init_base(fluid%dm_Xh)
+    ! mask would also be read from JSON... I'm hard coding
+    if_mask = .false.
+    objective_location_zone_name = "objective_location"
+
+    call this%init_base(fluid%dm_Xh, if_mask, objective_location_zone_name)
 
     ! you will need to init this!
     ! append a source term based on the minimum dissipation
@@ -157,6 +165,7 @@ contains
     call adjoint_forcing%init_from_components( &
          adjoint%f_adj_x, adjoint%f_adj_y, adjoint%f_adj_z, &
          fluid%u, fluid%v, fluid%w, this%obj_scale, &
+         this%mask, this%if_mask, &
          adjoint%c_Xh)
     ! append adjoint forcing term based on objective function
     call adjoint%source_term%add_source_term(adjoint_forcing)
@@ -171,6 +180,7 @@ contains
             adjoint%f_adj_x, adjoint%f_adj_y, adjoint%f_adj_z, design, &
             this%k*this%obj_scale, &
             fluid%u, fluid%v, fluid%w, &
+            this%mask, this%if_mask, &
             adjoint%c_Xh)
        ! append adjoint forcing term based on objective function
        call adjoint%source_term%add_source_term(lube_term)
@@ -208,9 +218,6 @@ contains
     call neko_scratch_registry%request_field(objective_field, temp_indices(4))
 
     ! compute the objective function.
-    ! TODO
-    ! we should be using masks etc
-
     call grad(wo1%x, wo2%x, wo3%x, fluid%u%x, fluid%C_Xh)
     call field_col3(objective_field, wo1, wo1)
     call field_addcol3(objective_field, wo2, wo2)
@@ -226,6 +233,10 @@ contains
     call field_addcol3(objective_field, wo2, wo2)
     call field_addcol3(objective_field, wo3, wo3)
 
+    if (this%if_mask) then
+       call mask_exterior_const(objective_field, this%mask, 0.0_rp)
+    end if
+
     ! integrate the field
     n = wo1%size()
     this%dissipation = glsc2(objective_field%x, fluid%C_Xh%b, n)
@@ -239,6 +250,9 @@ contains
        call field_col3(objective_field, fluid%u, design%brinkman_amplitude)
        call field_addcol3(objective_field, fluid%v, design%brinkman_amplitude)
        call field_addcol3(objective_field, fluid%w, design%brinkman_amplitude)
+       if (this%if_mask) then
+          call mask_exterior_const(objective_field, this%mask, 0.0_rp)
+       end if
        this%lube_value = glsc2(objective_field%x, fluid%C_Xh%b, n)
        this%objective_function_value = this%dissipation &
             + 0.5*this%K*this%lube_value

--- a/sources/objectives/minimum_dissipation_objective_function.f90
+++ b/sources/objectives/minimum_dissipation_objective_function.f90
@@ -254,7 +254,7 @@ contains
        call field_addcol3(objective_field, fluid%w, design%brinkman_amplitude)
        if (this%if_mask) then
           this%lube_value = glsc2_mask(objective_field%x, fluid%C_Xh%b, &
-          n, this%mask%mask, this%mask%size)
+               n, this%mask%mask, this%mask%size)
        else
           this%lube_value = glsc2(objective_field%x, fluid%C_Xh%b, n)
        end if

--- a/sources/objectives/minimum_dissipation_objective_function.f90
+++ b/sources/objectives/minimum_dissipation_objective_function.f90
@@ -238,7 +238,7 @@ contains
     n = wo1%size()
     if (this%if_mask) then
        this%dissipation = glsc2_mask(objective_field%x, fluid%C_Xh%b, &
-       n, this%mask%mask, this%mask%size)
+            n, this%mask%mask, this%mask%size)
     else
        this%dissipation = glsc2(objective_field%x, fluid%C_Xh%b, n)
     end if

--- a/sources/objectives/objective_function.f90
+++ b/sources/objectives/objective_function.f90
@@ -38,6 +38,8 @@ module objective_function
   use adjoint_scheme, only: adjoint_scheme_t
   use topopt_design, only: topopt_design_t
   use dofmap, only: dofmap_t
+  use point_zone_registry, only: neko_point_zone_registry
+  use point_zone, only: point_zone_t
   implicit none
   private
 

--- a/sources/objectives/volume_constraint.f90
+++ b/sources/objectives/volume_constraint.f90
@@ -150,7 +150,7 @@ contains
           call neko_error('GPU not supported volume constraint')
        else
           this%volume_domain = glsc2_mask(work%x, fluid%c_xh%B, &
-          n, this%mask%mask, this%mask%size)
+               n, this%mask%mask, this%mask%size)
        end if
        call neko_scratch_registry%relinquish_field(temp_indices)
     else

--- a/sources/objectives/volume_constraint.f90
+++ b/sources/objectives/volume_constraint.f90
@@ -190,7 +190,7 @@ contains
           call neko_error('GPU not supported volume constraint')
        else
           this%volume = glsc2_mask(design%design_indicator%x, fluid%c_xh%B, &
-          n, this%mask%mask, this%mask%size)
+               n, this%mask%mask, this%mask%size)
        end if
     else
        if (neko_bcknd_device .eq. 1) then

--- a/sources/objectives/volume_constraint.f90
+++ b/sources/objectives/volume_constraint.f90
@@ -65,7 +65,8 @@ module volume_constraint
   use math, only : glsc2
   use field_math, only: field_rone, field_cmult
   use topopt_design, only: topopt_design_t
-  use mask_ops, only: masked_glsc2, mask_exterior_const
+  use mask_ops, only:  mask_exterior_const
+  use math_ext, only: glsc2_mask
   implicit none
   private
 
@@ -148,8 +149,8 @@ contains
        if (neko_bcknd_device .eq. 1) then
           call neko_error('GPU not supported volume constraint')
        else
-          this%volume_domain = masked_glsc2(work%x, fluid%c_xh%B, &
-          this%mask, n)
+          this%volume_domain = glsc2_mask(work%x, fluid%c_xh%B, &
+          n, this%mask%mask, this%mask%size)
        end if
        call neko_scratch_registry%relinquish_field(temp_indices)
     else
@@ -188,8 +189,8 @@ contains
        if (neko_bcknd_device .eq. 1) then
           call neko_error('GPU not supported volume constraint')
        else
-          this%volume = masked_glsc2(design%design_indicator%x, fluid%c_xh%B, &
-          this%mask, n)
+          this%volume = glsc2_mask(design%design_indicator%x, fluid%c_xh%B, &
+          n, this%mask%mask, this%mask%size)
        end if
     else
        if (neko_bcknd_device .eq. 1) then

--- a/sources/objectives/volume_constraint.f90
+++ b/sources/objectives/volume_constraint.f90
@@ -136,10 +136,6 @@ contains
     this%v_max = 0.2
 
     ! Now we can extract the mask/if_mask from the design
-
-    ! TODO
-    ! will I segfault if we have no mask?
-    ! I think I will... test this
     n = design%design_indicator%size()
     if (design%if_mask) then
        ! init the base

--- a/sources/objectives/volume_constraint.f90
+++ b/sources/objectives/volume_constraint.f90
@@ -65,6 +65,7 @@ module volume_constraint
   use math, only : glsc2
   use field_math, only: field_rone, field_cmult
   use topopt_design, only: topopt_design_t
+  use mask_ops, only: masked_glsc2, mask_exterior_const
   implicit none
   private
 
@@ -82,6 +83,8 @@ module volume_constraint
      real(kind=rp) :: v_max
      !> current volume
      real(kind=rp) :: volume
+     !> volume of the optimization domain
+     real(kind=rp) :: volume_domain
 
 
    contains
@@ -106,6 +109,9 @@ contains
     class(fluid_scheme_t), intent(inout) :: fluid
     class(adjoint_scheme_t), intent(inout) :: adjoint
     type(topopt_design_t), intent(inout) :: design
+    type(field_t), pointer :: work
+    integer :: temp_indices(1)
+    integer :: n
 
     ! TODO
     ! I don't think there's much to init here
@@ -129,7 +135,34 @@ contains
     this%is_max = .false.
     this%v_max = 0.2
 
-    call this%init_base(fluid%dm_Xh)
+    ! Now we can extract the mask/if_mask from the design
+
+    ! TODO
+    ! will I segfault if we have no mask?
+    ! I think I will... test this
+    n = design%design_indicator%size()
+    if (design%if_mask) then
+       ! init the base
+       call this%init_base(fluid%dm_Xh, design%if_mask, &
+       design%optimization_domain%name)
+
+       ! calculate the volume of the optimization domain
+       call neko_scratch_registry%request_field(work , temp_indices(1))
+       call field_rone(work)
+       if (neko_bcknd_device .eq. 1) then
+          call neko_error('GPU not supported volume constraint')
+       else
+          this%volume_domain = masked_glsc2(work%x, fluid%c_xh%B, &
+          this%mask, n)
+       end if
+       call neko_scratch_registry%relinquish_field(temp_indices)
+    else
+       ! init the base
+       call this%init_base(fluid%dm_Xh, design%if_mask)
+
+       ! point to the volume of the domain
+       this%volume_domain = fluid%c_xh%volume
+    end if
 
   end subroutine volume_constraint_init
 
@@ -149,27 +182,28 @@ contains
     class(fluid_scheme_t), intent(in) :: fluid
     type(topopt_design_t), intent(inout) :: design
     integer :: i
-    type(field_t), pointer :: wo1, wo2, wo3
-    type(field_t), pointer :: objective_field
-    integer :: temp_indices(4)
     integer n
 
-    ! Again, we don't really need to take design and fluid in here...
     n = design%design_indicator%size()
     ! TODO
     ! in the future we should be using the mapped design varaible
     !corresponding to this constraint!!!
-    this%volume = glsc2(design%design_indicator%x, fluid%c_xh%B, n)
+    if (design%if_mask) then
+       if (neko_bcknd_device .eq. 1) then
+          call neko_error('GPU not supported volume constraint')
+       else
+          this%volume = masked_glsc2(design%design_indicator%x, fluid%c_xh%B, &
+          this%mask, n)
+       end if
+    else
+       if (neko_bcknd_device .eq. 1) then
+          call neko_error('GPU not supported volume constraint')
+       else
+          this%volume = glsc2(design%design_indicator%x, fluid%c_xh%B, n)
+       end if
+    end if
 
-    ! NOTE
-    ! TODO
-    ! the definition of the "volume" can get a little tricky once we start
-    ! introducing masks for the optimization domain, because then we should
-    ! calculate the volume of the optimization domain and take a ratio that way.
-    ! point is, a design should have an internal parameter of the volume of
-    ! the design domain,
-    ! and we should us THAT volume for computing the volume percentage
-    this%volume = this%volume/fluid%c_xh%volume
+    this%volume = this%volume/this%volume_domain
 
     ! then we need to check min or max
     if (this%is_max) then
@@ -202,11 +236,11 @@ contains
     if (this%is_max) then
        ! max volume
        call field_cmult(this%sensitivity_to_coefficient, &
-            1.0_rp / fluid%c_xh%volume)
+            1.0_rp / this%volume_domain)
     else
        ! min volume
        call field_cmult(this%sensitivity_to_coefficient, &
-            -1.0_rp / fluid%c_xh%volume)
+            -1.0_rp / this%volume_domain)
     end if
 
   end subroutine volume_constraint_compute_sensitivity

--- a/sources/objectives/volume_constraint.f90
+++ b/sources/objectives/volume_constraint.f90
@@ -65,7 +65,7 @@ module volume_constraint
   use math, only : glsc2
   use field_math, only: field_rone, field_cmult
   use topopt_design, only: topopt_design_t
-  use mask_ops, only:  mask_exterior_const
+  use mask_ops, only: mask_exterior_const
   use math_ext, only: glsc2_mask
   implicit none
   private


### PR DESCRIPTION
Here I've added masks based on `point_zones` for both the design indicator and source terms.
- volume constraint is now based on the optimization domain
- we have some basic masking functionality in `mask_ops` but I intend to extend this in the future for more complex functionality (and GPUs)
- this is a big ***warning*** for Abbas (currently implementing the `optimizer_t`) I've just masked the sensitivity. This is not the correct way of handling the interface with MMA, because the $N$ is wrong. You should use the masks on initialization of MMA such that only those within the mask are flagged as design variables.