### PR TITLE
Add missing CUDA definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(CMAKE_Fortran_STANDARD 2008)
 option(DEVICE_TYPE "Enable device support" OFF)
 if (DEVICE_TYPE STREQUAL "CUDA")
     enable_language(CUDA)
+    add_compile_definitions(HAVE_CUDA 1)
 endif()
 
 # ............................................................................ #


### PR DESCRIPTION
Include a compile definition for CUDA support when the DEVICE_TYPE is set to CUDA.