### PR TITLE
Improve CMake structure and build process for examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ endif()
 # Options
 
 option(BUILD_DOCS "Build documentation" OFF)
-option(BUILD_EXAMPLES "Build the examples" ON)
 option(BUILD_TESTING "Build the tests" OFF)
 
 # Advanced options
@@ -204,9 +203,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sources)
 # Build the examples
 # ============================================================================ #
 
-if (BUILD_EXAMPLES)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
 
 # ============================================================================ #
 # Build the tests
@@ -236,7 +233,6 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     message(STATUS "Current configuration:")
     message(STATUS "- CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
     message(STATUS "- BUILD_DOCS: ${BUILD_DOCS}")
-    message(STATUS "- BUILD_EXAMPLES: ${BUILD_EXAMPLES}")
     message(STATUS "- BUILD_TESTING: ${BUILD_TESTING}")
     message(STATUS "- ONLY_DOCS: ${ONLY_DOCS}")
     message(STATUS "- DEVICE_TYPE: ${DEVICE_TYPE}")

--- a/cmake/build_example.cmake
+++ b/cmake/build_example.cmake
@@ -80,12 +80,26 @@ function(build_example)
         message(STATUS "")
     endif()
 
+    # If the example contains extra sources, set the module directory.
+    if (DEFINED EXTRA_SOURCES)
+        set(CMAKE_Fortran_MODULE_DIRECTORY
+            ${CMAKE_Fortran_MODULE_DIRECTORY}/${EXAMPLE_NAME})
+        # Create the module directory.
+        file(MAKE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY})
+    endif()
+
     # ........................................................................ #
     # Construct example name from the folder structure relative to EXAMPLES_DIR.
     set(TARGET_DIRECTORY ${EXAMPLES_DIR}/${EXAMPLE_NAME})
     string(REPLACE "/" "_" EXAMPLE_NAME ${EXAMPLE_NAME})
+    string(CONCAT EXAMPLE_NAME "Examples-" ${EXAMPLE_NAME})
 
-    add_executable(${EXAMPLE_NAME} ${DRIVER} ${EXTRA_SOURCES})
+    add_executable(${EXAMPLE_NAME}
+        EXCLUDE_FROM_ALL
+        ${DRIVER}
+        ${EXTRA_SOURCES}
+        )
+    add_dependencies(Examples ${EXAMPLE_NAME})
 
     # Set the output directory of the executable.
     set_target_properties(${EXAMPLE_NAME}
@@ -109,7 +123,20 @@ function(build_example)
         target_link_libraries(${EXAMPLE_NAME} MPI::MPI_Fortran)
     endif()
 
+    # Import the neko-top static library
+    add_library(neko-top-a STATIC IMPORTED)
+    set_target_properties(neko-top-a PROPERTIES
+        IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/libneko-top.a"
+    )
+
+    add_dependencies(${EXAMPLE_NAME} neko-top)
+
     # Link our local Neko-TOP library to the driver
-    target_link_libraries(${EXAMPLE_NAME} neko-top)
+    target_link_libraries(${EXAMPLE_NAME} neko-top-a)
+    target_include_directories(${EXAMPLE_NAME}
+        PRIVATE
+            ${CMAKE_BINARY_DIR}/modules
+            ${CMAKE_Fortran_MODULE_DIRECTORY}
+    )
 
 endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,22 +15,21 @@
 # - "topopt"  : Topology optimization driver.
 
 # ============================================================================ #
-# Determine if we wish to build the examples.
-option(BUILD_EXAMPLES "Build the examples" ON)
-
-if(NOT BUILD_EXAMPLES)
-    return()
-else()
-    message(STATUS "Building examples")
-endif()
-
-# ============================================================================ #
 # Include the build_example function
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(build_example)
 
 # Set the examples directory
 set(EXAMPLES_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "Examples directory")
+
+# ============================================================================ #
+# Define our custom target.
+
+# Add a custom target for the examples
+add_custom_target(Examples
+    COMMENT "Build all the examples."
+    DEPENDS neko-top
+    )
 
 # ============================================================================ #
 # Add the example directories.

--- a/setup.sh
+++ b/setup.sh
@@ -124,6 +124,7 @@ CMAKE_VARIABLES+=("-DNEKO_DIR=$NEKO_DIR")
 printf "Compiling the example codes and Neko-TOP\n"
 cmake -B $MAIN_DIR/build -S $MAIN_DIR "${CMAKE_VARIABLES[@]}"
 cmake --build $MAIN_DIR/build --parallel
+cmake --build $MAIN_DIR/build --target Examples --parallel
 
 # ============================================================================ #
 # Print the status of the build

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -4,10 +4,19 @@
 # Set CMake Variables.
 
 # Setup the global inclusion for fortran
-set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/modules)
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/modules
+    CACHE PATH "Fortran module directory")
 include_directories(${CMAKE_Fortran_MODULE_DIRECTORY})
 
 add_library(neko-top STATIC)
+
+# Set the output directory of the library.
+set_target_properties(neko-top
+    PROPERTIES
+    OUTPUT_NAME "neko-top"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/include"
+)
 
 # Add the local neko extension library
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/neko_ext)
@@ -96,7 +105,7 @@ endif()
 # Specify installation instructions
 
 install(TARGETS neko-top
-    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/lib/
+    DESTINATION ${CMAKE_SOURCE_DIR}/lib/
 )
 install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}
     DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
- Neko-TOP static library is built by default
- The `Examples` target now builds the examples.
- The setup script is updated to account for this.

Time to run `./setup.sh` (With all external dependencies ready)

- Before: 41 sec
- After: 26 sec