### PR TITLE
Fix CMake compile definition and preprocessor directives for CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(CMAKE_Fortran_STANDARD 2008)
 option(DEVICE_TYPE "Enable device support" OFF)
 if (DEVICE_TYPE STREQUAL "CUDA")
     enable_language(CUDA)
-    add_compile_definitions(HAVE_CUDA 1)
+    add_compile_definitions(HAVE_CUDA=1)
 endif()
 
 # ............................................................................ #

--- a/sources/neko_ext/math/bcknd/device_math_ext.f90
+++ b/sources/neko_ext/math/bcknd/device_math_ext.f90
@@ -36,7 +36,7 @@ module device_math_ext
   use, intrinsic :: iso_c_binding, only : c_ptr, c_int
   implicit none
 
-#ifdef HAVE_HIP
+#if HAVE_HIP
 
 #elif HAVE_CUDA
 
@@ -114,7 +114,7 @@ contains
     integer :: size
     type(c_ptr) :: mask_d
     integer :: mask_size
-#ifdef HAVE_CUDA
+#if HAVE_CUDA
     call cuda_cadd_mask(a_d, c, size, mask_d, mask_size)
 #else
     call neko_error('No device backend configured')
@@ -126,7 +126,7 @@ contains
     integer :: size
     type(c_ptr) :: mask_d
     integer :: mask_size
-#ifdef HAVE_CUDA
+#if HAVE_CUDA
     call cuda_invcol1_mask(a_d, size, mask_d, mask_size)
 #else
     call neko_error('No device backend configured')
@@ -139,7 +139,7 @@ contains
     integer :: size
     type(c_ptr) :: mask_d
     integer :: mask_size
-#ifdef HAVE_CUDA
+#if HAVE_CUDA
     call cuda_col2_mask(a_d, b_d, size, mask_d, mask_size)
 #else
     call neko_error('No device backend configured')
@@ -153,7 +153,7 @@ contains
     integer :: size
     type(c_ptr) :: mask_d
     integer :: mask_size
-#ifdef HAVE_CUDA
+#if HAVE_CUDA
     call cuda_col3_mask(a_d, b_d, c_d, size, mask_d, mask_size)
 #else
     call neko_error('No device backend configured')
@@ -167,7 +167,7 @@ contains
     integer :: size
     type(c_ptr) :: mask_d
     integer :: mask_size
-#ifdef HAVE_CUDA
+#if HAVE_CUDA
     call cuda_sub3_mask(a_d, b_d, c_d, size, mask_d, mask_size)
 #else
     call neko_error('No device backend configured')


### PR DESCRIPTION
Correct the application of the compile definition for CUDA in CMake and update preprocessor directives to ensure proper conditional compilation.