### PR TITLE
Align interfaces with changes in Neko

### DIFF
--- a/examples/control_flow/adjoint.f90
+++ b/examples/control_flow/adjoint.f90
@@ -72,7 +72,7 @@ module simcomp_example
   use mesh_field, only : mesh_fld_t, mesh_field_init, mesh_field_free
   use parmetis, only : parmetis_partmeshkway
   use redist, only : redist_mesh
-  use sampler, only : sampler_t
+  use output_controller, only : output_controller_t
   use adjoint_ic, only : set_adjoint_ic
   use scalar_ic, only : set_scalar_ic
   use field, only : field_t
@@ -105,7 +105,7 @@ module simcomp_example
      type(field_t), pointer :: u_adj, v_adj, w_adj, p_adj, s_adj
      real(kind=rp) :: tol
      type(adjoint_output_t) :: f_out
-     type(sampler_t) :: s
+     type(output_controller_t) :: s
 
      logical :: have_scalar = .false.
      logical :: converged = .false.
@@ -369,7 +369,7 @@ contains
     end if
 
     !
-    ! Setup sampler
+    ! Setup output_controller_t
     !
     call this%s%init(C%end_time)
     if (scalar) then
@@ -381,7 +381,7 @@ contains
     end if
 
     ! HARRY
-    ! fuck the sampler we're changing this anyway
+    ! fuck the output_controller_t we're changing this anyway
     call json_get_or_default(C%params, 'case.fluid.output_control',&
          string_val, 'org')
 
@@ -566,9 +566,9 @@ contains
        call neko_log%message(log_buf)
     end if
 
-    !> Call stats, samplers and user-init before time loop
+    !> Call stats, output_controller_ts and user-init before time loop
     call neko_log%section('Postprocessing')
-    call this%s%sample(t_adj, tstep_adj)
+    call this%s%execute(t_adj, tstep_adj)
 
     ! HARRY
     ! ok this I guess this is techincally where we set the initial condition 
@@ -629,7 +629,7 @@ contains
        call neko_log%section('Postprocessing')
 
        ! call this%case%q%eval(t_adj, this%case%dt, tstep_adj)
-       call this%s%sample(t_adj, tstep_adj)
+       call this%s%execute(t_adj, tstep_adj)
 
        ! Update material properties
        call this%case%usr%material_properties(t_adj, tstep_adj, &
@@ -648,7 +648,7 @@ contains
 
     call json_get_or_default(this%case%params, 'case.output_at_end',&
          output_at_end, .true.)
-    call this%s%sample(t_adj, tstep_adj, output_at_end)
+    call this%s%execute(t_adj, tstep_adj, output_at_end)
 
     if (.not. (output_at_end) .and. t_adj .lt. this%case%end_time) then
        call simulation_joblimit_chkp(this%case, t_adj)
@@ -739,7 +739,7 @@ contains
     call neko_log%message(log_buf)
     call neko_log%end_section()
 
-    call C%s%set_counter(t)
+    call C%output_controller%set_counter(t)
   end subroutine simulation_restart
 
   !> Write a checkpoint at joblimit

--- a/examples/control_flow/adjoint.f90
+++ b/examples/control_flow/adjoint.f90
@@ -381,7 +381,8 @@ contains
     end if
 
     ! HARRY
-    ! fuck the output_controller_t we're changing this anyway
+    ! We should be using our own output_controller_t, 
+    ! not the one used internally by neko.
     call json_get_or_default(C%params, 'case.fluid.output_control',&
          string_val, 'org')
 

--- a/sources/adjoint/adjoint_case.f90
+++ b/sources/adjoint/adjoint_case.f90
@@ -73,7 +73,7 @@ module adjoint_case
   use mesh_field, only: mesh_fld_t, mesh_field_init, mesh_field_free
   use parmetis, only: parmetis_partmeshkway
   use redist, only: redist_mesh
-  use sampler, only: sampler_t
+  use output_controller, only: output_controller_t
   use flow_ic, only: set_flow_ic
   use scalar_ic, only: set_scalar_ic
   use field, only: field_t
@@ -109,7 +109,7 @@ module adjoint_case
      ! Fields
      real(kind=rp) :: tol
      type(adjoint_output_t) :: f_out
-     type(sampler_t) :: s
+     type(output_controller_t) :: output_controller
 
      logical :: have_scalar = .false.
 
@@ -203,7 +203,7 @@ contains
     !    call neko_case%scalar%init(neko_case%msh, this%scheme%c_Xh, &
     !         this%scheme%gs_Xh, neko_case%params, neko_case%usr,&
     !         neko_case%material_properties)
-    !    call this%scheme%chkp%add_scalar(neko_case%scalar%s)
+    !    call this%scheme%chkp%add_scalar(neko_case%scalar%output_controller)
     !    this%scheme%chkp%abs1 => neko_case%scalar%abx1
     !    this%scheme%chkp%abs2 => neko_case%scalar%abx2
     !    this%scheme%chkp%slag => neko_case%scalar%slag
@@ -250,11 +250,11 @@ contains
     !    call json_get(neko_case%params, 'case.scalar.initial_condition.type', &
     ! string_val)
     !    if (trim(string_val) .ne. 'user') then
-    !       call set_scalar_ic(neko_case%scalar%s, &
+    !       call set_scalar_ic(neko_case%scalar%output_controller, &
     !         neko_case%scalar%c_Xh, neko_case%scalar%gs_Xh, string_val, &
     ! neko_case%params)
     !    else
-    !       call set_scalar_ic(neko_case%scalar%s, &
+    !       call set_scalar_ic(neko_case%scalar%output_controller, &
     !         neko_case%scalar%c_Xh, neko_case%scalar%gs_Xh, &
     ! neko_case%usr%scalar_user_ic, neko_case%params)
     !    end if
@@ -274,7 +274,7 @@ contains
     call this%scheme%validate
 
     ! if (scalar) then
-    !    call neko_case%scalar%slag%set(neko_case%scalar%s)
+    !    call neko_case%scalar%slag%set(neko_case%scalar%output_controller)
     !    call neko_case%scalar%validate
     ! end if
 
@@ -291,9 +291,9 @@ contains
     end if
 
     !
-    ! Setup sampler
+    ! Setup output_controller
     !
-    call this%s%init(neko_case%end_time)
+    call this%output_controller%init(neko_case%end_time)
     if (scalar) then
        this%f_out = adjoint_output_t(precision, this%scheme, neko_case%scalar, &
             path = trim(output_directory))
@@ -308,15 +308,15 @@ contains
     if (trim(string_val) .eq. 'org') then
        ! yes, it should be real_val below for type compatibility
        call json_get(neko_case%params, 'case.nsamples', real_val)
-       call this%s%add(this%f_out, real_val, 'nsamples')
+       call this%output_controller%add(this%f_out, real_val, 'nsamples')
     else if (trim(string_val) .eq. 'never') then
        ! Fix a dummy 0.0 output_value
        call json_get_or_default(neko_case%params, 'case.fluid.output_value', &
             real_val, 0.0_rp)
-       call this%s%add(this%f_out, 0.0_rp, string_val)
+       call this%output_controller%add(this%f_out, 0.0_rp, string_val)
     else
        call json_get(neko_case%params, 'case.fluid.output_value', real_val)
-       call this%s%add(this%f_out, real_val, string_val)
+       call this%output_controller%add(this%f_out, real_val, string_val)
     end if
 
     ! !
@@ -335,7 +335,7 @@ contains
     !    call json_get_or_default(neko_case%params, 'case.checkpoint_value', &
     ! real_val,&
     !         1e10_rp)
-    !   !  call this%s%add(neko_case%f_chkp, real_val, string_val)
+    !   !  call this%output_controller%add(neko_case%f_chkp, real_val, string_val)
     ! end if
 
   end subroutine adjoint_case_init_common
@@ -346,7 +346,7 @@ contains
 
     nullify(this%case)
     call this%scheme%free()
-    call this%s%free()
+    call this%output_controller%free()
 
   end subroutine adjoint_free
 

--- a/sources/adjoint/simulation_adjoint.f90
+++ b/sources/adjoint/simulation_adjoint.f90
@@ -98,7 +98,7 @@ contains
     !> Call stats, samplers and user-init before time loop
     call neko_log%section('Postprocessing')
     ! call this%case%q%eval(t_adj, this%case%dt, tstep_adj)
-    call this%s%sample(t_adj, tstep_adj)
+    call this%output_controller%execute(t_adj, tstep_adj)
 
     ! HARRY
     ! ok this I guess this is techincally where we set the initial condition
@@ -152,7 +152,7 @@ contains
        call neko_log%section('Postprocessing')
 
        !  call this%case%q%eval(t_adj, this%case%dt, tstep_adj)
-       call this%s%sample(t_adj, tstep_adj)
+       call this%output_controller%execute(t_adj, tstep_adj)
 
        ! Update material properties
        call this%case%usr%material_properties(t, tstep, this%case%fluid%rho, &
@@ -170,7 +170,7 @@ contains
 
     call json_get_or_default(this%case%params, 'case.output_at_end',&
          output_at_end, .true.)
-    call this%s%sample(t_adj, tstep_adj, output_at_end)
+    call this%output_controller%execute(t_adj, tstep_adj, output_at_end)
 
     if (.not. (output_at_end) .and. t_adj .lt. this%case%end_time) then
        call simulation_joblimit_chkp(this%case, t_adj)
@@ -259,7 +259,7 @@ contains
     call neko_log%message(log_buf)
     call neko_log%end_section()
 
-    call C%s%set_counter(t)
+    call C%output_controller%set_counter(t)
   end subroutine simulation_restart
 
 !> Write a checkpoint at joblimit

--- a/sources/designs/topopt_design.f90
+++ b/sources/designs/topopt_design.f90
@@ -73,7 +73,6 @@ module topopt_design
   use mesh_field, only : mesh_fld_t, mesh_field_init, mesh_field_free
   use parmetis, only : parmetis_partmeshkway
   use redist, only : redist_mesh
-  use sampler, only : sampler_t
   use flow_ic, only : set_flow_ic
   use scalar_ic, only : set_scalar_ic
   use field, only : field_t

--- a/sources/neko_ext/neko_ext.f90
+++ b/sources/neko_ext/neko_ext.f90
@@ -70,7 +70,7 @@ contains
     end do
 
     ! Reset the time step counter
-    call neko_case%s%set_counter(t)
+    call neko_case%output_controller%set_counter(t)
 
     ! Restart the fields
     call neko_case%fluid%restart(neko_case%dtlag, neko_case%tlag)
@@ -142,7 +142,7 @@ contains
     use num_types, only: rp
     use chkp_output, only: chkp_output_t
     use json_utils, only: json_get_or_default
-    use sampler, only: sampler_t
+    use output_controller, only : output_controller_t
     implicit none
 
     type(case_t), intent(inout) :: neko_case
@@ -164,7 +164,7 @@ contains
     neko_case%f_out%output_t%file_%file_type%fname = trim(file_name)
     neko_case%f_out%output_t%file_%file_type%counter = 0
     neko_case%f_out%output_t%file_%file_type%start_counter = 0
-    call neko_case%s%sample(0.0_rp, 0, .true.)
+    call neko_case%output_controller%execute(0.0_rp, 0, .true.)
 
   end subroutine setup_iteration
 

--- a/sources/objectives/objective_function.f90
+++ b/sources/objectives/objective_function.f90
@@ -73,7 +73,7 @@ module objective_function
   use mesh_field, only : mesh_fld_t, mesh_field_init, mesh_field_free
   use parmetis, only : parmetis_partmeshkway
   use redist, only : redist_mesh
-  use sampler, only : sampler_t
+  ! use sampler, only : sampler_t
   use flow_ic, only : set_flow_ic
   use scalar_ic, only : set_scalar_ic
   use field, only : field_t


### PR DESCRIPTION
This pull request aligns the interfaces with the changes made in Neko. It updates the usage of the `sampler_t` module to the `output_controller_t` module in multiple files. These changes ensure that the code is compatible with the latest version of Neko.