### PR TITLE
Fix MPI synchronization bug and clean up codebase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,36 +1,4 @@
 {
-    "fortran.linter.includePaths": [
-        "${workspaceFolder}/build/modules",
-        "${workspaceFolder}/external/neko/**",
-        "${workspaceFolder}/external/json-fortran/**",
-    ],
-    "fortran.fortls.excludeDirectories": [
-        "${workspaceFolder}/build",
-        "${workspaceFolder}/external",
-    ],
-    "fortran.linter.modOutput": "${workspaceFolder}/build/modules",
-    "fortran.linter.compiler": "gfortran",
-    "fortran.linter.compilerPath": "/usr/bin/gfortran",
-    "fortran.linter.extraArgs": [
-        "-Wall",
-        "-Wextra",
-        "-Wpedantic",
-    ],
-    "fortran.formatting.formatter": "findent",
-    "fortran.formatting.findentArgs": [
-        "-Rr", // Auto fill end statements with type of block and name
-        "-i2", // Default indentation
-        "-d3", // Indentation for do loops
-        "-f3", // Indentation for if statements
-        "-s3", // Indentation for select case statements
-        "-w3", // Indentation for where statements
-        "-t3", // Indentation for type statements
-        "-j3", // Indentation for interface statements
-        "-kd", // Indentation for continuation lines (-: no change, d: default)
-        "--ws_remred", // Remove redundant white space
-        "--align_paren", // Align parenthesis across continuation lines
-        "--indent_ampersand", // Indentation for continuation lines with preceeding &
-    ],
     "files.exclude": {
         "**/*.mod": true,
         "**/*.o": true,
@@ -43,15 +11,12 @@
         "${workspaceFolder}/scripts/functions",
         "${workspaceFolder}/scripts/notebook",
     ],
-    "cmake.generator": "Unix Makefiles",
+    "cmake.generator": "Ninja",
     "cmake.ctestArgs": [
         "--output-on-failure",
         "--timeout",
         "60",
     ],
-    "todo-tree.tree.showCountsInTree": true,
-    "todo-tree.tree.showBadges": true,
-    "todo-tree.tree.disableCompactFolders": false,
     "[FortranFreeForm]": {
         "editor.insertSpaces": true,
         "editor.tabSize": 2,

--- a/examples/rugby_ball/driver.f90
+++ b/examples/rugby_ball/driver.f90
@@ -25,8 +25,8 @@ program usrneko
 
 
   tolerance = 1.0e-3_rp
-  ! max_iter = 100
-  call optimizer%run(problem, tolerance)
+  max_iter = 100
+  call optimizer%run(problem, tolerance, max_iter)
 
   call problem%free()
   call design%free()

--- a/examples/rugby_verification/driver.f90
+++ b/examples/rugby_verification/driver.f90
@@ -25,8 +25,8 @@ program usrneko
 
 
   tolerance = 1.0e-3_rp
-  ! max_iter = 100
-  call optimizer%run(problem, tolerance)
+  max_iter = 5
+  call optimizer%run(problem, tolerance, max_iter)
 
   call problem%free()
   call design%free()

--- a/examples/rugby_verification/rugby_ball.case
+++ b/examples/rugby_verification/rugby_ball.case
@@ -4,7 +4,7 @@
         "mesh_file": "box.nmsh",
         "output_checkpoints": false,
         "output_at_end": false,
-        "output_boundary": true,
+        "output_boundary": false,
         "end_time": 0.1,
         "timestep": 1e-4,
         "numerics": {
@@ -23,12 +23,7 @@
                 {
                     "type": "no_slip",
                     "zone_indices": [ 1, 2 ]
-                },
-                // {
-                //     "type": "velocity_value",
-                //     "value": [ 0, 0, 0 ],
-                //     "zone_indices": [ 2 ]
-                // }
+                }
             ],
         },
         "fluid": {
@@ -99,7 +94,6 @@
             {
                 "type": "lube_term",
                 "weight": 1.0,
-                // "mask_name": "optimization_domain",
                 "K": 1.0
             }
         ],
@@ -113,7 +107,7 @@
         ],
     },
     "mma": {
-        "max_iter": 5,
+        "max_iter": 100,
         "asyinit": 0.5,
         "asyincr": 1.2,
         "asydecr": 0.7,

--- a/examples/rugby_verification/rugby_ball.case
+++ b/examples/rugby_verification/rugby_ball.case
@@ -4,7 +4,7 @@
         "mesh_file": "box.nmsh",
         "output_checkpoints": false,
         "output_at_end": false,
-        "output_boundary": false,
+        "output_boundary": true,
         "end_time": 0.1,
         "timestep": 1e-4,
         "numerics": {
@@ -19,21 +19,24 @@
                     0.0, 0.0, 0.0
                 ]
             },
+            "boundary_conditions": [
+                {
+                    "type": "no_slip",
+                    "zone_indices": [ 1, 2 ]
+                },
+                // {
+                //     "type": "velocity_value",
+                //     "value": [ 0, 0, 0 ],
+                //     "zone_indices": [ 2 ]
+                // }
+            ],
         },
         "fluid": {
             "scheme": "pnpn",
             "Re": 2,
             "initial_condition": {
                 "type": "uniform",
-                "value": [
-                    0.0, 0.0, 0.0
-                ]
-            },
-            "inflow_condition": {
-                "type": "uniform",
-                "value": [
-                    1.0, 0.0, 0.0
-                ]
+                "value": [ 0.0, 0.0, 0.0 ]
             },
             "velocity_solver": {
                 "type": "cg",
@@ -49,7 +52,13 @@
                 "absolute_tolerance": 1e-4,
                 "max_iterations": 800
             },
-            "boundary_types": [ "v", "v", "sym", "sym" ],
+            "boundary_conditions": [
+                {
+                    "type": "velocity_value",
+                    "value": [ 1, 0, 0 ],
+                    "zone_indices": [ 1, 2 ]
+                }
+            ],
             "output_control": "tsteps",
             "output_value": 50000000
         },
@@ -81,8 +90,30 @@
             }
         ]
     },
+    "optimization": {
+        "objectives": [
+            {
+                "type": "minimum_dissipation",
+                "weight": 1.0
+            },
+            {
+                "type": "lube_term",
+                "weight": 1.0,
+                // "mask_name": "optimization_domain",
+                "K": 1.0
+            }
+        ],
+        "constraints": [
+            {
+                "type": "volume",
+                "mask_name": "optimization_domain",
+                "limit": 0.2,
+                "is_max": false
+            }
+        ],
+    },
     "mma": {
-        "max_iter": 10,
+        "max_iter": 5,
         "asyinit": 0.5,
         "asyincr": 1.2,
         "asydecr": 0.7,

--- a/examples/rugby_verification/run.sh
+++ b/examples/rugby_verification/run.sh
@@ -21,7 +21,7 @@ for i in "${NPROC[@]}"; do
     # the output to the reference solution.
     diff -q target_$i.txt optimization_data.txt
     if [ $? -ne 0 ]; then
-        echo "Output does not match the reference solution. Exiting." >&2
+        echo "Output $i does not match the reference solution. Exiting." >&2
         exit 1
     fi
 

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -20,6 +20,9 @@ contains
     integer, intent(in) :: iter
     integer :: i, j, ierr
     real(kind=rp) :: asy_factor
+    real(kind=rp), dimension(this%n) :: x_diff
+
+    x_diff = this%xmax%x - this%xmin%x
 
     ! ------------------------------------------------------------------------ !
     ! Setup the current asymptotes
@@ -30,8 +33,8 @@ contains
 
       if (iter .lt. 3) then
          ! Initialize the lower and upper asymptotes
-         low = x - this%asyinit * (xmax - xmin)
-         upp = x + this%asyinit * (xmax - xmin)
+         low = x - this%asyinit * x_diff
+         upp = x + this%asyinit * x_diff
       else
          do j = 1, this%n
             if ((x(j) - x_1(j)) * (x_1(j) - x_2(j)) .lt. 0.0_rp) then
@@ -49,11 +52,11 @@ contains
 
          ! Setting a minimum and maximum for the low and upp
          ! asymptotes (eq3.9)
-         low = max(low, x - 10.0_rp * (xmax - xmin))
-         low = min(low, x - 0.01_rp * (xmax - xmin))
+         low = max(low, x - 10.0_rp * x_diff)
+         low = min(low, x - 0.01_rp * x_diff)
 
-         upp = min(upp, x + 10.0_rp * (xmax - xmin))
-         upp = max(upp, x + 0.01_rp * (xmax - xmin))
+         upp = min(upp, x + 10.0_rp * x_diff)
+         upp = max(upp, x + 0.01_rp * x_diff)
       end if
 
     end associate
@@ -70,8 +73,8 @@ contains
          xmin => this%xmin%x, xmax => this%xmax%x, &
          low => this%low%x, upp => this%upp%x)
 
-      alpha = max(xmin, low + 0.1_rp*(x - low), x - 0.5_rp*(xmax - xmin))
-      beta = min(xmax, upp - 0.1_rp*(upp - x), x + 0.5_rp*(xmax - xmin))
+      alpha = max(xmin, low + 0.1_rp*(x - low), x - 0.5_rp*x_diff)
+      beta = min(xmax, upp - 0.1_rp*(upp - x), x + 0.5_rp*x_diff)
 
     end associate
 
@@ -87,13 +90,13 @@ contains
       p0j = ( &
            1.001_rp * max(df0dx, 0.0_rp) &
            + 0.001_rp * max(-df0dx, 0.0_rp) &
-           + 0.00001_rp / max(xmax - xmin, 0.00001_rp) &
+           + 0.00001_rp / max(x_diff, 0.00001_rp) &
            ) * (upp - x)**2
 
       q0j = ( &
            0.001_rp * max(df0dx, 0.0_rp) &
            + 1.001_rp * max(-df0dx, 0.0_rp) &
-           + 0.00001_rp / max(xmax - xmin, 0.00001_rp)&
+           + 0.00001_rp / max(x_diff, 0.00001_rp)&
            ) * (x - low)**2
 
       do j = 1, this%n
@@ -101,13 +104,13 @@ contains
             pij(i, j) = ( &
                  1.001_rp * max(dfdx(i, j), 0.0_rp) &
                  + 0.001_rp * max(-dfdx(i, j), 0.0_rp) &
-                 + 0.00001_rp / max(xmax(j) - xmin(j), 0.00001_rp) &
+                 + 0.00001_rp / max(x_diff(j), 0.00001_rp) &
                  ) * (upp(j) - x(j))**2
 
             qij(i, j) = ( &
                  0.001_rp * max(dfdx(i, j), 0.0_rp) &
                  + 1.001_rp * max(-dfdx(i, j), 0.0_rp) &
-                 + 0.00001_rp / max(xmax(j) - xmin(j), 0.00001_rp) &
+                 + 0.00001_rp / max(x_diff(j), 0.00001_rp) &
                  ) * (x(j) - low(j))**2
          end do
       end do
@@ -180,7 +183,7 @@ contains
     integer, dimension(this%m+1) :: ipiv
 
     ! Parameters for global communication
-    real(kind=rp) :: re_xstuff_squ_global
+    real(kind=rp) :: re_sq_norm
     real(kind=rp) :: minimal_epsilon
 
     integer :: nglobal
@@ -267,15 +270,15 @@ contains
        residu_small = [rey, rez, relambda, remu, rezeta, res]
 
        residumax = maxval(abs(residu))
-       re_xstuff_squ_global = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
+       re_sq_norm = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
 
        call MPI_Allreduce(MPI_IN_PLACE, residumax, 1, &
             mpi_real_precision, mpi_max, neko_comm, ierr)
 
-       call MPI_Allreduce(MPI_IN_PLACE, re_xstuff_squ_global, &
+       call MPI_Allreduce(MPI_IN_PLACE, re_sq_norm, &
             1, mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-       residunorm = sqrt(norm2(residu_small)**2 + re_xstuff_squ_global)
+       residunorm = sqrt(norm2(residu_small)**2 + re_sq_norm)
 
        ! --------------------------------------------------------------------- !
        ! Internal loop
@@ -489,14 +492,11 @@ contains
 
              residu_small = [rey, rez, relambda, remu, rezeta, res]
 
-             re_xstuff_squ_global = norm2(rex)**2 &
-                  + norm2(rexsi)**2 &
-                  + norm2(reeta)**2
-             call MPI_Allreduce(MPI_IN_PLACE, re_xstuff_squ_global, &
+             re_sq_norm = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
+             call MPI_Allreduce(MPI_IN_PLACE, re_sq_norm, &
                   1, mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-
-             newresidu = sqrt(norm2(residu_small)**2 + re_xstuff_squ_global)
+             newresidu = sqrt(norm2(residu_small)**2 + re_sq_norm)
 
              steg = steg / 2.0_rp
           end do
@@ -565,7 +565,7 @@ contains
 
     real(kind=rp), dimension(4*this%m+2) :: residu_small
     integer :: ierr
-    real(kind=rp) :: re_xstuff_squ_global
+    real(kind=rp) :: re_sq_norm
 
     rex = df0dx + matmul(transpose(dfdx), this%lambda%x) &
          - this%xsi%x + this%eta%x
@@ -583,15 +583,15 @@ contains
     residu_small = [rey, rez, relambda, remu, rezeta, res]
 
     this%residumax = maxval(abs(residu))
-    re_xstuff_squ_global = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
+    re_sq_norm = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
 
     call MPI_Allreduce(MPI_IN_PLACE, this%residumax, 1, &
          mpi_real_precision, mpi_max, neko_comm, ierr)
 
-    call MPI_Allreduce(MPI_IN_PLACE, re_xstuff_squ_global, 1, &
+    call MPI_Allreduce(MPI_IN_PLACE, re_sq_norm, 1, &
          mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-    this%residunorm = sqrt(norm2(residu_small)**2 + re_xstuff_squ_global)
+    this%residunorm = sqrt(norm2(residu_small)**2 + re_sq_norm)
 
   end subroutine mma_KKT_cpu
 end submodule mma_cpu

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -5,6 +5,7 @@ submodule (mma) mma_cpu
   use comm, only: neko_comm, mpi_real_precision
 
 contains
+
   module subroutine mma_gensub_cpu(this, iter, x, df0dx, fval, dfdx)
     ! ----------------------------------------------------- !
     ! Generate the approximation sub problem by computing   !
@@ -18,44 +19,50 @@ contains
     real(kind=rp), dimension(this%m, this%n), intent(in) :: dfdx
     integer, intent(in) :: iter
     integer :: i, j, ierr
+    real(kind=rp) :: asy_factor
 
-    if (iter .lt. 3) then
+    ! ------------------------------------------------------------------------ !
+    ! Setup the current asymptotes
 
-       ! Initialize the lower and upper asymptotes
-       this%low%x = x - this%asyinit * (this%xmax%x - this%xmin%x)
-       this%upp%x = x + this%asyinit * (this%xmax%x - this%xmin%x)
+    associate(low => this%low%x, upp => this%upp%x, &
+         xmin => this%xmin%x, xmax => this%xmax%x, &
+         xold_1 => this%xold1%x, xold_2 => this%xold2%x)
 
-    else
+      if (iter .lt. 3) then
 
-       !Move asymptotes low and upp
-       do j = 1, this%n
-          if ((x(j) - this%xold1%x(j))*(this%xold1%x(j) - this%xold2%x(j)) &
-               .lt. 0.0_rp) then
-             this%low%x(j) = x(j) - &
-                  this%asydecr * (this%xold1%x(j) - this%low%x(j))
-             this%upp%x(j) = x(j) + &
-                  this%asydecr * (this%upp%x(j) - this%xold1%x(j))
+         ! Initialize the lower and upper asymptotes
+         low = x - this%asyinit * (xmax - xmin)
+         upp = x + this%asyinit * (xmax - xmin)
 
-          else if ((x(j) - this%xold1%x(j))* &
-               (this%xold1%x(j) - this%xold2%x(j)) .gt. 0.0_rp) then
-             this%low%x(j) = x(j) - &
-                  this%asyincr * (this%xold1%x(j) - this%low%x(j))
-             this%upp%x(j) = x(j) + &
-                  this%asyincr * (this%upp%x(j) - this%xold1%x(j))
-          else
-             this%low%x(j) = x(j) - (this%xold1%x(j) - this%low%x(j))
-             this%upp%x(j) = x(j) + (this%upp%x(j) - this%xold1%x(j))
-          end if
-       end do
+      else
 
-       ! Setting a minimum and maximum for the low and upp
-       ! asymptotes (eq3.9)
-       this%low%x = max(this%low%x, x - 10.0_rp * (this%xmax%x - this%xmin%x))
-       this%low%x = min(this%low%x, x - 0.01_rp * (this%xmax%x - this%xmin%x))
+         do j = 1, this%n
+            if ((x(j) - xold_1(j)) * (xold_1(j) - xold_2(j)) &
+                 .lt. 0.0_rp) then
+               asy_factor = this%asydecr
+            else if ((x(j) - xold_1(j)) * (xold_1(j) - xold_2(j)) &
+                 .gt. 0.0_rp) then
+               asy_factor = this%asyincr
+            else
+               asy_factor = 1.0_rp
+            end if
 
-       this%upp%x = min(this%upp%x, x + 10.0_rp * (this%xmax%x - this%xmin%x))
-       this%upp%x = max(this%upp%x, x + 0.01_rp * (this%xmax%x - this%xmin%x))
-    end if
+            low(j) = x(j) - asy_factor * (xold_1(j) - low(j))
+            upp(j) = x(j) + asy_factor * (upp(j) - xold_1(j))
+         end do
+
+
+         ! Setting a minimum and maximum for the low and upp
+         ! asymptotes (eq3.9)
+         low = max(low, x - 10.0_rp * (xmax - xmin))
+         low = min(low, x - 0.01_rp * (xmax - xmin))
+
+         upp = min(upp, x + 10.0_rp * (xmax - xmin))
+         upp = max(upp, x + 0.01_rp * (xmax - xmin))
+      end if
+
+    end associate
+
 
     ! Set the the bounds and coefficients for the approximation
     ! the move bounds (alpha and beta )are slightly more restrictive
@@ -136,7 +143,7 @@ contains
     real(kind=rp) :: epsi, residumax, residunorm, &
          z, zeta, rez, rezeta, &
          delz, dz, dzeta, &
-         steg, dummy_one, zold, zetaold, newresidu
+         steg, zold, zetaold, newresidu
     real(kind=rp), dimension(this%m) :: y, lambda, s, mu, &
          rey, relambda, remu, res, &
          dely, dellambda, &
@@ -166,7 +173,6 @@ contains
 
     ! intial value for the parameters in the subsolve based on
     ! page 15 of "https://people.kth.se/~krille/mmagcmma.pdf"
-    dummy_one = 1.0_rp
     epsi = 1.0_rp !100
     x = 0.5_rp * (this%alpha%x + this%beta%x)
     y = 1.0_rp
@@ -200,9 +206,6 @@ contains
        rey = this%c%x + this%d%x*y - lambda - mu
        rez = this%a0 - zeta - dot_product(lambda, this%a%x)
 
-       ! relambda = matmul(this%pij%x,1.0/(this%upp%x - x)) + &
-       !         matmul(this%qij%x, 1.0/(x - this%low%x)) - &
-       !         this%a%x*z - y + s - this%bi%x
        relambda = 0.0_rp
        do i = 1, this%m
           do j = 1, this%n
@@ -224,18 +227,18 @@ contains
        res = lambda * s - epsi
 
        residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
+       residu_small = [rey, rez, relambda, remu, rezeta, res]
 
        residumax = maxval(abs(residu))
+       re_xstuff_squ_global = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
+
        call MPI_Allreduce(MPI_IN_PLACE, residumax, 1, &
             mpi_real_precision, mpi_max, neko_comm, ierr)
 
-       re_xstuff_squ_global = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
        call MPI_Allreduce(MPI_IN_PLACE, re_xstuff_squ_global, &
             1, mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-       residu_small = [rey, rez, relambda, remu, rezeta, res]
        residunorm = sqrt(norm2(residu_small)**2 + re_xstuff_squ_global)
-
 
        do iter = 1, this%max_iter
 
@@ -370,7 +373,7 @@ contains
           xx = [y, z, lambda, xsi, eta, mu, zeta, s]
 
           steg = 1.0_rp / maxval([ &
-               dummy_one, &
+               1.0_rp, &
                -1.01_rp * dxx / xx, &
                -1.01_rp * dx / (x - this%alpha%x), &
                1.01_rp * dx / (this%beta%x - x) &
@@ -442,9 +445,7 @@ contains
              rezeta = zeta * z - epsi
              res = lambda * s - epsi
 
-             residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
              residu_small = [rey, rez, relambda, remu, rezeta, res]
-
 
              re_xstuff_squ_global = norm2(rex)**2 &
                   + norm2(rexsi)**2 &
@@ -458,9 +459,11 @@ contains
              steg = steg / 2.0_rp
           end do
 
+          residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
+
           residunorm = newresidu
-          residumax = 0.0_rp
-          call MPI_Allreduce(maxval(abs(residu)), residumax, 1, &
+          residumax = maxval(abs(residu))
+          call MPI_Allreduce(MPI_IN_PLACE, residumax, 1, &
                mpi_real_precision, mpi_max, neko_comm, ierr)
 
           !correct the step size for the extra devision by 2 in the final
@@ -524,28 +527,29 @@ contains
     integer :: ierr
     real(kind=rp) :: re_xstuff_squ_global
 
-    rex = df0dx + matmul(transpose(dfdx), this%lambda%x) - &
-         this%xsi%x + this%eta%x
-    rey = this%c%x + this%d%x*this%y%x - this%lambda%x - &
-         this%mu%x
+    rex = df0dx + matmul(transpose(dfdx), this%lambda%x) &
+         - this%xsi%x + this%eta%x
+    rey = this%c%x + this%d%x*this%y%x - this%lambda%x - this%mu%x
     rez = this%a0 - this%zeta - dot_product(this%lambda%x, this%a%x)
 
-    relambda = fval - this%a%x*this%z - this%y%x + this%s%x
-    rexsi = this%xsi%x*(x - this%xmin%x)
-    reeta = this%eta%x*(this%xmax%x - x)
-    remu = this%mu%x*this%y%x
-    rezeta = this%zeta*this%z
-    res = this%lambda%x*this%s%x
+    relambda = fval - this%a%x * this%z - this%y%x + this%s%x
+    rexsi = this%xsi%x * (x - this%xmin%x)
+    reeta = this%eta%x * (this%xmax%x - x)
+    remu = this%mu%x * this%y%x
+    rezeta = this%zeta * this%z
+    res = this%lambda%x * this%s%x
 
     residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
+    residu_small = [rey, rez, relambda, remu, rezeta, res]
 
-    call MPI_Allreduce(maxval(abs(residu)), this%residumax, 1, &
+    this%residumax = maxval(abs(residu))
+    re_xstuff_squ_global = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
+
+    call MPI_Allreduce(MPI_IN_PLACE, this%residumax, 1, &
          mpi_real_precision, mpi_max, neko_comm, ierr)
 
-    call MPI_Allreduce(norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2, &
-         re_xstuff_squ_global, 1, mpi_real_precision, mpi_sum, neko_comm, ierr)
-
-    residu_small = [rey, rez, relambda, remu, rezeta, res]
+    call MPI_Allreduce(MPI_IN_PLACE, re_xstuff_squ_global, 1, &
+         mpi_real_precision, mpi_sum, neko_comm, ierr)
 
     this%residunorm = sqrt(norm2(residu_small)**2 + re_xstuff_squ_global)
 

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -1,6 +1,6 @@
 submodule (mma) mma_cpu
   use mpi_f08, only: MPI_INTEGER, MPI_REAL, mpi_sum, mpi_min, mpi_max, &
-       MPI_Allreduce
+       MPI_Allreduce, MPI_IN_PLACE
   use utils, only: neko_error
   use comm, only: neko_comm, mpi_real_precision
 
@@ -227,6 +227,7 @@ contains
     integer, dimension(this%m+1) :: ipiv
 
     real(kind=rp) :: re_xstuff_squ_global
+    real(kind=rp) :: minimal_epsilon
 
     integer :: nglobal
 
@@ -244,7 +245,13 @@ contains
     eta(:) = max(1.0_rp, 1.0_rp/(this%beta%x(:) - x(:)))
     mu(:) = max(1.0_rp, 0.5_rp*this%c%x(:))
 
-    do while (epsi .gt. max(0.9_rp*this%epsimin, 1.0e-12_rp))
+    ! computing the minimal epsilon based on eq(5.10)
+    minimal_epsilon = max(0.9_rp*this%epsimin, 1.0e-12_rp)
+    call MPI_Allreduce(MPI_IN_PLACE, minimal_epsilon, 1, &
+         mpi_real_precision, mpi_min, neko_comm, ierr)
+
+    do while (epsi .gt. minimal_epsilon)
+
        ! calculating residuals based on
        ! "https://people.kth.se/~krille/mmagcmma.pdf" for the variables
        ! x, y, z, lambda residuals based on eq(5.9a)-(5.9d), respectively.

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -31,14 +31,14 @@ contains
        !Move asymptotes low and upp
        do j = 1, this%n
           if ((x(j) - this%xold1%x(j))*(this%xold1%x(j) - this%xold2%x(j)) &
-               .lt. 0) then
+               .lt. 0.0_rp) then
              this%low%x(j) = x(j) - &
                   this%asydecr * (this%xold1%x(j) - this%low%x(j))
              this%upp%x(j) = x(j) + &
                   this%asydecr * (this%upp%x(j) - this%xold1%x(j))
 
           else if ((x(j) - this%xold1%x(j))* &
-               (this%xold1%x(j) - this%xold2%x(j)) .gt. 0) then
+               (this%xold1%x(j) - this%xold2%x(j)) .gt. 0.0_rp) then
              this%low%x(j) = x(j) - &
                   this%asyincr * (this%xold1%x(j) - this%low%x(j))
              this%upp%x(j) = x(j) + &
@@ -51,14 +51,14 @@ contains
           ! setting a minimum and maximum for the low and upp
           ! asymptotes (eq3.9)
           this%low%x(j) = max(this%low%x(j), &
-               x(j) - 10*(this%xmax%x(j) - this%xmin%x(j)))
+               x(j) - 10.0_rp*(this%xmax%x(j) - this%xmin%x(j)))
           this%low%x(j) = min(this%low%x(j), &
-               x(j) - 0.01*(this%xmax%x(j) - this%xmin%x(j)))
+               x(j) - 0.01_rp*(this%xmax%x(j) - this%xmin%x(j)))
 
           this%upp%x(j) = min(this%upp%x(j), &
-               x(j) + 10*(this%xmax%x(j) - this%xmin%x(j)))
+               x(j) + 10.0_rp*(this%xmax%x(j) - this%xmin%x(j)))
           this%upp%x(j) = max(this%upp%x(j), &
-               x(j) + 0.01*(this%xmax%x(j) - this%xmin%x(j)))
+               x(j) + 0.01_rp*(this%xmax%x(j) - this%xmin%x(j)))
        end do
     end if
     ! we can move alpha and beta out of the following loop if needed as:
@@ -77,7 +77,7 @@ contains
             0.1_rp*(x(j)- this%low%x(j)), &
             x(j) - 0.5_rp*(this%xmax%x(j) - this%xmin%x(j)))
        this%beta%x(j) = min(this%xmax%x(j), this%upp%x(j) - &
-            0.1*(this%upp%x(j) - x(j)), &
+            0.1_rp*(this%upp%x(j) - x(j)), &
             x(j) + 0.5_rp*(this%xmax%x(j) - this%xmin%x(j)))
 
        !Calculate p0j, q0j, pij, qij
@@ -460,8 +460,8 @@ contains
           !2*this%n+4*this%m+2
           dxx = [dy, dz, dlambda, dxsi, deta, dmu, dzeta, ds]
           xx = [y, z, lambda, xsi, eta, mu, zeta, s]
-          steg = maxval([dummy_one, -1.01*dxx/xx, -1.01*dx/ &
-               (x(:) - this%alpha%x(:)), 1.01*dx/(this%beta%x(:) - x(:))])
+          steg = maxval([dummy_one, -1.01_rp*dxx/xx, -1.01_rp*dx/ &
+               (x(:) - this%alpha%x(:)), 1.01_rp*dx/(this%beta%x(:) - x(:))])
           steg = 1.0_rp/steg
 
           call MPI_Allreduce(steg, steg, 1, &
@@ -551,7 +551,7 @@ contains
 
           !correct the step size for the extra devision by 2 in the final
           !loop
-          steg = 2*steg
+          steg = 2.0_rp*steg
 
           ! print *,"Processor ",pe_rank, "iter = ", iter, "epsi = ", epsi, &
           !     "steg = ", steg, "residunorm = ",residunorm, &

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -18,16 +18,15 @@ contains
     real(kind=rp), dimension(this%m, this%n), intent(in) :: dfdx
     integer, intent(in) :: iter
     integer :: i, j, ierr
-    real(kind=rp), dimension(this%m) :: globaltmp_m
 
     if (iter .lt. 3) then
-       do j = 1, this%n
-          this%low%x(j) = x(j) - this%asyinit * (this%xmax%x(j) - &
-               this%xmin%x(j))
-          this%upp%x(j) = x(j) + this%asyinit * (this%xmax%x(j) - &
-               this%xmin%x(j))
-       end do
+
+       ! Initialize the lower and upper asymptotes
+       this%low%x = x - this%asyinit * (this%xmax%x - this%xmin%x)
+       this%upp%x = x + this%asyinit * (this%xmax%x - this%xmin%x)
+
     else
+
        !Move asymptotes low and upp
        do j = 1, this%n
           if ((x(j) - this%xold1%x(j))*(this%xold1%x(j) - this%xold2%x(j)) &
@@ -61,11 +60,13 @@ contains
                x(j) + 0.01_rp*(this%xmax%x(j) - this%xmin%x(j)))
        end do
     end if
+
     ! we can move alpha and beta out of the following loop if needed as:
     ! this%alpha = max(this%xmin, this%low + &
     !     0.1*(this%x- this%low), this%x - 0.5*(this%xmax - this%xmin))
     ! this%beta = min(this%xmax, this%upp -  &
     !     0.1*(this%upp - this%x), this%x + 0.5*(this%xmax - this%xmin))
+
     do j = 1, this%n
        ! set the the bounds and coefficients for the approximation
        ! the move bounds (alpha and beta )are slightly more restrictive
@@ -73,20 +74,19 @@ contains
        ! also check
        ! https://comsolyar.com/wp-content/uploads/2020/03/gcmma.pdf
        ! eq (2.8) and (2.9)
-       this%alpha%x(j) = max(this%xmin%x(j), this%low%x(j) + &
-            0.1_rp*(x(j)- this%low%x(j)), &
+       this%alpha%x(j) = max(this%xmin%x(j), &
+            this%low%x(j) + 0.1_rp*(x(j) - this%low%x(j)), &
             x(j) - 0.5_rp*(this%xmax%x(j) - this%xmin%x(j)))
-       this%beta%x(j) = min(this%xmax%x(j), this%upp%x(j) - &
-            0.1_rp*(this%upp%x(j) - x(j)), &
+       this%beta%x(j) = min(this%xmax%x(j), &
+            this%upp%x(j) - 0.1_rp*(this%upp%x(j) - x(j)), &
             x(j) + 0.5_rp*(this%xmax%x(j) - this%xmin%x(j)))
 
        !Calculate p0j, q0j, pij, qij
        !where j = 1,2,...,n and i = 1,2,...,m  (eq(2.3)-eq(2.5))
-       this%p0j%x(j) = (this%upp%x(j) - x(j))**2 * &
-            (1.001_rp*max(df0dx(j),0.0_rp) + &
-            0.001_rp*max(-df0dx(j),0.0_rp) + &
-            (0.00001_rp/(max(0.00001_rp, &
-            (this%xmax%x(j) - this%xmin%x(j))))))
+       this%p0j%x(j) = ( 1.001_rp * max(df0dx(j), 0.0_rp) &
+            + 0.001_rp * max(-df0dx(j), 0.0_rp) &
+            + 0.00001_rp / max(0.00001_rp, this%xmax%x(j) - this%xmin%x(j))) &
+            * (this%upp%x(j) - x(j))**2
 
        this%q0j%x(j) = (x(j) - this%low%x(j))**2 * &
             (0.001_rp*max(df0dx(j),0.0_rp) + &
@@ -119,67 +119,9 @@ contains
        end do
     end do
 
-
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    !!!!Showing that for double precision, bi will be different when!!!!!!!!
-    !!!!!!!!!!!computed in parallel compare to sequential!!!!!!!!!!!!!!!!!!!
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    ! this%bi%x = 0.0_rp
-    ! longbi = 0.0
-    ! do i = 1, this%m
-    !     !MPI: here this%n is the global n
-    !     do j = 1, this%n
-    !         this%bi%x(i) = this%bi%x(i) + &
-    !                     this%pij%x(i,j)/ (this%upp%x(j) - x(j)) + &
-    !                     this%qij%x(i,j)/(x(j) - this%low%x(j))
-    !         longbi(i) = longbi(i) + &
-    !                     this%pij%x(i,j)/ (this%upp%x(j) - x(j)) + &
-    !                     this%qij%x(i,j)/(x(j) - this%low%x(j))
-    !     end do
-    ! end do
-    ! print *, "bi =  ", this%bi%x, "this%n = ", this%n
-    ! print *, "longbi =  ", longbi
-    ! ierr = 2160
-    ! longbi = 0.0
-    ! this%bi%x = 0.0
-    ! do i = 1, this%m
-    !     do j = 1, ierr
-    !         this%bi%x(i) = this%bi%x(i) + &
-    !                     this%pij%x(i,j)/ (this%upp%x(j) - x(j)) + &
-    !                     this%qij%x(i,j)/(x(j) - this%low%x(j))
-    !         longbi(i) = longbi(i) + &
-    !                     this%pij%x(i,j)/ (this%upp%x(j) - x(j)) + &
-    !                     this%qij%x(i,j)/(x(j) - this%low%x(j))
-    !     end do
-    ! end do
-    ! print *, "bi =  ", this%bi%x, "first batch(1-ierr)"
-    ! print *, "longbi =  ", longbi, "first batch(1-ierr)"
-    ! longbiglobal = longbi
-    ! longbi = 0.0
-    ! globaltmp_m = this%bi
-    ! this%bi%x = 0.0
-    ! do i = 1, this%m
-    !     do j = ierr+1, this%n
-    !         this%bi%x(i) = this%bi%x(i) + &
-    !                     this%pij%x(i,j)/ (this%upp%x(j) - x(j)) + &
-    !                     this%qij%x(i,j)/(x(j) - this%low%x(j))
-    !         longbi(i) = longbi(i) + &
-    !                     this%pij%x(i,j)/ (this%upp%x(j) - x(j)) + &
-    !                     this%qij%x(i,j)/(x(j) - this%low%x(j))
-    !     end do
-    ! end do
-    ! print *, "bi =  ", this%bi%x, "second batch(ierr+1:end)"
-    ! print *, "longbi =  ", longbi, "second batch(ierr+1:end)"
-    ! print *, "bi =  ", this%bi+globaltmp_m, "first + second"
-    ! print *, "longbi =  ", longbi+longbiglobal, "first + second"
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-
-    globaltmp_m = 0.0_rp
-    call MPI_Allreduce(this%bi%x, globaltmp_m, this%m, &
+    call MPI_Allreduce(MPI_IN_PLACE, this%bi%x, this%m, &
          mpi_real_precision, mpi_sum, neko_comm, ierr)
-    this%bi%x = globaltmp_m - fval
+    this%bi%x = this%bi%x - fval
 
   end subroutine mma_gensub_cpu
 
@@ -235,163 +177,131 @@ contains
     ! page 15 of "https://people.kth.se/~krille/mmagcmma.pdf"
     dummy_one = 1.0_rp
     epsi = 1.0_rp !100
-    x(:) = 0.5_rp*(this%alpha%x(:)+this%beta%x(:))
-    y(:) = 1.0_rp
+    x = 0.5_rp * (this%alpha%x + this%beta%x)
+    y = 1.0_rp
     z = 1.0_rp
     zeta = 1.0_rp
-    lambda(:) = 1.0_rp
-    s(:) = 1.0_rp
-    xsi(:) = max(1.0_rp, 1.0_rp/(x(:) - this%alpha%x(:)))
-    eta(:) = max(1.0_rp, 1.0_rp/(this%beta%x(:) - x(:)))
-    mu(:) = max(1.0_rp, 0.5_rp*this%c%x(:))
+    lambda = 1.0_rp
+    s = 1.0_rp
+    xsi = max(1.0_rp, 1.0_rp / (x - this%alpha%x))
+    eta = max(1.0_rp, 1.0_rp / (this%beta%x - x))
+    mu = max(1.0_rp, 0.5_rp * this%c%x)
+
+    call MPI_Allreduce(this%n, nglobal, 1, &
+         MPI_INTEGER, mpi_sum, neko_comm, ierr)
 
     ! computing the minimal epsilon based on eq(5.10)
-    minimal_epsilon = max(0.9_rp*this%epsimin, 1.0e-12_rp)
+    minimal_epsilon = max(0.9_rp * this%epsimin, 1.0e-12_rp)
     call MPI_Allreduce(MPI_IN_PLACE, minimal_epsilon, 1, &
          mpi_real_precision, mpi_min, neko_comm, ierr)
 
     do while (epsi .gt. minimal_epsilon)
-
        ! calculating residuals based on
        ! "https://people.kth.se/~krille/mmagcmma.pdf" for the variables
        ! x, y, z, lambda residuals based on eq(5.9a)-(5.9d), respectively.
-       rex(:) = ((this%p0j%x(:) + matmul(transpose(this%pij%x(:,:)), &
-            lambda(:)))/(this%upp%x(:) - x(:))**2 - &
-            (this%q0j%x(:) + matmul(transpose(this%qij%x(:,:)), &
-            lambda(:)))/(x(:) - this%low%x(:))**2 ) - &
-            xsi(:) + eta(:)
+       rex = (this%p0j%x + matmul(transpose(this%pij%x), &
+            lambda))/(this%upp%x - x)**2 - &
+            (this%q0j%x + matmul(transpose(this%qij%x), &
+            lambda))/(x - this%low%x)**2 - &
+            xsi + eta
 
-       call MPI_Allreduce(this%n, nglobal, 1, &
-            MPI_INTEGER, mpi_sum, neko_comm, ierr)
+       rey = this%c%x + this%d%x*y - lambda - mu
+       rez = this%a0 - zeta - dot_product(lambda, this%a%x)
 
-       !!!! computing without matmul and transpose
-       ! rex = 0.0_rp
-       ! do j = 1, this%n
-       !     do i = 1, this%m
-       !         rex(j) = rex(j) + this%pij%x(i,j) * &
-       !             lambda(i)/(this%upp%x(j) - x(j))**2 - &
-       !             this%qij%x(i,j) * lambda(i)/(x(j) - this%low%x(j))**2
-       !     end do
-       !     rex(j) = rex(j) + this%p0j%x(j)/(this%upp%x(j) - x(j))**2 &
-       !                     - this%q0j%x(j)/(x(j) - this%low%x(j))**2 &
-       !                     - xsi(j)  + eta(j)
-       ! end do
-
-
-       rey(:) = this%c%x(:) + this%d%x(:)*y(:) - lambda(:) - mu(:)
-       rez = this%a0 - zeta - dot_product(lambda(:), this%a%x(:))
-
-       ! relambda(:) = matmul(this%pij%x(:,:),1.0/(this%upp%x(:) - x(:))) + &
-       !         matmul(this%qij%x(:,:), 1.0/(x(:) - this%low%x(:))) - &
-       !         this%a%x(:)*z - y(:) + s(:) - this%bi%x(:)
+       ! relambda = matmul(this%pij%x,1.0/(this%upp%x - x)) + &
+       !         matmul(this%qij%x, 1.0/(x - this%low%x)) - &
+       !         this%a%x*z - y + s - this%bi%x
        relambda = 0.0_rp
        do i = 1, this%m
-          do j = 1, this%n !this n is global
+          do j = 1, this%n
              ! Accumulate sums for relambda (the term gi(x))
              relambda(i) = relambda(i) + &
-                  this%pij%x(i,j)/(this%upp%x(j) - x(j)) &
-                  + this%qij%x(i,j)/(x(j) - this%low%x(j))
+                  this%pij%x(i,j) / (this%upp%x(j) - x(j)) &
+                  + this%qij%x(i,j) / (x(j) - this%low%x(j))
           end do
        end do
 
-
-       globaltmp_m = 0.0_rp
-       call MPI_Allreduce(relambda, globaltmp_m, this%m, &
+       call MPI_Allreduce(MPI_IN_PLACE, relambda, this%m, &
             mpi_real_precision, mpi_sum, neko_comm, ierr)
-       relambda = globaltmp_m - this%a%x(:)*z - y(:) + s(:) - this%bi%x(:)
+       relambda = relambda - this%a%x*z - y + s - this%bi%x
 
-
-       rexsi(:) = xsi(:)*(x(:) - this%alpha%x(:)) - epsi
-       reeta(:) = eta(:)*(this%beta%x(:) - x(:)) - epsi
-       remu(:) = mu(:)*y(:) - epsi
-       rezeta = zeta*z - epsi
-       res(:) = lambda(:)*s(:) - epsi
+       rexsi = xsi * (x - this%alpha%x) - epsi
+       reeta = eta * (this%beta%x - x) - epsi
+       remu = mu * y - epsi
+       rezeta = zeta * z - epsi
+       res = lambda * s - epsi
 
        residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
-       residumax = 0.0_rp
 
-       call MPI_Allreduce(maxval(abs(residu)), residumax, 1, &
+       residumax = maxval(abs(residu))
+       call MPI_Allreduce(MPI_IN_PLACE, residumax, 1, &
             mpi_real_precision, mpi_max, neko_comm, ierr)
 
-       re_xstuff_squ_global = 0.0_rp
-       call MPI_Allreduce(norm2(rex)**2+norm2(rexsi)**2+norm2(reeta)**2,&
-            re_xstuff_squ_global, 1, mpi_real_precision, mpi_sum,&
-            neko_comm, ierr)
-       residu_small = [rey, rez, relambda, &
-            remu, rezeta, res]
+       re_xstuff_squ_global = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
+       call MPI_Allreduce(MPI_IN_PLACE, re_xstuff_squ_global, &
+            1, mpi_real_precision, mpi_sum, neko_comm, ierr)
+
+       residu_small = [rey, rez, relambda, remu, rezeta, res]
        residunorm = sqrt(norm2(residu_small)**2 + re_xstuff_squ_global)
 
 
-       do iter = 1, this%max_iter !ittt
-          if (iter .gt. (this%max_iter -2)) then
-             ! print *, "The mma inner loop seems not to converge"
-             ! print *, "residumax = ", residumax, "for epsi = ", epsi, &
-             !         ", ittt  = ", iter, "out of ", this%max_iter
-          end if
+       do iter = 1, this%max_iter
+
           !Check the condition
           if (residumax .lt. epsi) exit
 
           delx = 0.0_rp
           do j = 1, this%n
              do i = 1, this%m
-                delx(j) = delx(j) + this%pij%x(i,j) * &
-                     lambda(i)/(this%upp%x(j) - x(j))**2 &
-                     - this%qij%x(i,j) * lambda(i)/(x(j) - this%low%x(j))**2
+                delx(j) = delx(j) &
+                     + this%pij%x(i,j) * lambda(i) / (this%upp%x(j) - x(j))**2 &
+                     - this%qij%x(i,j) * lambda(i) / (x(j) - this%low%x(j))**2
              end do
-             delx(j) = delx(j) + this%p0j%x(j)/(this%upp%x(j) - x(j))**2 &
-                  - this%q0j%x(j)/(x(j) - this%low%x(j))**2 &
-                  - epsi/(x(j) - this%alpha%x(j)) &
-                  + epsi/(this%beta%x(j) - x(j))
+             delx(j) = delx(j) &
+                  + this%p0j%x(j) / (this%upp%x(j) - x(j))**2 &
+                  - this%q0j%x(j) / (x(j) - this%low%x(j))**2 &
+                  - epsi / (x(j) - this%alpha%x(j)) &
+                  + epsi / (this%beta%x(j) - x(j))
           end do
-          dely = this%c%x + this%d%x*y - lambda - epsi/y
-          delz = this%a0 - dot_product(lambda(:), this%a%x(:)) - epsi/z
 
-          dellambda(:) = 0.0_rp
+          dely = this%c%x + this%d%x*y - lambda - epsi/y
+          delz = this%a0 - dot_product(lambda, this%a%x) - epsi/z
+
+          ! Accumulate sums for dellambda (the term gi(x))
+          dellambda = 0.0_rp
           do i = 1, this%m
-             do j = 1, this%n !this n is global
-                ! Accumulate sums for dellambda (the term gi(x))
+             do j = 1, this%n
                 dellambda(i) = dellambda(i) + &
                      this%pij%x(i,j)/(this%upp%x(j) - x(j)) &
                      + this%qij%x(i,j)/(x(j) - this%low%x(j))
              end do
           end do
 
-          globaltmp_m = 0.0_rp
-          call MPI_Allreduce(dellambda, globaltmp_m, this%m, &
+          call MPI_Allreduce(MPI_IN_PLACE, dellambda, this%m, &
                mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-          dellambda = globaltmp_m - this%a%x*z - y - this%bi%x + epsi/lambda
-
-          ! delx(:) = ((this%p0j%x(:) + matmul(transpose(this%pij%x(:,:)), &
-          !     lambda(:)))/(this%upp%x(:) - x(:))**2 - &
-          !     (this%q0j%x(:) + matmul(transpose(this%qij%x(:,:)), &
-          !     lambda(:)))/(x(:) - this%low%x(:))**2 ) - &
-          !     epsi/(x(:) - this%alpha%x(:)) + epsi/(this%beta%x(:) - x(:))
-
-          ! dely(:) =  this%c%x(:) + this%d%x(:)*y(:) - lambda(:) - epsi/y(:)
-          ! delz = this%a0 - dot_product(lambda(:), this%a%x(:)) - epsi/z
-          ! dellambda(:) = matmul(this%pij%x(:,:),1.0/(this%upp%x(:) - x(:)))+&
-          !     matmul(this%qij%x(:,:), 1.0/(x(:) - this%low%x(:))) - &
-          !     this%a%x(:)*z - y(:) - this%bi%x(:) + epsi/lambda(:)
+          dellambda = dellambda - this%a%x*z - y - this%bi%x + epsi/lambda
 
           do ggdumiter = 1, this%m
-             GG(ggdumiter, :) = this%pij%x(ggdumiter,:)/ &
-                  (this%upp%x(:) - x(:))**2 - &
-                  this%qij%x(ggdumiter,:)/(x(:) - this%low%x(:))**2
+             GG(ggdumiter, :) = this%pij%x(ggdumiter,:) / (this%upp%x - x)**2 &
+                  - this%qij%x(ggdumiter,:) / (x - this%low%x)**2
           end do
 
-          diagx(:) = ((this%p0j%x(:) + matmul(transpose(this%pij%x(:,:)), &
-               lambda(:)))/(this%upp%x(:) - x(:))**3 + &
-               (this%q0j%x(:) + matmul(transpose(this%qij%x(:,:)), &
-               lambda(:)))/(x(:) - this%low%x(:))**3 )
-          diagx(:) = 2.0_rp*diagx(:) + xsi(:)/(x(:) - this%alpha%x(:)) + &
-               eta(:)/(this%beta%x(:)- x(:))
+          diagx = &
+               (this%p0j%x + matmul(transpose(this%pij%x), lambda)) &
+               / (this%upp%x - x)**3 &
+               + (this%q0j%x + matmul(transpose(this%qij%x), lambda)) &
+               / (x - this%low%x)**3
+
+          diagx = 2.0_rp * diagx &
+               + xsi / (x - this%alpha%x) &
+               + eta / (this%beta%x - x)
 
 
           !Here we only consider the case m<n in the matlab code
           !assembling the right hand side matrix based on eq(5.20)
-          ! bb = [dellambda + dely(:)/(this%d%x(:) + &
-          !         (mu(:)/y(:))) - matmul(GG,delx/diagx), delz ]
+          ! bb = [dellambda + dely/(this%d%x + &
+          !         (mu/y)) - matmul(GG,delx/diagx), delz ]
           !!!!!!!!!!!!!!for MPI computation of bb!!!!!!!!!!!!!!!!!!!!!!!!!
           bb = 0.0_rp
           do i = 1, this%m
@@ -412,7 +322,7 @@ contains
           ! matmul(matmul(GG,mma_diag(1/diagx)), transpose(GG))
           ! !update diag(AA)
           ! AA(1:this%m,1:this%m) = AA(1:this%m,1:this%m) + &
-          !     mma_diag(s(:)/lambda(:) + 1.0/(this%d%x(:) + (mu(:)/y(:))))
+          !     mma_diag(s/lambda + 1.0/(this%d%x + (mu/y)))
 
           AA = 0.0_rp
           !Direct computation of the matrix multiplication
@@ -437,14 +347,15 @@ contains
                   1.0_rp / (this%d%x(i) + mu(i) / y(i)))
           end do
 
-          AA(1:this%m, this%m+1) = this%a%x(:)
-          AA(this%m+1, 1:this%m) = this%a%x(:)
-          AA(this%m+1, this%m+1) = -zeta/z
+          AA(1:this%m, this%m+1) = this%a%x
+          AA(this%m+1, 1:this%m) = this%a%x
+          AA(this%m+1, this%m+1) = - zeta/z
 
 
 
 
           call DGESV(this%m+1, 1, AA, this%m+1, ipiv, bb, this%m+1, info)
+
           ! if info! = 0 then DGESV is failed.
           if (info .ne. 0) then
              write(stderr, *) "DGESV failed to solve the linear system in MMA."
@@ -455,23 +366,25 @@ contains
           dlambda = bb(1:this%m)
           dz = bb(this%m + 1)
           ! based on eq(5.19)
-          dx = -delx/diagx - matmul(transpose(GG), dlambda)/diagx
+          dx = - delx / diagx - matmul(transpose(GG), dlambda) / diagx
 
-          dy = (-dely+dlambda)/(this%d%x(:) + (mu(:)/y(:)))
-          dxsi = -xsi + (epsi-dx*xsi(:))/(x(:) - this%alpha%x(:))
-          deta = -eta + (epsi+dx*eta(:))/(this%beta%x(:) - x(:))
-          dmu = -mu + (epsi-mu*dy(:))/y(:)
-          dzeta = -zeta + (epsi-zeta*dz)/z
-          ds = -s + (epsi-dlambda*s(:))/lambda(:)
+          dy = (-dely + dlambda) / (this%d%x + mu / y)
+          dxsi = -xsi + (epsi - dx * xsi) / (x - this%alpha%x)
+          deta = -eta + (epsi + dx * eta) / (this%beta%x - x)
+          dmu = -mu + (epsi - mu * dy) / y
+          dzeta = -zeta + (epsi - zeta * dz) / z
+          ds = -s + (epsi - dlambda * s) / lambda
 
           !2*this%n+4*this%m+2
           dxx = [dy, dz, dlambda, dxsi, deta, dmu, dzeta, ds]
           xx = [y, z, lambda, xsi, eta, mu, zeta, s]
-          steg = maxval([dummy_one, -1.01_rp*dxx/xx, -1.01_rp*dx/ &
-               (x(:) - this%alpha%x(:)), 1.01_rp*dx/(this%beta%x(:) - x(:))])
-          steg = 1.0_rp/steg
+          steg = maxval([dummy_one, &
+               -1.01_rp * dxx / xx, &
+               -1.01_rp * dx / (x - this%alpha%x), &
+               1.01_rp * dx / (this%beta%x - x)])
 
-          call MPI_Allreduce(steg, steg, 1, &
+          steg = 1.0_rp / steg
+          call MPI_Allreduce(MPI_IN_PLACE, steg, 1, &
                mpi_real_precision, mpi_min, neko_comm, ierr)
 
           xold = x
@@ -486,11 +399,15 @@ contains
 
           !The innermost loop to determine the suitable step length
           !using the Backtracking Line Search approach
-          newresidu = 2.0_rp*residunorm
+          newresidu = 2.0_rp * residunorm
+          call MPI_Allreduce(MPI_IN_PLACE, newresidu, 1, &
+               mpi_real_precision, mpi_min, neko_comm, ierr)
+
           itto = 0
           do while ((newresidu .gt. residunorm) .and. (itto .lt. 50))
              itto = itto + 1
-             !update the variables
+
+             ! update the variables
              x = xold + steg*dx
              y = yold + steg*dy
              z = zold + steg*dz
@@ -500,55 +417,52 @@ contains
              mu = muold + steg*dmu
              zeta = zetaold + steg*dzeta
              s = sold + steg*ds
+
              !recompute the newresidu to see if this stepsize improves
              !the residue
-             rex(:) = ((this%p0j%x(:) + matmul(transpose(this%pij%x(:,:)), &
-                  lambda(:)))/(this%upp%x(:) - x(:))**2 - &
-                  (this%q0j%x(:) + matmul(transpose(this%qij%x(:,:)), &
-                  lambda(:)))/(x(:) - this%low%x(:))**2 ) - &
-                  xsi(:) + eta(:)
-             rey(:) = this%c%x(:) + this%d%x(:)*y(:) - lambda(:) - mu(:)
-             rez = this%a0 - zeta - dot_product(lambda(:), this%a%x(:))
-             ! relambda(:) = matmul(this%pij%x(:,:),1.0/&
-             !         (this%upp%x(:) - x(:))) + matmul(this%qij%x(:,:), &
-             !         1.0/(x(:) - this%low%x(:))) - this%a%x(:)*z - &
-             !         y(:) + s(:) - this%bi%x(:)
+             rex = (this%p0j%x + matmul(transpose(this%pij%x), lambda)) &
+                  / (this%upp%x - x)**2 &
+                  - (this%q0j%x + matmul(transpose(this%qij%x), lambda)) &
+                  / (x - this%low%x)**2 &
+                  - xsi + eta
+
+             rey = this%c%x + this%d%x*y - lambda - mu
+             rez = this%a0 - zeta - dot_product(lambda, this%a%x)
+
              relambda = 0.0_rp
              do i = 1, this%m
                 do j = 1, this%n !this n is global
                    ! Accumulate sums for relambda (the term gi(x))
-                   relambda(i) = relambda(i) + &
-                        this%pij%x(i,j)/(this%upp%x(j) - x(j)) &
-                        + this%qij%x(i,j)/(x(j) - this%low%x(j))
+                   relambda(i) = relambda(i) &
+                        + this%pij%x(i,j) / (this%upp%x(j) - x(j)) &
+                        + this%qij%x(i,j) / (x(j) - this%low%x(j))
                 end do
              end do
-             globaltmp_m = 0.0_rp
-             call MPI_Allreduce(relambda, globaltmp_m, this%m, &
+
+             call MPI_Allreduce(MPI_IN_PLACE, relambda, this%m, &
                   mpi_real_precision, mpi_sum, neko_comm, ierr)
-             relambda = globaltmp_m
 
+             relambda = relambda - this%a%x*z - y + s - this%bi%x
 
-             relambda = relambda - this%a%x(:)*z - y(:) + s(:) - this%bi%x(:)
+             rexsi = xsi * (x - this%alpha%x) - epsi
+             reeta = eta * (this%beta%x - x) - epsi
+             remu = mu * y - epsi
+             rezeta = zeta * z - epsi
+             res = lambda * s - epsi
 
-             rexsi(:) = xsi(:)*(x(:) - this%alpha%x(:)) - epsi
-             reeta(:) = eta(:)*(this%beta%x(:) - x(:)) - epsi
-             remu(:) = mu(:)*y(:) - epsi
-             rezeta = zeta*z - epsi
-             res(:) = lambda(:)*s(:) - epsi
+             residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
 
-             residu = [rex, rey, rez, relambda, &
-                  rexsi, reeta, remu, rezeta, res]
-
-             re_xstuff_squ_global = 0.0_rp
-             call MPI_Allreduce(norm2(rex)**2 + &
-                  norm2(rexsi)**2+norm2(reeta)**2, re_xstuff_squ_global, &
+             re_xstuff_squ_global = norm2(rex)**2 &
+                  + norm2(rexsi)**2 &
+                  + norm2(reeta)**2
+             call MPI_Allreduce(MPI_IN_PLACE, re_xstuff_squ_global, &
                   1, mpi_real_precision, mpi_sum, neko_comm, ierr)
-             residu_small = [rey, rez, relambda, &
-                  remu, rezeta, res]
+
+             residu_small = [rey, rez, relambda, remu, rezeta, res]
              newresidu = sqrt(norm2(residu_small)**2 + &
                   re_xstuff_squ_global)
 
-             steg = steg/2.0_rp
+             steg = steg / 2.0_rp
           end do
 
           residunorm = newresidu
@@ -558,14 +472,10 @@ contains
 
           !correct the step size for the extra devision by 2 in the final
           !loop
-          steg = 2.0_rp*steg
-
-          ! print *,"Processor ",pe_rank, "iter = ", iter, "epsi = ", epsi, &
-          !     "steg = ", steg, "residunorm = ",residunorm, &
-          !       "residumax = ",residumax
+          steg = 2.0_rp * steg
        end do
-       epsi = 0.1_rp*epsi
 
+       epsi = 0.1_rp * epsi
     end do
 
     ! Save the new design
@@ -621,18 +531,18 @@ contains
     integer :: ierr
     real(kind=rp) :: re_xstuff_squ_global
 
-    rex(:) = df0dx + matmul(transpose(dfdx), this%lambda%x(:)) - &
-         this%xsi%x(:) + this%eta%x(:)
-    rey(:) = this%c%x(:) + this%d%x(:)*this%y%x(:) - this%lambda%x(:) - &
-         this%mu%x(:)
-    rez = this%a0 - this%zeta - dot_product(this%lambda%x(:), this%a%x(:))
+    rex = df0dx + matmul(transpose(dfdx), this%lambda%x) - &
+         this%xsi%x + this%eta%x
+    rey = this%c%x + this%d%x*this%y%x - this%lambda%x - &
+         this%mu%x
+    rez = this%a0 - this%zeta - dot_product(this%lambda%x, this%a%x)
 
-    relambda(:) = fval - this%a%x(:)*this%z - this%y%x(:) + this%s%x(:)
-    rexsi(:) = this%xsi%x(:)*(x(:) - this%xmin%x(:))
-    reeta(:) = this%eta%x(:)*(this%xmax%x(:) - x(:))
-    remu(:) = this%mu%x(:)*this%y%x(:)
+    relambda = fval - this%a%x*this%z - this%y%x + this%s%x
+    rexsi = this%xsi%x*(x - this%xmin%x)
+    reeta = this%eta%x*(this%xmax%x - x)
+    remu = this%mu%x*this%y%x
     rezeta = this%zeta*this%z
-    res(:) = this%lambda%x(:)*this%s%x(:)
+    res = this%lambda%x*this%s%x
 
     residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
 

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -32,8 +32,7 @@
 
 !> Submodule for the CPU implementations related to MMA
 submodule (mma) mma_cpu
-  use mpi_f08, only: MPI_INTEGER, MPI_REAL, mpi_sum, mpi_min, mpi_max, &
-       MPI_Allreduce, MPI_IN_PLACE
+  use mpi_f08, only: MPI_REAL, MPI_IN_PLACE, mpi_min, mpi_max
   use utils, only: neko_error
   use comm, only: neko_comm, mpi_real_precision
 
@@ -215,9 +214,6 @@ contains
 
     ! Parameters for global communication
     real(kind=rp) :: re_sq_norm
-    real(kind=rp) :: minimal_epsilon
-
-    integer :: nglobal
 
     ! ------------------------------------------------------------------------ !
     ! initial value for the parameters in the subsolve based on
@@ -234,20 +230,10 @@ contains
     eta = max(1.0_rp, 1.0_rp / (this%beta%x - x))
     mu = max(1.0_rp, 0.5_rp * this%c%x)
 
-    call MPI_Allreduce(this%n, nglobal, 1, &
-         MPI_INTEGER, mpi_sum, neko_comm, ierr)
-
-    ! ------------------------------------------------------------------------ !
-    ! Computing the minimal epsilon and choose the most conservative one
-
-    minimal_epsilon = max(0.9_rp * this%epsimin, 1.0e-12_rp)
-    call MPI_Allreduce(MPI_IN_PLACE, minimal_epsilon, 1, &
-         mpi_real_precision, mpi_min, neko_comm, ierr)
-
     ! ------------------------------------------------------------------------ !
     !  The main loop of the dual-primal interior point method.
 
-    do while (epsi .gt. minimal_epsilon)
+    do while (epsi .gt. max(0.9_rp * this%epsimin, 1.0e-12_rp))
 
        ! --------------------------------------------------------------------- !
        ! Calculating residuals based on

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -1,3 +1,36 @@
+! Copyright (c) 2025, The Neko-TOP Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+
+!> Submodule for the CPU implementations related to MMA
 submodule (mma) mma_cpu
   use mpi_f08, only: MPI_INTEGER, MPI_REAL, mpi_sum, mpi_min, mpi_max, &
        MPI_Allreduce, MPI_IN_PLACE
@@ -7,11 +40,11 @@ submodule (mma) mma_cpu
 contains
 
   module subroutine mma_gensub_cpu(this, iter, x, df0dx, fval, dfdx)
-    ! ----------------------------------------------------- !
-    ! Generate the approximation sub problem by computing   !
-    ! the lower and upper asymtotes and the other necessary !
-    ! parameters (alpha, beta, p0j, q0j, pij, qij, ...).    !
-    ! ----------------------------------------------------- !
+    ! ------------------------------------------------------ !
+    ! Generate the approximation sub problem by computing    !
+    ! the lower and upper asymptotes and the other necessary !
+    ! parameters (alpha, beta, p0j, q0j, pij, qij, ...).     !
+    ! ------------------------------------------------------ !
     class(mma_t), intent(inout) :: this
     real(kind=rp), dimension(this%n), intent(in) :: x
     real(kind=rp), dimension(this%n), intent(in) :: df0dx
@@ -28,7 +61,6 @@ contains
     ! Setup the current asymptotes
 
     associate(low => this%low%x, upp => this%upp%x, &
-         xmin => this%xmin%x, xmax => this%xmax%x, &
          x_1 => this%xold1%x, x_2 => this%xold2%x)
 
       if (iter .lt. 3) then
@@ -84,8 +116,7 @@ contains
 
     associate(p0j => this%p0j%x, q0j => this%q0j%x, &
          pij => this%pij%x, qij => this%qij%x, &
-         low => this%low%x, upp => this%upp%x, &
-         xmin => this%xmin%x, xmax => this%xmax%x)
+         low => this%low%x, upp => this%upp%x)
 
       p0j = ( &
            1.001_rp * max(df0dx, 0.0_rp) &
@@ -147,7 +178,7 @@ contains
     ! to solve MMA sub problem.                               !
     ! A Backtracking Line Search approach is used to compute  !
     ! the step size; starting with the full Newton's step     !
-    ! (delta = 1) and deviding by 2 until we have a step size !
+    ! (delta = 1) and dividing by 2 until we have a step size !
     ! that leads to a feasible point while ensuring a         !
     ! decrease in the residue.                                !
     ! ------------------------------------------------------- !
@@ -155,11 +186,11 @@ contains
     real(kind=rp), dimension(this%n), intent(inout) :: designx
     !Note that there is a local dummy "x" in this subroutine, thus, we call
     !the current design "designx" instead of just "x"
-    integer :: i, j, k, iter, ggdumiter, itto, ierr
-    real(kind=rp) :: epsi, residumax, residunorm, &
+    integer :: i, j, k, iter, i, itto, ierr
+    real(kind=rp) :: epsi, residual_max, residual_norm, &
          z, zeta, rez, rezeta, &
          delz, dz, dzeta, &
-         steg, zold, zetaold, newresidu
+         steg, zold, zetaold, new_residual
     real(kind=rp), dimension(this%m) :: y, lambda, s, mu, &
          rey, relambda, remu, res, &
          dely, dellambda, &
@@ -169,9 +200,9 @@ contains
          rex, rexsi, reeta, &
          delx, diagx, dx, dxsi, deta, &
          xold, xsiold, etaold
-    real(kind=rp), dimension(3*this%n+4*this%m+2) :: residu
-    real(kind=rp), dimension(4*this%m+2) :: residu_small
-    real(kind=rp), dimension(2*this%n+4*this%m+2) :: xx, dxx
+    real(kind=rp), dimension(4*this%m + 2) :: residual_small
+    real(kind=rp), dimension(3*this%n + 4*this%m + 2) :: residual
+    real(kind=rp), dimension(2*this%n + 4*this%m + 2) :: xx, dxx
 
     real(kind=rp), dimension(this%m, this%n) :: GG
     real(kind=rp), dimension(this%m+1) :: bb
@@ -189,7 +220,7 @@ contains
     integer :: nglobal
 
     ! ------------------------------------------------------------------------ !
-    ! intial value for the parameters in the subsolve based on
+    ! initial value for the parameters in the subsolve based on
     ! page 15 of "https://people.kth.se/~krille/mmagcmma.pdf"
 
     epsi = 1.0_rp !100
@@ -238,7 +269,6 @@ contains
          rey = c + d * y - lambda - mu
          rez = a0 - zeta - dot_product(lambda, a)
 
-
          relambda = 0.0_rp
          do i = 1, this%m
             do j = 1, this%n
@@ -266,19 +296,19 @@ contains
        res = lambda * s - epsi
 
        ! Setup vectors of residuals and their norms
-       residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
-       residu_small = [rey, rez, relambda, remu, rezeta, res]
+       residual = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
+       residual_small = [rey, rez, relambda, remu, rezeta, res]
 
-       residumax = maxval(abs(residu))
+       residual_max = maxval(abs(residual))
        re_sq_norm = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
 
-       call MPI_Allreduce(MPI_IN_PLACE, residumax, 1, &
+       call MPI_Allreduce(MPI_IN_PLACE, residual_max, 1, &
             mpi_real_precision, mpi_max, neko_comm, ierr)
 
        call MPI_Allreduce(MPI_IN_PLACE, re_sq_norm, &
             1, mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-       residunorm = sqrt(norm2(residu_small)**2 + re_sq_norm)
+       residual_norm = sqrt(norm2(residual_small)**2 + re_sq_norm)
 
        ! --------------------------------------------------------------------- !
        ! Internal loop
@@ -286,7 +316,7 @@ contains
        do iter = 1, this%max_iter
 
           !Check the condition
-          if (residumax .lt. epsi) exit
+          if (residual_max .lt. epsi) exit
 
           delx = 0.0_rp
           do j = 1, this%n
@@ -321,9 +351,9 @@ contains
 
           dellambda = dellambda - this%a%x*z - y - this%bi%x + epsi / lambda
 
-          do ggdumiter = 1, this%m
-             GG(ggdumiter, :) = this%pij%x(ggdumiter,:) / (this%upp%x - x)**2 &
-                  - this%qij%x(ggdumiter,:) / (x - this%low%x)**2
+          do i = 1, this%m
+             GG(i,:) = this%pij%x(i,:) / (this%upp%x - x)**2 &
+                  - this%qij%x(i,:) / (x - this%low%x)**2
           end do
 
           diagx = &
@@ -375,7 +405,6 @@ contains
                 end do
              end do
           end do
-
 
           call MPI_Allreduce(MPI_IN_PLACE, AA(1:this%m, 1:this%m), &
                this%m*this%m, mpi_real_precision, mpi_sum, neko_comm, ierr)
@@ -433,18 +462,18 @@ contains
           zetaold = zeta
           sold = s
 
-          !The innermost loop to determine the suitable step length
-          !using the Backtracking Line Search approach
-          newresidu = 2.0_rp * residunorm
+          ! The innermost loop to determine the suitable step length
+          ! using the Backtracking Line Search approach
+          new_residual = 2.0_rp * residual_norm
 
-          ! Share the newresidu and steg values
+          ! Share the new_residual and steg values
           call MPI_Allreduce(MPI_IN_PLACE, steg, 1, &
                mpi_real_precision, mpi_min, neko_comm, ierr)
-          call MPI_Allreduce(MPI_IN_PLACE, newresidu, 1, &
+          call MPI_Allreduce(MPI_IN_PLACE, new_residual, 1, &
                mpi_real_precision, mpi_min, neko_comm, ierr)
 
           itto = 0
-          do while ((newresidu .gt. residunorm) .and. (itto .lt. 50))
+          do while ((new_residual .gt. residual_norm) .and. (itto .lt. 50))
              itto = itto + 1
 
              ! update the variables
@@ -458,8 +487,8 @@ contains
              zeta = zetaold + steg*dzeta
              s = sold + steg*ds
 
-             !recompute the newresidu to see if this stepsize improves
-             !the residue
+             ! Recompute the new_residual to see if this stepsize improves
+             ! the residue
              rex = (this%p0j%x + matmul(transpose(this%pij%x), lambda)) &
                   / (this%upp%x - x)**2 &
                   - (this%q0j%x + matmul(transpose(this%qij%x), lambda)) &
@@ -469,10 +498,10 @@ contains
              rey = this%c%x + this%d%x*y - lambda - mu
              rez = this%a0 - zeta - dot_product(lambda, this%a%x)
 
+             ! Accumulate sums for relambda (the term gi(x))
              relambda = 0.0_rp
              do i = 1, this%m
-                do j = 1, this%n !this n is global
-                   ! Accumulate sums for relambda (the term gi(x))
+                do j = 1, this%n
                    relambda(i) = relambda(i) &
                         + this%pij%x(i, j) / (this%upp%x(j) - x(j)) &
                         + this%qij%x(i, j) / (x(j) - this%low%x(j))
@@ -490,36 +519,36 @@ contains
              rezeta = zeta * z - epsi
              res = lambda * s - epsi
 
-             residu_small = [rey, rez, relambda, remu, rezeta, res]
+             residual_small = [rey, rez, relambda, remu, rezeta, res]
 
              re_sq_norm = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
              call MPI_Allreduce(MPI_IN_PLACE, re_sq_norm, &
                   1, mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-             newresidu = sqrt(norm2(residu_small)**2 + re_sq_norm)
+             new_residual = sqrt(norm2(residual_small)**2 + re_sq_norm)
 
              steg = steg / 2.0_rp
           end do
           steg = 2.0_rp * steg ! Correction for the final division by 2
 
-          residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
+          residual = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
 
           ! Update the maximum and norm of the residuals
-          residunorm = newresidu
-          residumax = maxval(abs(residu))
-          call MPI_Allreduce(MPI_IN_PLACE, residumax, 1, &
+          residual_norm = new_residual
+          residual_max = maxval(abs(residual))
+          call MPI_Allreduce(MPI_IN_PLACE, residual_max, 1, &
                mpi_real_precision, mpi_max, neko_comm, ierr)
        end do
 
        epsi = 0.1_rp * epsi
     end do
 
-    ! Save the new design
+    ! Save the new designx
     this%xold2 = this%xold1
     this%xold1%x = designx
     designx = x
 
-    !update the parameters of the MMA object nesessary to compute KKT residu
+    !update the parameters of the MMA object nesessary to compute KKT residual
     this%y%x = y
     this%z = z
     this%lambda%x = lambda
@@ -531,10 +560,11 @@ contains
 
   end subroutine mma_subsolve_dpip_cpu
 
+  !> Implementation of the KKT residual computation for the MMA algorithm.
   subroutine mma_KKT_cpu(this, x, df0dx, fval, dfdx)
     ! ----------------------------------------------------- !
     ! Compute the KKT condition right hand side for a given !
-    ! design x and set the max and norm values of the       !
+    ! designx x and set the max and norm values of the       !
     ! residue of KKT system to this%residumax and           !
     ! this%residunorm.                                      !
     !                                                       !
@@ -561,9 +591,9 @@ contains
     real(kind=rp) :: rez, rezeta
     real(kind=rp), dimension(this%m) :: rey, relambda, remu, res
     real(kind=rp), dimension(this%n) :: rex, rexsi, reeta
-    real(kind=rp), dimension(3*this%n+4*this%m+2) :: residu
+    real(kind=rp), dimension(3*this%n+4*this%m+2) :: residual
 
-    real(kind=rp), dimension(4*this%m+2) :: residu_small
+    real(kind=rp), dimension(4*this%m+2) :: residual_small
     integer :: ierr
     real(kind=rp) :: re_sq_norm
 
@@ -579,10 +609,10 @@ contains
     rezeta = this%zeta * this%z
     res = this%lambda%x * this%s%x
 
-    residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
-    residu_small = [rey, rez, relambda, remu, rezeta, res]
+    residual = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
+    residual_small = [rey, rez, relambda, remu, rezeta, res]
 
-    this%residumax = maxval(abs(residu))
+    this%residumax = maxval(abs(residual))
     re_sq_norm = norm2(rex)**2 + norm2(rexsi)**2 + norm2(reeta)**2
 
     call MPI_Allreduce(MPI_IN_PLACE, this%residumax, 1, &
@@ -591,7 +621,7 @@ contains
     call MPI_Allreduce(MPI_IN_PLACE, re_sq_norm, 1, &
          mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-    this%residunorm = sqrt(norm2(residu_small)**2 + re_sq_norm)
+    this%residunorm = sqrt(norm2(residual_small)**2 + re_sq_norm)
 
   end subroutine mma_KKT_cpu
 end submodule mma_cpu

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -46,76 +46,69 @@ contains
              this%low%x(j) = x(j) - (this%xold1%x(j) - this%low%x(j))
              this%upp%x(j) = x(j) + (this%upp%x(j) - this%xold1%x(j))
           end if
-
-          ! setting a minimum and maximum for the low and upp
-          ! asymptotes (eq3.9)
-          this%low%x(j) = max(this%low%x(j), &
-               x(j) - 10.0_rp*(this%xmax%x(j) - this%xmin%x(j)))
-          this%low%x(j) = min(this%low%x(j), &
-               x(j) - 0.01_rp*(this%xmax%x(j) - this%xmin%x(j)))
-
-          this%upp%x(j) = min(this%upp%x(j), &
-               x(j) + 10.0_rp*(this%xmax%x(j) - this%xmin%x(j)))
-          this%upp%x(j) = max(this%upp%x(j), &
-               x(j) + 0.01_rp*(this%xmax%x(j) - this%xmin%x(j)))
        end do
+
+       ! Setting a minimum and maximum for the low and upp
+       ! asymptotes (eq3.9)
+       this%low%x = max(this%low%x, x - 10.0_rp * (this%xmax%x - this%xmin%x))
+       this%low%x = min(this%low%x, x - 0.01_rp * (this%xmax%x - this%xmin%x))
+
+       this%upp%x = min(this%upp%x, x + 10.0_rp * (this%xmax%x - this%xmin%x))
+       this%upp%x = max(this%upp%x, x + 0.01_rp * (this%xmax%x - this%xmin%x))
     end if
 
-    ! we can move alpha and beta out of the following loop if needed as:
-    ! this%alpha = max(this%xmin, this%low + &
-    !     0.1*(this%x- this%low), this%x - 0.5*(this%xmax - this%xmin))
-    ! this%beta = min(this%xmax, this%upp -  &
-    !     0.1*(this%upp - this%x), this%x + 0.5*(this%xmax - this%xmin))
+    ! Set the the bounds and coefficients for the approximation
+    ! the move bounds (alpha and beta )are slightly more restrictive
+    ! than low and upp. This is done based on eq(3.6)--eq(3.10).
+    ! also check
+    ! https://comsolyar.com/wp-content/uploads/2020/03/gcmma.pdf
+    ! eq (2.8) and (2.9)
+    this%alpha%x = max(this%xmin%x, &
+         this%low%x + 0.1_rp * (x - this%low%x), &
+         x - 0.5_rp * (this%xmax%x - this%xmin%x))
+
+    this%beta%x = min(this%xmax%x, &
+         this%upp%x - 0.1_rp * (this%upp%x - x), &
+         x + 0.5_rp * (this%xmax%x - this%xmin%x))
+
+
+    !Calculate p0j, q0j, pij, qij
+    !where j = 1,2,...,n and i = 1,2,...,m  (eq(2.3)-eq(2.5))
+    this%p0j%x = ( &
+         1.001_rp * max(df0dx, 0.0_rp) &
+         + 0.001_rp * max(-df0dx, 0.0_rp) &
+         + 0.00001_rp / max(this%xmax%x - this%xmin%x, 0.00001_rp) &
+         ) * (this%upp%x - x)**2
+
+    this%q0j%x = ( &
+         0.001_rp * max(df0dx, 0.0_rp) &
+         + 1.001_rp * max(-df0dx, 0.0_rp) &
+         + 0.00001_rp / max(this%xmax%x - this%xmin%x, 0.00001_rp)&
+         ) * (x - this%low%x)**2
 
     do j = 1, this%n
-       ! set the the bounds and coefficients for the approximation
-       ! the move bounds (alpha and beta )are slightly more restrictive
-       ! than low and upp. This is done based on eq(3.6)--eq(3.10).
-       ! also check
-       ! https://comsolyar.com/wp-content/uploads/2020/03/gcmma.pdf
-       ! eq (2.8) and (2.9)
-       this%alpha%x(j) = max(this%xmin%x(j), &
-            this%low%x(j) + 0.1_rp*(x(j) - this%low%x(j)), &
-            x(j) - 0.5_rp*(this%xmax%x(j) - this%xmin%x(j)))
-       this%beta%x(j) = min(this%xmax%x(j), &
-            this%upp%x(j) - 0.1_rp*(this%upp%x(j) - x(j)), &
-            x(j) + 0.5_rp*(this%xmax%x(j) - this%xmin%x(j)))
-
-       !Calculate p0j, q0j, pij, qij
-       !where j = 1,2,...,n and i = 1,2,...,m  (eq(2.3)-eq(2.5))
-       this%p0j%x(j) = ( 1.001_rp * max(df0dx(j), 0.0_rp) &
-            + 0.001_rp * max(-df0dx(j), 0.0_rp) &
-            + 0.00001_rp / max(0.00001_rp, this%xmax%x(j) - this%xmin%x(j))) &
-            * (this%upp%x(j) - x(j))**2
-
-       this%q0j%x(j) = (x(j) - this%low%x(j))**2 * &
-            (0.001_rp*max(df0dx(j),0.0_rp) + &
-            1.001_rp*max(-df0dx(j),0.0_rp) + &
-            (0.00001_rp/(max(0.00001_rp, &
-            (this%xmax%x(j) - this%xmin%x(j))))))
-
        do i = 1, this%m
-          this%pij%x(i,j) = (this%upp%x(j) - x(j))**2 * &
-               (1.001_rp*max(dfdx(i,j),0.0_rp) + &
-               0.001_rp*max(-dfdx(i,j),0.0_rp) + &
-               (0.00001_rp/(max(0.00001_rp, &
-               (this%xmax%x(j) - this%xmin%x(j))))))
-          this%qij%x(i,j) = (x(j) - this%low%x(j))**2 * &
-               (0.001_rp*max(dfdx(i, j), 0.0_rp) + &
-               1.001_rp*max(-dfdx(i, j), 0.0_rp) + &
-               (0.00001_rp/(max(0.00001_rp, &
-               (this%xmax%x(j) - this%xmin%x(j))))))
+          this%pij%x(i, j) = ( &
+               1.001_rp * max(dfdx(i, j), 0.0_rp) &
+               + 0.001_rp * max(-dfdx(i, j), 0.0_rp) &
+               + 0.00001_rp / max(this%xmax%x(j) - this%xmin%x(j), 0.00001_rp) &
+               ) * (this%upp%x(j) - x(j))**2
+
+          this%qij%x(i, j) = ( &
+               0.001_rp * max(dfdx(i, j), 0.0_rp) &
+               + 1.001_rp * max(-dfdx(i, j), 0.0_rp) &
+               + 0.00001_rp / max(this%xmax%x(j) - this%xmin%x(j), 0.00001_rp) &
+               ) * (x(j) - this%low%x(j))**2
        end do
     end do
 
-    !computing bi as defined in page 5
+    ! Computing bi as defined in page 5
     this%bi%x = 0.0_rp
     do i = 1, this%m
-       !MPI: here this%n is the global n
        do j = 1, this%n
-          this%bi%x(i) = this%bi%x(i) + &
-               this%pij%x(i,j) / (this%upp%x(j) - x(j)) + &
-               this%qij%x(i,j) / (x(j) - this%low%x(j))
+          this%bi%x(i) = this%bi%x(i) &
+               + this%pij%x(i, j) / (this%upp%x(j) - x(j)) &
+               + this%qij%x(i, j) / (x(j) - this%low%x(j))
        end do
     end do
 
@@ -148,8 +141,7 @@ contains
          rey, relambda, remu, res, &
          dely, dellambda, &
          dy, dlambda, ds, dmu, &
-         yold, lambdaold, sold, muold, &
-         globaltmp_m
+         yold, lambdaold, sold, muold
     real(kind=rp), dimension(this%n) :: x, xsi, eta, &
          rex, rexsi, reeta, &
          delx, diagx, dx, dxsi, deta, &
@@ -161,7 +153,6 @@ contains
     real(kind=rp), dimension(this%m, this%n) :: GG
     real(kind=rp), dimension(this%m+1) :: bb
     real(kind=rp), dimension(this%m+1, this%m+1) :: AA
-    real(kind=rp), dimension(this%m, this%m) :: globaltmp_mm
 
     ! using DGESV( N, NRHS, A, LDA, IPIV, B, LDB, INFO ) in lapack to solve
     ! the linear system which needs the following parameters
@@ -196,14 +187,15 @@ contains
          mpi_real_precision, mpi_min, neko_comm, ierr)
 
     do while (epsi .gt. minimal_epsilon)
+
        ! calculating residuals based on
        ! "https://people.kth.se/~krille/mmagcmma.pdf" for the variables
        ! x, y, z, lambda residuals based on eq(5.9a)-(5.9d), respectively.
-       rex = (this%p0j%x + matmul(transpose(this%pij%x), &
-            lambda))/(this%upp%x - x)**2 - &
-            (this%q0j%x + matmul(transpose(this%qij%x), &
-            lambda))/(x - this%low%x)**2 - &
-            xsi + eta
+       rex = (this%p0j%x + matmul(transpose(this%pij%x), lambda)) &
+            / (this%upp%x - x)**2 &
+            - (this%q0j%x + matmul(transpose(this%qij%x), lambda)) &
+            / (x - this%low%x)**2 &
+            - xsi + eta
 
        rey = this%c%x + this%d%x*y - lambda - mu
        rez = this%a0 - zeta - dot_product(lambda, this%a%x)
@@ -215,9 +207,9 @@ contains
        do i = 1, this%m
           do j = 1, this%n
              ! Accumulate sums for relambda (the term gi(x))
-             relambda(i) = relambda(i) + &
-                  this%pij%x(i,j) / (this%upp%x(j) - x(j)) &
-                  + this%qij%x(i,j) / (x(j) - this%low%x(j))
+             relambda(i) = relambda(i) &
+                  + this%pij%x(i, j) / (this%upp%x(j) - x(j)) &
+                  + this%qij%x(i, j) / (x(j) - this%low%x(j))
           end do
        end do
 
@@ -257,30 +249,31 @@ contains
                      + this%pij%x(i,j) * lambda(i) / (this%upp%x(j) - x(j))**2 &
                      - this%qij%x(i,j) * lambda(i) / (x(j) - this%low%x(j))**2
              end do
-             delx(j) = delx(j) &
-                  + this%p0j%x(j) / (this%upp%x(j) - x(j))**2 &
-                  - this%q0j%x(j) / (x(j) - this%low%x(j))**2 &
-                  - epsi / (x(j) - this%alpha%x(j)) &
-                  + epsi / (this%beta%x(j) - x(j))
           end do
 
-          dely = this%c%x + this%d%x*y - lambda - epsi/y
-          delz = this%a0 - dot_product(lambda, this%a%x) - epsi/z
+          delx = delx &
+               + this%p0j%x / (this%upp%x - x)**2 &
+               - this%q0j%x / (x - this%low%x)**2 &
+               - epsi / (x - this%alpha%x) &
+               + epsi / (this%beta%x - x)
+
+          dely = this%c%x + this%d%x * y - lambda - epsi / y
+          delz = this%a0 - dot_product(lambda, this%a%x) - epsi / z
 
           ! Accumulate sums for dellambda (the term gi(x))
           dellambda = 0.0_rp
           do i = 1, this%m
              do j = 1, this%n
-                dellambda(i) = dellambda(i) + &
-                     this%pij%x(i,j)/(this%upp%x(j) - x(j)) &
-                     + this%qij%x(i,j)/(x(j) - this%low%x(j))
+                dellambda(i) = dellambda(i) &
+                     + this%pij%x(i, j) / (this%upp%x(j) - x(j)) &
+                     + this%qij%x(i, j) / (x(j) - this%low%x(j))
              end do
           end do
 
           call MPI_Allreduce(MPI_IN_PLACE, dellambda, this%m, &
                mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-          dellambda = dellambda - this%a%x*z - y - this%bi%x + epsi/lambda
+          dellambda = dellambda - this%a%x*z - y - this%bi%x + epsi / lambda
 
           do ggdumiter = 1, this%m
              GG(ggdumiter, :) = this%pij%x(ggdumiter,:) / (this%upp%x - x)**2 &
@@ -305,17 +298,17 @@ contains
           !!!!!!!!!!!!!!for MPI computation of bb!!!!!!!!!!!!!!!!!!!!!!!!!
           bb = 0.0_rp
           do i = 1, this%m
-             do j = 1, this%n ! this n is global
+             do j = 1, this%n
                 bb(i) = bb(i) + GG(i, j) * (delx(j) / diagx(j))
              end do
           end do
-          globaltmp_m = 0.0_rp
-          call MPI_Allreduce(bb(1:this%m), globaltmp_m, this%m, &
-               mpi_real_precision, mpi_sum, neko_comm, ierr)
-          bb(1:this%m) = globaltmp_m
 
-          bb(1:this%m) = dellambda + dely/(this%d%x + (mu/y)) - bb(1:this%m)
-          bb(this%m +1) = delz
+          call MPI_Allreduce(MPI_IN_PLACE, bb(1:this%m), this%m, &
+               mpi_real_precision, mpi_sum, neko_comm, ierr)
+
+          bb(1:this%m) = dellambda + dely / (this%d%x + mu / y) - bb(1:this%m)
+          bb(this%m + 1) = delz
+
           !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           ! !assembling the coefficients matrix AA based on eq(5.20)
           ! AA(1:this%m,1:this%m) =  &
@@ -331,32 +324,29 @@ contains
              do j = 1, this%m
                 ! Compute the (i, j) element of AA
                 do k = 1, this%n !this n is global
-                   AA(i, j) = AA(i, j) + GG(i, k) * &
-                        (1.0_rp / diagx(k)) * GG(j, k)
+                   AA(i, j) = AA(i, j) &
+                        + GG(i, k) * (1.0_rp / diagx(k)) * GG(j, k)
                 end do
              end do
           end do
 
-          globaltmp_mm = 0.0_rp
-          call MPI_Allreduce(AA(1:this%m, 1:this%m), globaltmp_mm, &
+
+          call MPI_Allreduce(MPI_IN_PLACE, AA(1:this%m, 1:this%m), &
                this%m*this%m, mpi_real_precision, mpi_sum, neko_comm, ierr)
-          AA(1:this%m,1:this%m) = globaltmp_mm
+
           do i = 1, this%m
              !update the diag AA
-             AA(i, i) = AA(i, i) + (s(i) / lambda(i) + &
-                  1.0_rp / (this%d%x(i) + mu(i) / y(i)))
+             AA(i, i) = AA(i, i) &
+                  + s(i) / lambda(i) &
+                  + 1.0_rp / (this%d%x(i) + mu(i) / y(i))
           end do
 
           AA(1:this%m, this%m+1) = this%a%x
           AA(this%m+1, 1:this%m) = this%a%x
           AA(this%m+1, this%m+1) = - zeta/z
 
+          call DGESV(this%m + 1, 1, AA, this%m + 1, ipiv, bb, this%m + 1, info)
 
-
-
-          call DGESV(this%m+1, 1, AA, this%m+1, ipiv, bb, this%m+1, info)
-
-          ! if info! = 0 then DGESV is failed.
           if (info .ne. 0) then
              write(stderr, *) "DGESV failed to solve the linear system in MMA."
              write(stderr, *) "Please check mma_subsolve_dpip in mma.f90"
@@ -378,12 +368,14 @@ contains
           !2*this%n+4*this%m+2
           dxx = [dy, dz, dlambda, dxsi, deta, dmu, dzeta, ds]
           xx = [y, z, lambda, xsi, eta, mu, zeta, s]
-          steg = maxval([dummy_one, &
+
+          steg = 1.0_rp / maxval([ &
+               dummy_one, &
                -1.01_rp * dxx / xx, &
                -1.01_rp * dx / (x - this%alpha%x), &
-               1.01_rp * dx / (this%beta%x - x)])
+               1.01_rp * dx / (this%beta%x - x) &
+               ])
 
-          steg = 1.0_rp / steg
           call MPI_Allreduce(MPI_IN_PLACE, steg, 1, &
                mpi_real_precision, mpi_min, neko_comm, ierr)
 
@@ -434,8 +426,8 @@ contains
                 do j = 1, this%n !this n is global
                    ! Accumulate sums for relambda (the term gi(x))
                    relambda(i) = relambda(i) &
-                        + this%pij%x(i,j) / (this%upp%x(j) - x(j)) &
-                        + this%qij%x(i,j) / (x(j) - this%low%x(j))
+                        + this%pij%x(i, j) / (this%upp%x(j) - x(j)) &
+                        + this%qij%x(i, j) / (x(j) - this%low%x(j))
                 end do
              end do
 
@@ -451,6 +443,8 @@ contains
              res = lambda * s - epsi
 
              residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
+             residu_small = [rey, rez, relambda, remu, rezeta, res]
+
 
              re_xstuff_squ_global = norm2(rex)**2 &
                   + norm2(rexsi)**2 &
@@ -458,9 +452,8 @@ contains
              call MPI_Allreduce(MPI_IN_PLACE, re_xstuff_squ_global, &
                   1, mpi_real_precision, mpi_sum, neko_comm, ierr)
 
-             residu_small = [rey, rez, relambda, remu, rezeta, res]
-             newresidu = sqrt(norm2(residu_small)**2 + &
-                  re_xstuff_squ_global)
+
+             newresidu = sqrt(norm2(residu_small)**2 + re_xstuff_squ_global)
 
              steg = steg / 2.0_rp
           end do

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -26,29 +26,24 @@ contains
 
     associate(low => this%low%x, upp => this%upp%x, &
          xmin => this%xmin%x, xmax => this%xmax%x, &
-         xold_1 => this%xold1%x, xold_2 => this%xold2%x)
+         x_1 => this%xold1%x, x_2 => this%xold2%x)
 
       if (iter .lt. 3) then
-
          ! Initialize the lower and upper asymptotes
          low = x - this%asyinit * (xmax - xmin)
          upp = x + this%asyinit * (xmax - xmin)
-
       else
-
          do j = 1, this%n
-            if ((x(j) - xold_1(j)) * (xold_1(j) - xold_2(j)) &
-                 .lt. 0.0_rp) then
+            if ((x(j) - x_1(j)) * (x_1(j) - x_2(j)) .lt. 0.0_rp) then
                asy_factor = this%asydecr
-            else if ((x(j) - xold_1(j)) * (xold_1(j) - xold_2(j)) &
-                 .gt. 0.0_rp) then
+            else if ((x(j) - x_1(j)) * (x_1(j) - x_2(j)) .gt. 0.0_rp) then
                asy_factor = this%asyincr
             else
                asy_factor = 1.0_rp
             end if
 
-            low(j) = x(j) - asy_factor * (xold_1(j) - low(j))
-            upp(j) = x(j) + asy_factor * (upp(j) - xold_1(j))
+            low(j) = x(j) - asy_factor * (x_1(j) - low(j))
+            upp(j) = x(j) + asy_factor * (upp(j) - x_1(j))
          end do
 
 
@@ -63,65 +58,83 @@ contains
 
     end associate
 
-
+    ! ------------------------------------------------------------------------ !
     ! Set the the bounds and coefficients for the approximation
-    ! the move bounds (alpha and beta )are slightly more restrictive
+    ! the move bounds (alpha and beta) are slightly more restrictive
     ! than low and upp. This is done based on eq(3.6)--eq(3.10).
     ! also check
     ! https://comsolyar.com/wp-content/uploads/2020/03/gcmma.pdf
     ! eq (2.8) and (2.9)
-    this%alpha%x = max(this%xmin%x, &
-         this%low%x + 0.1_rp * (x - this%low%x), &
-         x - 0.5_rp * (this%xmax%x - this%xmin%x))
 
-    this%beta%x = min(this%xmax%x, &
-         this%upp%x - 0.1_rp * (this%upp%x - x), &
-         x + 0.5_rp * (this%xmax%x - this%xmin%x))
+    associate(alpha => this%alpha%x, beta => this%beta%x, &
+         xmin => this%xmin%x, xmax => this%xmax%x, &
+         low => this%low%x, upp => this%upp%x)
 
+      alpha = max(xmin, low + 0.1_rp*(x - low), x - 0.5_rp*(xmax - xmin))
+      beta = min(xmax, upp - 0.1_rp*(upp - x), x + 0.5_rp*(xmax - xmin))
 
-    !Calculate p0j, q0j, pij, qij
-    !where j = 1,2,...,n and i = 1,2,...,m  (eq(2.3)-eq(2.5))
-    this%p0j%x = ( &
-         1.001_rp * max(df0dx, 0.0_rp) &
-         + 0.001_rp * max(-df0dx, 0.0_rp) &
-         + 0.00001_rp / max(this%xmax%x - this%xmin%x, 0.00001_rp) &
-         ) * (this%upp%x - x)**2
+    end associate
 
-    this%q0j%x = ( &
-         0.001_rp * max(df0dx, 0.0_rp) &
-         + 1.001_rp * max(-df0dx, 0.0_rp) &
-         + 0.00001_rp / max(this%xmax%x - this%xmin%x, 0.00001_rp)&
-         ) * (x - this%low%x)**2
+    ! ------------------------------------------------------------------------ !
+    ! Calculate p0j, q0j, pij, qij
+    ! where j = 1,2,...,n and i = 1,2,...,m  (eq(2.3)-eq(2.5))
 
-    do j = 1, this%n
-       do i = 1, this%m
-          this%pij%x(i, j) = ( &
-               1.001_rp * max(dfdx(i, j), 0.0_rp) &
-               + 0.001_rp * max(-dfdx(i, j), 0.0_rp) &
-               + 0.00001_rp / max(this%xmax%x(j) - this%xmin%x(j), 0.00001_rp) &
-               ) * (this%upp%x(j) - x(j))**2
+    associate(p0j => this%p0j%x, q0j => this%q0j%x, &
+         pij => this%pij%x, qij => this%qij%x, &
+         low => this%low%x, upp => this%upp%x, &
+         xmin => this%xmin%x, xmax => this%xmax%x)
 
-          this%qij%x(i, j) = ( &
-               0.001_rp * max(dfdx(i, j), 0.0_rp) &
-               + 1.001_rp * max(-dfdx(i, j), 0.0_rp) &
-               + 0.00001_rp / max(this%xmax%x(j) - this%xmin%x(j), 0.00001_rp) &
-               ) * (x(j) - this%low%x(j))**2
-       end do
-    end do
+      p0j = ( &
+           1.001_rp * max(df0dx, 0.0_rp) &
+           + 0.001_rp * max(-df0dx, 0.0_rp) &
+           + 0.00001_rp / max(xmax - xmin, 0.00001_rp) &
+           ) * (upp - x)**2
 
+      q0j = ( &
+           0.001_rp * max(df0dx, 0.0_rp) &
+           + 1.001_rp * max(-df0dx, 0.0_rp) &
+           + 0.00001_rp / max(xmax - xmin, 0.00001_rp)&
+           ) * (x - low)**2
+
+      do j = 1, this%n
+         do i = 1, this%m
+            pij(i, j) = ( &
+                 1.001_rp * max(dfdx(i, j), 0.0_rp) &
+                 + 0.001_rp * max(-dfdx(i, j), 0.0_rp) &
+                 + 0.00001_rp / max(xmax(j) - xmin(j), 0.00001_rp) &
+                 ) * (upp(j) - x(j))**2
+
+            qij(i, j) = ( &
+                 0.001_rp * max(dfdx(i, j), 0.0_rp) &
+                 + 1.001_rp * max(-dfdx(i, j), 0.0_rp) &
+                 + 0.00001_rp / max(xmax(j) - xmin(j), 0.00001_rp) &
+                 ) * (x(j) - low(j))**2
+         end do
+      end do
+
+    end associate
+
+    ! ------------------------------------------------------------------------ !
     ! Computing bi as defined in page 5
-    this%bi%x = 0.0_rp
-    do i = 1, this%m
-       do j = 1, this%n
-          this%bi%x(i) = this%bi%x(i) &
-               + this%pij%x(i, j) / (this%upp%x(j) - x(j)) &
-               + this%qij%x(i, j) / (x(j) - this%low%x(j))
-       end do
-    end do
 
-    call MPI_Allreduce(MPI_IN_PLACE, this%bi%x, this%m, &
-         mpi_real_precision, mpi_sum, neko_comm, ierr)
-    this%bi%x = this%bi%x - fval
+    associate(bi => this%bi%x, &
+         pij => this%pij%x, qij => this%qij%x, &
+         low => this%low%x, upp => this%upp%x)
+
+      bi = 0.0_rp
+      do i = 1, this%m
+         do j = 1, this%n
+            bi(i) = bi(i) &
+                 + pij(i, j) / (upp(j) - x(j)) &
+                 + qij(i, j) / (x(j) - low(j))
+         end do
+      end do
+
+      call MPI_Allreduce(MPI_IN_PLACE, bi, this%m, &
+           mpi_real_precision, mpi_sum, neko_comm, ierr)
+      bi = bi - fval
+
+    end associate
 
   end subroutine mma_gensub_cpu
 
@@ -161,18 +174,21 @@ contains
     real(kind=rp), dimension(this%m+1) :: bb
     real(kind=rp), dimension(this%m+1, this%m+1) :: AA
 
-    ! using DGESV( N, NRHS, A, LDA, IPIV, B, LDB, INFO ) in lapack to solve
+    ! using DGESV in lapack to solve
     ! the linear system which needs the following parameters
     integer :: info
     integer, dimension(this%m+1) :: ipiv
 
+    ! Parameters for global communication
     real(kind=rp) :: re_xstuff_squ_global
     real(kind=rp) :: minimal_epsilon
 
     integer :: nglobal
 
+    ! ------------------------------------------------------------------------ !
     ! intial value for the parameters in the subsolve based on
     ! page 15 of "https://people.kth.se/~krille/mmagcmma.pdf"
+
     epsi = 1.0_rp !100
     x = 0.5_rp * (this%alpha%x + this%beta%x)
     y = 1.0_rp
@@ -187,35 +203,55 @@ contains
     call MPI_Allreduce(this%n, nglobal, 1, &
          MPI_INTEGER, mpi_sum, neko_comm, ierr)
 
-    ! computing the minimal epsilon based on eq(5.10)
+    ! ------------------------------------------------------------------------ !
+    ! Computing the minimal epsilon and choose the most conservative one
+
     minimal_epsilon = max(0.9_rp * this%epsimin, 1.0e-12_rp)
     call MPI_Allreduce(MPI_IN_PLACE, minimal_epsilon, 1, &
          mpi_real_precision, mpi_min, neko_comm, ierr)
 
+    ! ------------------------------------------------------------------------ !
+    !  The main loop of the dual-primal interior point method.
+
     do while (epsi .gt. minimal_epsilon)
 
-       ! calculating residuals based on
+       ! --------------------------------------------------------------------- !
+       ! Calculating residuals based on
        ! "https://people.kth.se/~krille/mmagcmma.pdf" for the variables
        ! x, y, z, lambda residuals based on eq(5.9a)-(5.9d), respectively.
-       rex = (this%p0j%x + matmul(transpose(this%pij%x), lambda)) &
-            / (this%upp%x - x)**2 &
-            - (this%q0j%x + matmul(transpose(this%qij%x), lambda)) &
-            / (x - this%low%x)**2 &
-            - xsi + eta
 
-       rey = this%c%x + this%d%x*y - lambda - mu
-       rez = this%a0 - zeta - dot_product(lambda, this%a%x)
+       associate(p0j => this%p0j%x, q0j => this%q0j%x, &
+            pij => this%pij%x, qij => this%qij%x, &
+            low => this%low%x, upp => this%upp%x, &
+            alpha => this%alpha%x, beta => this%beta%x, &
+            c => this%c%x, d => this%d%x, &
+            a0 => this%a0, a => this%a%x, &
+            bi => this%bi%x)
 
-       relambda = 0.0_rp
-       do i = 1, this%m
-          do j = 1, this%n
-             ! Accumulate sums for relambda (the term gi(x))
-             relambda(i) = relambda(i) &
-                  + this%pij%x(i, j) / (this%upp%x(j) - x(j)) &
-                  + this%qij%x(i, j) / (x(j) - this%low%x(j))
-          end do
-       end do
+         rex = (p0j + matmul(transpose(pij), lambda)) / (upp - x)**2 &
+              - (q0j + matmul(transpose(qij), lambda)) / (x - low)**2 &
+              - xsi + eta
 
+         rey = c + d * y - lambda - mu
+         rez = a0 - zeta - dot_product(lambda, a)
+
+
+         relambda = 0.0_rp
+         do i = 1, this%m
+            do j = 1, this%n
+               ! Accumulate sums for relambda (the term gi(x))
+               relambda(i) = relambda(i) &
+                    + pij(i, j) / (upp(j) - x(j)) &
+                    + qij(i, j) / (x(j) - low(j))
+            end do
+         end do
+
+       end associate
+
+       ! --------------------------------------------------------------------- !
+       ! Computing the norm of the residuals
+
+       ! Complete the computations of lambda residuals
        call MPI_Allreduce(MPI_IN_PLACE, relambda, this%m, &
             mpi_real_precision, mpi_sum, neko_comm, ierr)
        relambda = relambda - this%a%x*z - y + s - this%bi%x
@@ -226,6 +262,7 @@ contains
        rezeta = zeta * z - epsi
        res = lambda * s - epsi
 
+       ! Setup vectors of residuals and their norms
        residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
        residu_small = [rey, rez, relambda, remu, rezeta, res]
 
@@ -239,6 +276,9 @@ contains
             1, mpi_real_precision, mpi_sum, neko_comm, ierr)
 
        residunorm = sqrt(norm2(residu_small)**2 + re_xstuff_squ_global)
+
+       ! --------------------------------------------------------------------- !
+       ! Internal loop
 
        do iter = 1, this%max_iter
 
@@ -358,17 +398,17 @@ contains
 
           dlambda = bb(1:this%m)
           dz = bb(this%m + 1)
+
           ! based on eq(5.19)
           dx = - delx / diagx - matmul(transpose(GG), dlambda) / diagx
-
           dy = (-dely + dlambda) / (this%d%x + mu / y)
+
           dxsi = -xsi + (epsi - dx * xsi) / (x - this%alpha%x)
           deta = -eta + (epsi + dx * eta) / (this%beta%x - x)
           dmu = -mu + (epsi - mu * dy) / y
           dzeta = -zeta + (epsi - zeta * dz) / z
           ds = -s + (epsi - dlambda * s) / lambda
 
-          !2*this%n+4*this%m+2
           dxx = [dy, dz, dlambda, dxsi, deta, dmu, dzeta, ds]
           xx = [y, z, lambda, xsi, eta, mu, zeta, s]
 
@@ -379,9 +419,7 @@ contains
                1.01_rp * dx / (this%beta%x - x) &
                ])
 
-          call MPI_Allreduce(MPI_IN_PLACE, steg, 1, &
-               mpi_real_precision, mpi_min, neko_comm, ierr)
-
+          ! Save the old values
           xold = x
           yold = y
           zold = z
@@ -395,6 +433,10 @@ contains
           !The innermost loop to determine the suitable step length
           !using the Backtracking Line Search approach
           newresidu = 2.0_rp * residunorm
+
+          ! Share the newresidu and steg values
+          call MPI_Allreduce(MPI_IN_PLACE, steg, 1, &
+               mpi_real_precision, mpi_min, neko_comm, ierr)
           call MPI_Allreduce(MPI_IN_PLACE, newresidu, 1, &
                mpi_real_precision, mpi_min, neko_comm, ierr)
 
@@ -458,17 +500,15 @@ contains
 
              steg = steg / 2.0_rp
           end do
+          steg = 2.0_rp * steg ! Correction for the final division by 2
 
           residu = [rex, rey, rez, relambda, rexsi, reeta, remu, rezeta, res]
 
+          ! Update the maximum and norm of the residuals
           residunorm = newresidu
           residumax = maxval(abs(residu))
           call MPI_Allreduce(MPI_IN_PLACE, residumax, 1, &
                mpi_real_precision, mpi_max, neko_comm, ierr)
-
-          !correct the step size for the extra devision by 2 in the final
-          !loop
-          steg = 2.0_rp * steg
        end do
 
        epsi = 0.1_rp * epsi

--- a/sources/optimizer/mma.f90
+++ b/sources/optimizer/mma.f90
@@ -40,6 +40,7 @@ module mma
   use matrix, only: matrix_t
   use json_module, only: json_file
   use json_utils, only: json_get_or_default
+  use mpi_f08, only: MPI_Allreduce, MPI_INTEGER, MPI_SUM, MPI_COMM_WORLD
 
   ! Inclusions from external dependencies and standard libraries
   use, intrinsic :: iso_fortran_env, only: stderr => error_unit
@@ -160,18 +161,22 @@ contains
     !! For reading the values from json and then set the value for the arrays
     real(kind=rp) :: a0 , xmax_const, xmin_const, a_const, c_const, d_const
 
-    integer :: max_iter
+    integer :: max_iter, n_global, ierr
     real(kind=rp) :: epsimin, asyinit, asyincr, asydecr
     character(len=:), allocatable :: backend
 
     !! Read the scaling info for fval and dfdx from json
     real(kind=rp), intent(out) :: scale
     logical, intent(out) :: auto_scale
+
+    call MPI_Allreduce(n, n_global, 1, MPI_INTEGER, &
+         MPI_SUM, MPI_COMM_WORLD, ierr)
+
     ! ------------------------------------------------------------------------ !
     ! Assign defaults if nothing is parsed
     ! based on the Cpp Code by Niels
     call json_get_or_default(json, 'mma.epsimin', epsimin, &
-         1.0e-9_rp * sqrt(real(m + n, rp)))
+         1.0e-9_rp * sqrt(real(m + n_global, rp)))
     call json_get_or_default(json, 'mma.max_iter', max_iter, 100)
 
     ! Following parameters are set based on eq.3.8:--------

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -65,7 +65,7 @@ contains
     ! Initialize MMA solver
     ! Check the type of the problem using select type
     select type (problem)
-      type is (steady_state_problem_t)
+    type is (steady_state_problem_t)
 
        print *, "Initializing mma_optimizer with steady_state_problem_t."
 
@@ -76,7 +76,7 @@ contains
 
        print *, "scale = ", this%scale
        print *, "auto_scale = ", this%auto_scale
-      class default
+    class default
 
        call neko_error('Unknown problem type in the mma_optimizer_init')
     end select
@@ -84,26 +84,28 @@ contains
   end subroutine mma_optimizer_init
 
   ! Define the optimization loop for MMA
-  subroutine mma_optimizer_run(this, problem, tolerance)
+  subroutine mma_optimizer_run(this, problem, tolerance, max_iter)
     class(mma_optimizer_t), intent(inout) :: this
     class(problem_t), intent(inout) :: problem
     real(kind=rp), intent(in) :: tolerance
+    integer, intent(in) :: max_iter
 
     ! Check the type of the problem using select type
     select type (problem)
-      type is (steady_state_problem_t)
-       call this%run_ss(problem, tolerance)
+    type is (steady_state_problem_t)
+       call this%run_ss(problem, tolerance, max_iter)
 
-      class default
+    class default
        call neko_error('Unknown problem type in the mma_optimizer_run')
     end select
   end subroutine mma_optimizer_run
 
-  subroutine mma_optimizer_run_steady_state_prob(this, problem, tolerance)
+  subroutine mma_optimizer_run_steady_state_prob(this, problem, tolerance, &
+       max_iter)
     class(mma_optimizer_t), intent(inout) :: this
     class(steady_state_problem_t), intent(inout) :: problem
     real(kind=rp), intent(in) :: tolerance
-    integer :: max_iter
+    integer, intent(in) :: max_iter
     integer :: iter, ierr, nglobal
     real(kind=rp) :: scalingfactor
 
@@ -112,7 +114,6 @@ contains
     type(vector_t) :: objective_sensitivities
     type(matrix_t) :: constraint_sensitivities
 
-    max_iter = this%mma%get_max_iter()
     ! call MPI_Comm_rank(neko_comm, rank, ierr)
     call MPI_Allreduce(this%mma%get_n(), nglobal, 1, &
          MPI_INTEGER, mpi_sum, neko_comm, ierr)

--- a/sources/optimizer/optimizer.f90
+++ b/sources/optimizer/optimizer.f90
@@ -35,11 +35,12 @@ module optimizer
 
   !> Interface for running the optimization loop
   abstract interface
-     subroutine optimizer_run(this, problem, tolerance)
+     subroutine optimizer_run(this, problem, tolerance, max_iter)
        import optimizer_t, problem_t, rp
        class(optimizer_t), intent(inout) :: this
        class(problem_t), intent(inout) :: problem
        real(kind=rp), intent(in) :: tolerance
+       integer, intent(in) :: max_iter
      end subroutine optimizer_run
   end interface
 


### PR DESCRIPTION
Address a bug that caused MPI de-synchronization and enhance code clarity through multiple cleanup rounds. Additionally, update example configurations and refine precision settings.