### PR TITLE
Fix error log file name

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -238,7 +238,7 @@ function Run() {
     cd $LPATH/$example
     printf '\t%-12s %-s\n' "Started:" "$1"
     source $SPATH/functions.sh
-    run $1 1>output.log 2>error.err
+    run $1 1>output.log 2>error.log
     cd $CURRENT_DIR
 }
 
@@ -257,7 +257,7 @@ function Submit() {
             printf >&2 "Please set the MN5_ACCOUNT variable in the environment.\n"
             exit 1
         fi
-        sbatch -A $MN5_ACCOUNT -J $1 job_script.sh 1>/dev/null 2>error.err
+        sbatch -A $MN5_ACCOUNT -J $1 job_script.sh 1>/dev/null 2>error.log
 
     else
         printf >&2 "No or invalid cluster specified for submission.\n"
@@ -274,7 +274,7 @@ function Submit() {
 INTERRUPTED=0
 function handler() {
     if [ "$MAIN_DIR" != "$(pwd)" ]; then
-        printf "Interrupted" >error.err
+        printf "Interrupted" >error.log
     fi
     INTERRUPTED=1
 }
@@ -306,7 +306,7 @@ for case in ${example_list[@]}; do
     # Setup the log folder
     if [[ -f "$log/output.log" &&
         "$(head -n 1 $log/output.log)" == "Ready" ]]; then
-        rm -f $log/error.err && touch $log/error.err
+        rm -f $log/error.log && touch $log/error.log
 
         [ ! -z "$CLUSTER" ] && printf '\t%-12s %-s\n' "Queued:" "$example"
         QUEUE="$QUEUE $example"
@@ -314,8 +314,8 @@ for case in ${example_list[@]}; do
     fi
 
     # Remove old output and error files
-    find $log -type f -name "*.log" -or -name "error.err" -delete
-    touch $log/output.log $log/error.err
+    find $log -type f -name "*.log" -or -name "error.log" -delete
+    touch $log/output.log $log/error.log
 
     # Copy the case files to the log folder
     if [ ${case: -3} == ".sh" ]; then

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -178,10 +178,10 @@ function run {
     printf "See $logfile for the status output.\n"
 
     if [ -f "run.sh" ]; then
-        { time ./run.sh 1>$logfile; } 2>&1
+        { time ./run.sh 1>$logfile 2>error.err; } 2>&1
     elif [ ! -z "$SLURM_JOB_NAME" ]; then
         {
-            time srun --gpu-bind=single:1 $neko $casefile 1>$logfile
+            time srun --gpu-bind=single:1 $neko $casefile 1>$logfile 2>error.err
         } 2>&1
     else
         # Look for the number of cores to use

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -25,15 +25,15 @@ function cleanup {
     # Move all files which are not the error or executable files to the log
     # folder
     find ./ -type f \
-        -not -name "error.err" \
+        -not -name "error.log" \
         -not -name "neko" \
         -not -name "output.log" \
         -not -name "*.chkp" \
         -exec mv -t $results {} +
 
-    if [ -s "error.err" ]; then
+    if [ -s "error.log" ]; then
         printf "ERROR: An error occured during execution.\n"
-        printf "See error.err for details.\n"
+        printf "See error.log for details.\n"
         return 1
     else
         printf "=%.0s" {1..80} && printf "\n"
@@ -42,7 +42,7 @@ function cleanup {
     fi
 
     # Remove all but the log files
-    find ./ -type f -not -name "error.err" -not -name "output.log" -delete
+    find ./ -type f -not -name "error.log" -not -name "output.log" -delete
 
     # Clear the output file to indicate successful completion
     cp -ft $results output.log
@@ -113,9 +113,9 @@ function prepare {
 
         { time ./prepare.sh; } 2>&1
 
-        if [ -s "error.err" ]; then
+        if [ -s "error.log" ]; then
             printf "\nERROR: An error occured during preparation.\n"
-            printf "See error.err for details.\n"
+            printf "See error.log for details.\n"
             return 1
         else
             printf "\nPreparation concluded.\n"
@@ -178,10 +178,10 @@ function run {
     printf "See $logfile for the status output.\n"
 
     if [ -f "run.sh" ]; then
-        { time ./run.sh 1>$logfile 2>error.err; } 2>&1
+        { time ./run.sh 1>$logfile 2>error.log; } 2>&1
     elif [ ! -z "$SLURM_JOB_NAME" ]; then
         {
-            time srun --gpu-bind=single:1 $neko $casefile 1>$logfile 2>error.err
+            time srun --gpu-bind=single:1 $neko $casefile 1>$logfile 2>error.log
         } 2>&1
     else
         # Look for the number of cores to use
@@ -194,12 +194,12 @@ function run {
         if [ -z "$ncores" ]; then
             ncores="1"
         fi
-        { time $(mpirun -n $ncores $neko $casefile 1>$logfile 2>error.err); } 2>&1
+        { time $(mpirun -n $ncores $neko $casefile 1>$logfile 2>error.log); } 2>&1
     fi
 
-    if [ -s "error.err" ]; then
+    if [ -s "error.log" ]; then
         printf "\nERROR: An error occured during execution.\n"
-        printf "See error.err for details.\n"
+        printf "See error.log for details.\n"
         return 1
     else
         printf "\nNeko execution concluded.\n"

--- a/status.sh
+++ b/status.sh
@@ -59,14 +59,14 @@ fi
 printf "\n\e[4mTest status.\e[m\n"
 
 for test in ${tests[@]}; do
-    if [[ -d $RPATH/$test && ! -s $LPATH/$test/output.log && ! -s $LPATH/$test/error.err ]]; then
+    if [[ -d $RPATH/$test && ! -s $LPATH/$test/output.log && ! -s $LPATH/$test/error.log ]]; then
         printf '\t\e[1;32m%-12s\e[m %-s\n' "Complete:" "$test"
         rm -fr $LPATH/$test
     fi
 done
 
 for test in ${tests[@]}; do
-    if [[ -s $LPATH/$test/output.log && ! -s $LPATH/$test/error.err ]]; then
+    if [[ -s $LPATH/$test/output.log && ! -s $LPATH/$test/error.log ]]; then
         file=($(find $LPATH/$test -type f -name "*.case"))
 
         # If more than one file exists
@@ -112,9 +112,9 @@ done
 
 for test in ${tests[@]}; do
     # Check if there were errors. Print them if there were.
-    if [ -s $LPATH/$test/error.err ]; then
+    if [ -s $LPATH/$test/error.log ]; then
 
-        if [ "$(head -n 1 $LPATH/$test/error.err)" = "Interrupted" ]; then
+        if [ "$(head -n 1 $LPATH/$test/error.log)" = "Interrupted" ]; then
             printf '\t\e[1;31m%-12s\e[m %-s\n' "Interrupted:" "$test"
         else
             printf '\t\e[1;31m%-12s\e[m %-s\n' "Error:" "$test"
@@ -127,9 +127,9 @@ done
 
 for test in ${tests[@]}; do
     # Check if there were errors. Print them if there were.
-    if [ -s $LPATH/$test/error.err ]; then
+    if [ -s $LPATH/$test/error.log ]; then
 
-        if [ "$(head -n 1 $LPATH/$test/error.err)" = "Interrupted" ]; then
+        if [ "$(head -n 1 $LPATH/$test/error.log)" = "Interrupted" ]; then
             continue
         fi
 
@@ -145,12 +145,12 @@ for test in ${tests[@]}; do
         done
 
         printf "\n"
-        if [ $(cat $LPATH/$test/error.err | wc -l) -ge "10" ]; then
-            head -n 5 $LPATH/$test/error.err | fold -w 80
+        if [ $(cat $LPATH/$test/error.log | wc -l) -ge "10" ]; then
+            head -n 5 $LPATH/$test/error.log | fold -w 80
             printf ".....\n"
-            tail -n 5 $LPATH/$test/error.err | fold -w 80
+            tail -n 5 $LPATH/$test/error.log | fold -w 80
         else
-            cat $LPATH/$test/error.err | fold -w 80
+            cat $LPATH/$test/error.log | fold -w 80
         fi
         printf "\n"
 


### PR DESCRIPTION
The error log file name was changed from "error.err" to "error.log" in order to align with naming conventions. This change ensures consistency and improves clarity in the codebase.