### PR TITLE
Enhance Fortran build configuration and add LAPACK interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,13 +83,28 @@ set(PFUNIT_DIR       ${CMAKE_CURRENT_SOURCE_DIR}/external/pFUnit
 set(CMAKE_Fortran_PREPROCESS ON)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(
+        # Debugging flags
+        $<$<COMPILE_LANGUAGE:Fortran>:-g>
         $<$<COMPILE_LANGUAGE:Fortran>:-Og>
+
+        # Warnings which for debug builds are errors
         $<$<COMPILE_LANGUAGE:Fortran>:-Wall>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wextra>
-        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-unused-dummy-argument>
-        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-function-elimination>
-        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-missing-include-dirs>
         $<$<COMPILE_LANGUAGE:Fortran>:-Werror>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wsurprising>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-array-temporaries>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wimplicit-interface>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-unused-dummy-argument>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wfunction-elimination>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-missing-include-dirs>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wcompare-reals>
+
+        # Debugging checks
+        $<$<COMPILE_LANGUAGE:Fortran>:-fcheck=all>
+        $<$<COMPILE_LANGUAGE:Fortran>:-fbacktrace>
+        $<$<COMPILE_LANGUAGE:Fortran>:-ffpe-trap=invalid,zero,overflow>
+        $<$<COMPILE_LANGUAGE:Fortran>:-finit-real=snan>
+        $<$<COMPILE_LANGUAGE:Fortran>:-finit-integer=-99999999>
     )
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         $<$<COMPILE_LANGUAGE:Fortran>:-Wextra>
         $<$<COMPILE_LANGUAGE:Fortran>:-Werror>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wsurprising>
-        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-array-temporaries>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Warray-temporaries>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wimplicit-interface>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wno-unused-dummy-argument>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wfunction-elimination>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,10 +92,10 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         $<$<COMPILE_LANGUAGE:Fortran>:-Wextra>
         $<$<COMPILE_LANGUAGE:Fortran>:-Werror>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wsurprising>
-        $<$<COMPILE_LANGUAGE:Fortran>:-Warray-temporaries>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-array-temporaries>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wimplicit-interface>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wno-unused-dummy-argument>
-        $<$<COMPILE_LANGUAGE:Fortran>:-Wfunction-elimination>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-function-elimination>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wno-missing-include-dirs>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wcompare-reals>
 

--- a/examples/mma/mma_simcomp.f90
+++ b/examples/mma/mma_simcomp.f90
@@ -41,7 +41,8 @@ module mma_simcomp
   use logger, only: neko_log
   use mma, only: mma_t
   use comm, only: neko_comm, mpi_real_precision
-  use mpi_f08, only: MPI_INTEGER, MPI_Allreduce, MPI_SUM, MPI_COMM_WORLD
+  use mpi_f08, only: MPI_INTEGER, MPI_Allreduce, MPI_SUM, MPI_COMM_WORLD, &
+       MPI_Comm_size, MPI_Gatherv, MPI_Comm_rank, MPI_Allgather
   implicit none
   private
 

--- a/sources/adjoint/adjoint_pnpn.f90
+++ b/sources/adjoint/adjoint_pnpn.f90
@@ -79,7 +79,7 @@ module adjoint_pnpn
   use file, only: file_t
   use operators, only: ortho
   use vector, only: vector_t
-  use device_math, only: device_vlsc3
+  use device_math, only: device_vlsc3, device_cmult
   use math, only: vlsc3, cmult
   use json_utils_ext, only: json_key_fallback
   use, intrinsic :: iso_c_binding, only: c_ptr
@@ -1052,7 +1052,7 @@ contains
              ! convention marked weak and currently contain nested
              ! bcs, some of which are strong.
              select type (bc_i)
-               type is (symmetry_t)
+             type is (symmetry_t)
                 ! Symmetry has 3 internal bcs, but only one actually contains
                 ! markings.
                 ! Symmetry's apply_scalar doesn't do anything, so we need to mark
@@ -1068,14 +1068,14 @@ contains
                 call this%bcs_vel%append(bc_i)
 
                 call this%bc_sym_surface%mark_facets(bc_i%marked_facet)
-               type is (non_normal_t)
+             type is (non_normal_t)
                 ! This is a bc for the residuals and increments, not the
                 ! velocity itself. So, don't append to bcs_vel
                 call this%bclst_vel_res%append(bc_i)
                 call this%bc_du%mark_facets(bc_i%bc_x%marked_facet)
                 call this%bc_dv%mark_facets(bc_i%bc_y%marked_facet)
                 call this%bc_dw%mark_facets(bc_i%bc_z%marked_facet)
-               type is (shear_stress_t)
+             type is (shear_stress_t)
                 ! Same as symmetry
                 call this%bclst_vel_res%append(bc_i%symmetry)
                 call this%bclst_du%append(bc_i%symmetry%bc_x)
@@ -1083,7 +1083,7 @@ contains
                 call this%bclst_dw%append(bc_i%symmetry%bc_z)
 
                 call this%bcs_vel%append(bc_i)
-               type is (wall_model_bc_t)
+             type is (wall_model_bc_t)
                 ! Same as symmetry
                 call this%bclst_vel_res%append(bc_i%symmetry)
                 call this%bclst_du%append(bc_i%symmetry%bc_x)
@@ -1091,7 +1091,7 @@ contains
                 call this%bclst_dw%append(bc_i%symmetry%bc_z)
 
                 call this%bcs_vel%append(bc_i)
-               class default
+             class default
 
                 ! For the default case we use our dummy zero_dirichlet bcs to
                 ! mark the same faces as in ordinary velocity dirichlet
@@ -1228,19 +1228,19 @@ contains
     do i = 1, this%bcs_prs%size()
        bci => this%bcs_prs%get(i)
        select type (bc => bci)
-         type is (zero_dirichlet_t)
+       type is (zero_dirichlet_t)
           call bdry_mask%init_from_components(this%c_Xh, 3.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (dong_outflow_t)
+       type is (dong_outflow_t)
           call bdry_mask%init_from_components(this%c_Xh, 3.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (field_dirichlet_t)
+       type is (field_dirichlet_t)
           call bdry_mask%init_from_components(this%c_Xh, 8.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
@@ -1252,49 +1252,49 @@ contains
     do i = 1, this%bcs_vel%size()
        bci => this%bcs_vel%get(i)
        select type (bc => bci)
-         type is (zero_dirichlet_t)
+       type is (zero_dirichlet_t)
           call bdry_mask%init_from_components(this%c_Xh, 1.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (inflow_t)
+       type is (inflow_t)
           call bdry_mask%init_from_components(this%c_Xh, 2.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (symmetry_t)
+       type is (symmetry_t)
           call bdry_mask%init_from_components(this%c_Xh, 4.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (usr_inflow_t)
+       type is (usr_inflow_t)
           call bdry_mask%init_from_components(this%c_Xh, 5.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (field_dirichlet_vector_t)
+       type is (field_dirichlet_vector_t)
           call bdry_mask%init_from_components(this%c_Xh, 7.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (shear_stress_t)
+       type is (shear_stress_t)
           call bdry_mask%init_from_components(this%c_Xh, 9.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (wall_model_bc_t)
+       type is (wall_model_bc_t)
           call bdry_mask%init_from_components(this%c_Xh, 10.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()
           call bdry_mask%apply_scalar(bdry_field%x, this%dm_Xh%size())
           call bdry_mask%free()
-         type is (blasius_t)
+       type is (blasius_t)
           call bdry_mask%init_from_components(this%c_Xh, 11.0_rp)
           call bdry_mask%mark_facets(bci%marked_facet)
           call bdry_mask%finalize()

--- a/sources/neko_ext/CMakeLists.txt
+++ b/sources/neko_ext/CMakeLists.txt
@@ -17,4 +17,5 @@ target_sources(neko-top
         ${CMAKE_CURRENT_SOURCE_DIR}/neko_ext.f90
         ${CMAKE_CURRENT_SOURCE_DIR}/develop.f90
         ${CMAKE_CURRENT_SOURCE_DIR}/json_utils_ext.f90
+        ${CMAKE_CURRENT_SOURCE_DIR}/lapack_interfaces.f90
 )

--- a/sources/neko_ext/develop.f90
+++ b/sources/neko_ext/develop.f90
@@ -198,7 +198,7 @@ contains
     ! Determine the number of nodes in the facet
     N_nodes = 0
     select type (ele => C%msh%elements(element_id)%e)
-      type is (hex_t)
+    type is (hex_t)
        N_nodes = 4
     end select
 
@@ -217,7 +217,7 @@ contains
 
     ! Get the nodes
     select type (ele => C%msh%elements(element_id)%e)
-      type is (hex_t)
+    type is (hex_t)
        call ele%facet_order(t_hex, facet_id)
        do n = 1, N_nodes
           v = t_hex%x(n)

--- a/sources/neko_ext/develop.f90
+++ b/sources/neko_ext/develop.f90
@@ -60,7 +60,7 @@ contains
     real(kind=rp) :: a
 
     ! Internal variables
-    real(kind=rp), dimension(3) :: v1
+    real(kind=rp), dimension(3) :: v1, e1, e2, tmp
     real(kind=rp) :: cp(3)
     integer :: v
 
@@ -70,7 +70,10 @@ contains
     v1 = vertices(:, 1)
     cp = 0.0
     do v = 2, nv - 1
-       cp = cp + 0.5 * cross((vertices(:, v) - v1), (vertices(:, v + 1) - v1))
+       e1 = (vertices(:, v) - v1)
+       e2 = (vertices(:, v + 1) - v1)
+       tmp = cross(e1, e2)
+       cp = cp + 0.5 * tmp
     end do
 
     a = sqrt(dot(cp, cp))
@@ -286,9 +289,8 @@ contains
     call interpolator%find_points_xyz(facet_centers, N_facets)
     call interpolator%evaluate(temperature_local, neko_case%scalar%s%x)
 
-    temperature_mean = average_weighted( &
-         temperature_local - target_temperature, &
-         facet_area)
+    temperature_local = temperature_local - target_temperature
+    temperature_mean = average_weighted(temperature_local, facet_area)
 
     write (log_buf, '(a,f15.7)') &
          "Outlet area-weighted average temperature deviation: ", &

--- a/sources/neko_ext/lapack_interfaces.f90
+++ b/sources/neko_ext/lapack_interfaces.f90
@@ -1,0 +1,52 @@
+! Copyright (c) 2025, The Neko-TOP Authors
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+!   * Redistributions of source code must retain the above copyright
+!     notice, this list of conditions and the following disclaimer.
+!
+!   * Redistributions in binary form must reproduce the above
+!     copyright notice, this list of conditions and the following
+!     disclaimer in the documentation and/or other materials provided
+!     with the distribution.
+!
+!   * Neither the name of the authors nor the names of its
+!     contributors may be used to endorse or promote products derived
+!     from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+
+module lapack_interfaces
+  use num_types, only: rp
+
+  implicit none
+  private
+
+  public :: dgesv
+
+  interface
+     pure subroutine dgesv(n, nrhs, a, lda, ipiv, b, ldb, info)
+       import :: rp
+       integer, intent(in) :: n, nrhs, lda, ldb
+       real(kind=rp), intent(inout), dimension(lda, n) :: a
+       integer, intent(out), dimension(n) :: ipiv
+       real(kind=rp), intent(inout), dimension(ldb, nrhs) :: b
+       integer, intent(out) :: info
+     end subroutine dgesv
+  end interface
+
+end module lapack_interfaces

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -208,6 +208,8 @@ contains
     real(kind=rp), dimension(this%m+1) :: bb
     real(kind=rp), dimension(this%m+1, this%m+1) :: AA
 
+    real(kind=rp), dimension(this%m) :: work_1, work_2
+
     ! using DGESV in lapack to solve
     ! the linear system which needs the following parameters
     integer :: info
@@ -249,8 +251,11 @@ contains
             a0 => this%a0, a => this%a%x, &
             bi => this%bi%x)
 
-         rex = (p0j + matmul(transpose(pij), lambda)) / (upp - x)**2 &
-              - (q0j + matmul(transpose(qij), lambda)) / (x - low)**2 &
+         work_1 = matmul(transpose(pij), lambda)
+         work_2 = matmul(transpose(qij), lambda)
+
+         rex = (p0j + work_1) / (upp - x)**2 &
+              - (q0j + work_2) / (x - low)**2 &
               - xsi + eta
 
          rey = c + d * y - lambda - mu
@@ -343,11 +348,11 @@ contains
                   - this%qij%x(i,:) / (x - this%low%x)**2
           end do
 
-          diagx = &
-               (this%p0j%x + matmul(transpose(this%pij%x), lambda)) &
-               / (this%upp%x - x)**3 &
-               + (this%q0j%x + matmul(transpose(this%qij%x), lambda)) &
-               / (x - this%low%x)**3
+          work_1 = matmul(transpose(this%pij%x), lambda)
+          work_2 = matmul(transpose(this%qij%x), lambda)
+
+          diagx = (this%p0j%x + work_1) / (this%upp%x - x)**3 &
+               + (this%q0j%x + work_2) / (x - this%low%x)**3
 
           diagx = 2.0_rp * diagx &
                + xsi / (x - this%alpha%x) &
@@ -474,12 +479,13 @@ contains
              zeta = zetaold + steg*dzeta
              s = sold + steg*ds
 
+             work_1 = matmul(transpose(this%pij%x), lambda)
+             work_2 = matmul(transpose(this%qij%x), lambda)
+
              ! Recompute the new_residual to see if this stepsize improves
              ! the residue
-             rex = (this%p0j%x + matmul(transpose(this%pij%x), lambda)) &
-                  / (this%upp%x - x)**2 &
-                  - (this%q0j%x + matmul(transpose(this%qij%x), lambda)) &
-                  / (x - this%low%x)**2 &
+             rex = (this%p0j%x + work_1) / (this%upp%x - x)**2 &
+                  - (this%q0j%x + work_2) / (x - this%low%x)**2 &
                   - xsi + eta
 
              rey = this%c%x + this%d%x*y - lambda - mu

--- a/sources/optimizer/bcknd/cpu/mma_cpu.f90
+++ b/sources/optimizer/bcknd/cpu/mma_cpu.f90
@@ -35,6 +35,7 @@ submodule (mma) mma_cpu
   use mpi_f08, only: MPI_REAL, MPI_IN_PLACE, mpi_min, mpi_max
   use utils, only: neko_error
   use comm, only: neko_comm, mpi_real_precision
+  use lapack_interfaces, only: dgesv
 
 contains
 


### PR DESCRIPTION
Improve debugging options in the Fortran build configuration and introduce a new LAPACK interface module for solving linear equations. Additionally, refine type declarations for better clarity in the code.