### PR TITLE
Prevent deletion of work folder during cleanup

### DIFF
--- a/.github/actions/setup_neko/action.yml
+++ b/.github/actions/setup_neko/action.yml
@@ -112,9 +112,15 @@ runs:
     - name: Cleanup
       if: ${{ steps.cache-neko.outputs.cache-hit != 'true' }}
       shell: bash
+      env:
+        INSTALL_DIR: ${{ inputs.install-dir }}
+        WORKING_DIR: ${{ inputs.working-dir }}
       run: |
-        if [ ${{ inputs.install-dir }} != ${{ inputs.working-dir }} ]; then
-          rm -rf ${{ inputs.working-dir }}
+        echo "INSTALL_DIR: $INSTALL_DIR"
+        echo "WORKING_DIR: $WORKING_DIR"
+
+        if [ $(echo "$INSTALL_DIR" | grep -q "$WORKING_DIR") ]; then
+          rm -rf $WORKING_DIR
         fi
 
     - name: Set output

--- a/.github/workflows/check_neko-top.yml
+++ b/.github/workflows/check_neko-top.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           json-fortran-dir: ${{ steps.setup-json-fortran.outputs.install-dir }}
           version: ${{ inputs.neko-version }}
+          compiler-flags: "-w"
 
       - name: Setup pFUnit
         id: setup-pfunit


### PR DESCRIPTION
Ensure the work folder is not deleted if the install directory is contained within it during the cleanup process.