### PR TITLE
Fix compatibility with neko

### DIFF
--- a/sources/neko_top.f90
+++ b/sources/neko_top.f90
@@ -65,10 +65,6 @@ contains
     design_params = simulation_component_user_settings('design', comp_subdict)
     call topopt_components%add_user_simcomp(design, design_params)
 
-    call topopt_components%finalize()
-
-    call neko_log%end()
-
     call neko_log%end()
   end subroutine neko_top_init
 


### PR DESCRIPTION
Remove unnecessary calls in the `neko_top_init` subroutine to improve compatibility with neko.