### PR TITLE
Improved logging

### DIFF
--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -147,7 +147,7 @@ contains
     call problem%get_all_objective_values(all_objectives)
 
     ! Stamp the fist iteration
-    call mma_logger_assemble_data(log_data, 1, objective_value, &
+    call mma_logger_assemble_data(log_data, 0, objective_value, &
          all_objectives, constraint_value, 0.0_rp, 0.0_rp, scalingfactor, &
          problem%get_n_objectives(), problem%get_n_constraints())
     call this%logger%write(log_data)
@@ -156,7 +156,7 @@ contains
 
     associate(x => this%design%design_indicator%x)
 
-      do iter = 2, max_iter
+      do iter = 1, max_iter
          if (this%mma%get_residumax() .lt. tolerance) exit
 
          !Scaling

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -24,7 +24,7 @@ module mma_optimizer
   use neko_ext, only: reset
   use mask_ops, only: mask_exterior_const
 
-  use comm, only : pe_rank
+  use csv_file, only : csv_file_t
 
 
   implicit none
@@ -36,6 +36,7 @@ module mma_optimizer
 
      type(mma_t) :: mma
      type(topopt_design_t), pointer :: design
+     type(csv_file_t) :: logger
 
      !> Scaling constraint_value%x and constraint_sensitivities%x.
      !! Note that the values are not updated but they are scaled when passed
@@ -112,25 +113,21 @@ contains
     real(kind=rp) :: scalingfactor
 
     real(kind=rp) :: objective_value
+    type(vector_t) :: all_objectives
     type(vector_t) :: constraint_value
     type(vector_t) :: objective_sensitivities
     type(matrix_t) :: constraint_sensitivities
 
-    ! These would all be owned by the logger_t
-    ! ------------------------------------------------------------------------
-    !> format for writing real values in the log file
-    character(len=10) :: real_format
-    ! logging
-    character(len=1024) :: problem_log ! I assume 1024 is enough?
-    character(len=1024) :: optimization_log ! I assume 1024 is enough?
-    character(len=100) :: log_format
-    integer :: log_unit
+    character(len=1024) :: optimization_header
+    character(len=1024) :: problem_header
+    type(vector_t) :: log_data
     ! ------------------------------------------------------------------------
 
 
     ! call MPI_Comm_rank(neko_comm, rank, ierr)
     call MPI_Allreduce(this%mma%get_n(), nglobal, 1, &
          MPI_INTEGER, mpi_sum, neko_comm, ierr)
+
 
     !>initializing the scaling factor
     scalingfactor = 1.0_rp
@@ -143,46 +140,27 @@ contains
     call problem%get_constraint_values(constraint_value)
     call problem%get_objective_sensitivities(objective_sensitivities)
     call problem%get_constraint_sensitivities(constraint_sensitivities)
+    call problem%get_all_objective_values(all_objectives)
 
-    ! Should I write a logger_t such that this becomes a logger%init()
-    ! ------------------------------------------------------------------------
-    !Writing the optimization data in a separate file
-    log_unit = 1368
-    real_format = 'ES20.10'
-    open(log_unit, file = "optimization_data.txt", status = "replace")
-    log_format = '(I3, A, ", ", '//real_format//', ", ", '//real_format//&
-       ', ", ", '//real_format//')'
-    ! Write n, m, and tolerance in the first line of optimization_data.txt
-    ! do we really want this?
-    if (pe_rank .eq. 0) then
-       write(log_unit, '("n =", I10, ", m =", I10, ", tolerance =", ES25.17)') &
-            nglobal, this%mma%get_m(), tolerance
-    end if
 
-    ! Write the header for the remaining data
-    problem_log = problem%get_log_header()
-    optimization_log = 'iter, '//trim(problem_log)//&
+    ! Initialize the logger
+    call this%logger%init('optimization_data.txt')
+
+    ! Write the header
+    problem_header = problem%get_log_header()
+    optimization_header = 'iter, '//trim(problem_header)//&
        ', KKTmax, KKTnorm2, scalaing factor'
-    if (pe_rank .eq. 0) then
-       write(log_unit, '(A)') trim(optimization_log)
-    end if
-    ! ------------------------------------------------------------------------
+    call this%logger%set_header(trim(optimization_header))
+
+    ! Stamp the zeroth iteration
+    call mma_logger_assemble_data(log_data, 0, objective_value, &
+       all_objectives, constraint_value, 0.0_rp, 0.0_rp, scalingfactor, &
+       problem%get_n_objectives(), problem%get_n_constraints())
+    call this%logger%write(log_data)
+
+    call problem%write(0)
 
     associate(x => this%design%design_indicator%x)
-
-
-      ! Should I write a logger_t such that this becomes a logger%write()
-      ! ----------------------------------------------------------------------
-      ! Write the data row-by-row
-      problem_log = problem%get_log_state(real_format)
-      write(optimization_log, log_format) 0, trim(problem_log), &
-         this%mma%get_residumax(), this%mma%get_residunorm(), scalingfactor
-      if (pe_rank .eq. 0) then
-         write(1368, '(A)') trim(optimization_log)
-      end if
-      ! ----------------------------------------------------------------------
-
-      call problem%write(0)
 
       do iter = 1, max_iter
          if (this%mma%get_residumax() .lt. tolerance) exit
@@ -211,23 +189,18 @@ contains
          call problem%get_constraint_values(constraint_value)
          call problem%get_objective_sensitivities(objective_sensitivities)
          call problem%get_constraint_sensitivities(constraint_sensitivities)
+         call problem%get_all_objective_values(all_objectives)
 
          call this%mma%KKT(x, objective_sensitivities%x, &
               reshape([constraint_value%x], [this%mma%get_m()]), &
               constraint_sensitivities%x)
 
-         ! Write the data row-by-row
-         ! should I implement a logger_t, such that this is a logger%write()
-         ! -------------------------------------------------------------------
-         problem_log = problem%get_log_state(real_format)
-         write(optimization_log, log_format) iter, trim(problem_log), &
-            this%mma%get_residumax(), this%mma%get_residunorm(), scalingfactor
-         if (pe_rank .eq. 0) then
-            write(log_unit, '(A)') trim(optimization_log)
-            ! Flush the buffer to write the data during the run
-            flush(log_unit)
-         end if
-         ! -------------------------------------------------------------------
+         ! Stamp the zeroth iteration
+         call mma_logger_assemble_data(log_data, iter, objective_value, &
+            all_objectives, constraint_value, this%mma%get_residumax(), &
+            this%mma%get_residunorm(), scalingfactor, &
+            problem%get_n_objectives(), problem%get_n_constraints())
+         call this%logger%write(log_data)
 
          call problem%write(iter)
 
@@ -244,7 +217,6 @@ contains
     ! Final state after optimization
     print*, "MMA Optimization completed after", iter-1, "iterations."
 
-    close(log_unit)
     call constraint_value%free()
     call objective_sensitivities%free()
     call constraint_sensitivities%free()
@@ -259,5 +231,44 @@ contains
     call this%mma%free()
   end subroutine mma_optimizer_free
 
+  ! package up the log data
+  subroutine mma_logger_assemble_data(log_data, iter, objective_value, &
+     all_objectives, constraint_value, residumax, residunorm, scalingfactor, &
+     n, m)
+    type(vector_t), intent(out) :: log_data
+    integer, intent(in) :: iter
+    real(kind=rp), intent(in) ::objective_value
+    type(vector_t), intent(in) :: all_objectives
+    type(vector_t), intent(in) :: constraint_value
+    real(kind=rp), intent(in) :: residumax, residunorm, scalingfactor
+    integer, intent(in) :: n, m
+    integer :: i_tmp1, i_tmp2
+
+    ! initialize the logger data
+    ! iter | tot F | F_1 | .. |F_n | C_1 | ... | C_n | KKT | KKT2 | scale |
+    call log_data%init(5 + n + m)
+
+    ! iteration
+    log_data%x(1) = real(iter, kind=rp)
+
+    ! total objective
+    log_data%x(2) = objective_value
+
+    ! individual objectives
+    i_tmp1 = 3
+    i_tmp2 = i_tmp1 + n - 1
+    log_data%x(i_tmp1 : i_tmp2) = all_objectives%x
+
+    ! constraints
+    i_tmp1 = i_tmp2 + 1
+    i_tmp2 = i_tmp1 + m - 1
+    log_data%x(i_tmp1 : i_tmp2) = constraint_value%x
+
+    ! convergence stuff
+    log_data%x(i_tmp2 + 1) = residumax
+    log_data%x(i_tmp2 + 2) = residunorm
+    log_data%x(i_tmp2 + 3) = scalingfactor
+
+  end subroutine mma_logger_assemble_data
 end module mma_optimizer
 

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -24,6 +24,8 @@ module mma_optimizer
   use neko_ext, only: reset
   use mask_ops, only: mask_exterior_const
 
+  use comm, only : pe_rank
+
 
   implicit none
   private
@@ -114,6 +116,18 @@ contains
     type(vector_t) :: objective_sensitivities
     type(matrix_t) :: constraint_sensitivities
 
+    ! These would all be owned by the logger_t
+    ! ------------------------------------------------------------------------
+    !> format for writing real values in the log file
+    character(len=10) :: real_format 
+    ! logging
+    character(len=1024) :: problem_log ! I assume 1024 is enough?
+    character(len=1024) :: optimization_log ! I assume 1024 is enough?
+    character(len=100) :: log_format 
+    integer :: log_unit
+    ! ------------------------------------------------------------------------
+
+
     ! call MPI_Comm_rank(neko_comm, rank, ierr)
     call MPI_Allreduce(this%mma%get_n(), nglobal, 1, &
          MPI_INTEGER, mpi_sum, neko_comm, ierr)
@@ -130,24 +144,43 @@ contains
     call problem%get_objective_sensitivities(objective_sensitivities)
     call problem%get_constraint_sensitivities(constraint_sensitivities)
 
+    ! Should I write a logger_t such that this becomes a logger%init()
+    ! ------------------------------------------------------------------------
     !Writing the optimization data in a separate file
-    open(1368, file = "optimization_data.txt", status = "replace")
+    log_unit = 1368
+    real_format = 'ES25.17' 
+    open(log_unit, file = "optimization_data.txt", status = "replace")
+    log_format = '(I3, A, ", ", '//real_format//', ", ", '//real_format//&
+       ', ", ", '//real_format//')'
+    ! Write n, m, and tolerance in the first line of optimization_data.txt
+    ! do we really want this?
+    if (pe_rank .eq. 0) then
+       write(log_unit, '("n =", I10, ", m =", I10, ", tolerance =", ES25.17)') &
+            nglobal, this%mma%get_m(), tolerance
+    end if
+
+    ! Write the header for the remaining data
+    problem_log = problem%get_log_header()
+    optimization_log = 'iter, '//trim(problem_log)//&
+       ', KKTmax, KKTnorm2, scalaing factor'
+    if (pe_rank .eq. 0) then
+       write(log_unit, '(A)') trim(optimization_log)
+    end if
+    ! ------------------------------------------------------------------------
 
     associate(x => this%design%design_indicator%x)
 
-      ! Write n, m, and tolerance in the first line of optimization_data.txt
-      write(1368, '("n =", I10, ", m =", I10, ", tolerance =", ES25.17)') &
-           nglobal, this%mma%get_m(), tolerance
 
-      ! Write the header for the remaining data
-      write(1368, '(A)') "iter, objective_value, constraint_value, KKTmax, &
-           &KKTnorm2, scalingfactor"
-
+      ! Should I write a logger_t such that this becomes a logger%write()
+      ! ----------------------------------------------------------------------
       ! Write the data row-by-row
-      write(1368, '(I3, ",", ES25.17, ",", ES25.17, ",", ES25.17, ",", &
-           & ES25.17, ",", ES25.17)') &
-           0, objective_value, constraint_value%x, &
-           this%mma%get_residumax(), this%mma%get_residunorm(), scalingfactor
+      problem_log = problem%get_log_state(real_format)
+      write(optimization_log, log_format) 0, trim(problem_log), &
+         this%mma%get_residumax(), this%mma%get_residunorm(), scalingfactor
+      if (pe_rank .eq. 0) then
+         write(1368, '(A)') trim(optimization_log)
+      end if
+      ! ----------------------------------------------------------------------
 
       call problem%write(0)
 
@@ -183,12 +216,18 @@ contains
               reshape([constraint_value%x], [this%mma%get_m()]), &
               constraint_sensitivities%x)
 
-         write(1368, '(I3, ",", ES25.17, ",", ES25.17, ",", ES25.17, ",", &
-              & ES25.17, ",", ES25.17)') iter, objective_value, constraint_value%x, &
-              this%mma%get_residumax(), this%mma%get_residunorm(), scalingfactor
-
+         ! Write the data row-by-row
+         ! should I implement a logger_t, such that this is a logger%write()
+         ! -------------------------------------------------------------------
+         problem_log = problem%get_log_state(real_format)
+         write(optimization_log, log_format) iter, trim(problem_log), &
+            this%mma%get_residumax(), this%mma%get_residunorm(), scalingfactor
+         if (pe_rank .eq. 0) then
+            write(log_unit, '(A)') trim(optimization_log)
+         end if
          ! Flush the buffer to write the data during the run
-         flush(1368)
+         flush(log_unit)
+         ! -------------------------------------------------------------------
 
          call problem%write(iter)
 
@@ -202,13 +241,10 @@ contains
       end do
     end associate
 
-
-    close(1368)
-
     ! Final state after optimization
     print*, "MMA Optimization completed after", iter-1, "iterations."
 
-
+    close(log_unit)
     call constraint_value%free()
     call objective_sensitivities%free()
     call constraint_sensitivities%free()

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -144,13 +144,13 @@ contains
     ! Write the header
     problem_header = problem%get_log_header()
     optimization_header = 'iter, '//trim(problem_header)//&
-       ', KKTmax, KKTnorm2, scalaing factor'
+         ', KKTmax, KKTnorm2, scalaing factor'
     call this%logger%set_header(trim(optimization_header))
 
     ! Stamp the zeroth iteration
     call mma_logger_assemble_data(log_data, 0, objective_value, &
-       all_objectives, constraint_value, 0.0_rp, 0.0_rp, scalingfactor, &
-       problem%get_n_objectives(), problem%get_n_constraints())
+         all_objectives, constraint_value, 0.0_rp, 0.0_rp, scalingfactor, &
+         problem%get_n_objectives(), problem%get_n_constraints())
     call this%logger%write(log_data)
 
     call problem%write(0)
@@ -192,9 +192,9 @@ contains
 
          ! Stamp the i^th iteration
          call mma_logger_assemble_data(log_data, iter, objective_value, &
-            all_objectives, constraint_value, this%mma%get_residumax(), &
-            this%mma%get_residunorm(), scalingfactor, &
-            problem%get_n_objectives(), problem%get_n_constraints())
+              all_objectives, constraint_value, this%mma%get_residumax(), &
+              this%mma%get_residunorm(), scalingfactor, &
+              problem%get_n_objectives(), problem%get_n_constraints())
          call this%logger%write(log_data)
 
          call problem%write(iter)
@@ -228,8 +228,8 @@ contains
 
   ! package up the log data
   subroutine mma_logger_assemble_data(log_data, iter, objective_value, &
-     all_objectives, constraint_value, residumax, residunorm, scalingfactor, &
-     n, m)
+       all_objectives, constraint_value, residumax, residunorm, scalingfactor, &
+       n, m)
     type(vector_t), intent(out) :: log_data
     integer, intent(in) :: iter
     real(kind=rp), intent(in) ::objective_value

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -23,7 +23,6 @@ module mma_optimizer
   use field_math, only: field_rzero
   use neko_ext, only: reset
   use mask_ops, only: mask_exterior_const
-
   use csv_file, only : csv_file_t
 
 
@@ -121,13 +120,10 @@ contains
     character(len=1024) :: optimization_header
     character(len=1024) :: problem_header
     type(vector_t) :: log_data
-    ! ------------------------------------------------------------------------
-
 
     ! call MPI_Comm_rank(neko_comm, rank, ierr)
     call MPI_Allreduce(this%mma%get_n(), nglobal, 1, &
          MPI_INTEGER, mpi_sum, neko_comm, ierr)
-
 
     !>initializing the scaling factor
     scalingfactor = 1.0_rp
@@ -141,7 +137,6 @@ contains
     call problem%get_objective_sensitivities(objective_sensitivities)
     call problem%get_constraint_sensitivities(constraint_sensitivities)
     call problem%get_all_objective_values(all_objectives)
-
 
     ! Initialize the logger
     call this%logger%init('optimization_data.txt')
@@ -195,7 +190,7 @@ contains
               reshape([constraint_value%x], [this%mma%get_m()]), &
               constraint_sensitivities%x)
 
-         ! Stamp the zeroth iteration
+         ! Stamp the i^th iteration
          call mma_logger_assemble_data(log_data, iter, objective_value, &
             all_objectives, constraint_value, this%mma%get_residumax(), &
             this%mma%get_residunorm(), scalingfactor, &

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -146,13 +146,13 @@ contains
     call problem%get_constraint_sensitivities(constraint_sensitivities)
     call problem%get_all_objective_values(all_objectives)
 
-    ! Stamp the fist iteration
+    ! Stamp the initial condition
     call mma_logger_assemble_data(log_data, 0, objective_value, &
          all_objectives, constraint_value, 0.0_rp, 0.0_rp, scalingfactor, &
          problem%get_n_objectives(), problem%get_n_constraints())
     call this%logger%write(log_data)
 
-    call problem%write(1)
+    call problem%write(0)
 
     associate(x => this%design%design_indicator%x)
 

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -148,7 +148,7 @@ contains
     ! ------------------------------------------------------------------------
     !Writing the optimization data in a separate file
     log_unit = 1368
-    real_format = 'ES10.05'
+    real_format = 'ES20.10'
     open(log_unit, file = "optimization_data.txt", status = "replace")
     log_format = '(I3, A, ", ", '//real_format//', ", ", '//real_format//&
        ', ", ", '//real_format//')'

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -65,7 +65,7 @@ contains
     this%design => design
 
     ! Initialize the logger
-    call this%logger%init('optimization_data.txt')
+    call this%logger%init('optimization_data.csv')
 
     ! Write the header
     problem_header = problem%get_log_header()

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -119,11 +119,11 @@ contains
     ! These would all be owned by the logger_t
     ! ------------------------------------------------------------------------
     !> format for writing real values in the log file
-    character(len=10) :: real_format 
+    character(len=10) :: real_format
     ! logging
     character(len=1024) :: problem_log ! I assume 1024 is enough?
     character(len=1024) :: optimization_log ! I assume 1024 is enough?
-    character(len=100) :: log_format 
+    character(len=100) :: log_format
     integer :: log_unit
     ! ------------------------------------------------------------------------
 
@@ -148,7 +148,7 @@ contains
     ! ------------------------------------------------------------------------
     !Writing the optimization data in a separate file
     log_unit = 1368
-    real_format = 'ES25.17' 
+    real_format = 'ES10.05'
     open(log_unit, file = "optimization_data.txt", status = "replace")
     log_format = '(I3, A, ", ", '//real_format//', ", ", '//real_format//&
        ', ", ", '//real_format//')'
@@ -224,9 +224,9 @@ contains
             this%mma%get_residumax(), this%mma%get_residunorm(), scalingfactor
          if (pe_rank .eq. 0) then
             write(log_unit, '(A)') trim(optimization_log)
+            ! Flush the buffer to write the data during the run
+            flush(log_unit)
          end if
-         ! Flush the buffer to write the data during the run
-         flush(log_unit)
          ! -------------------------------------------------------------------
 
          call problem%write(iter)

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -23,7 +23,6 @@ module mma_optimizer
   use field_math, only: field_rzero
   use neko_ext, only: reset
   use mask_ops, only: mask_exterior_const
-  use csv_file, only : csv_file_t
 
 
   implicit none
@@ -35,7 +34,6 @@ module mma_optimizer
 
      type(mma_t) :: mma
      type(topopt_design_t), pointer :: design
-     type(csv_file_t) :: logger
 
      !> Scaling constraint_value%x and constraint_sensitivities%x.
      !! Note that the values are not updated but they are scaled when passed
@@ -61,8 +59,20 @@ contains
     class(mma_optimizer_t), intent(inout) :: this
     class(problem_t), intent(inout) :: problem
     type(topopt_design_t), target, intent(in) :: design
+    character(len=1024) :: optimization_header
+    character(len=1024) :: problem_header
 
     this%design => design
+
+    ! Initialize the logger
+    call this%logger%init('optimization_data.txt')
+
+    ! Write the header
+    problem_header = problem%get_log_header()
+    optimization_header = 'iter, '//trim(problem_header)//&
+         ', KKTmax, KKTnorm2, scalaing factor'
+    call this%logger%set_header(trim(optimization_header))
+
 
     ! Initialize MMA solver
     ! Check the type of the problem using select type
@@ -117,8 +127,6 @@ contains
     type(vector_t) :: objective_sensitivities
     type(matrix_t) :: constraint_sensitivities
 
-    character(len=1024) :: optimization_header
-    character(len=1024) :: problem_header
     type(vector_t) :: log_data
 
     ! call MPI_Comm_rank(neko_comm, rank, ierr)
@@ -138,26 +146,17 @@ contains
     call problem%get_constraint_sensitivities(constraint_sensitivities)
     call problem%get_all_objective_values(all_objectives)
 
-    ! Initialize the logger
-    call this%logger%init('optimization_data.txt')
-
-    ! Write the header
-    problem_header = problem%get_log_header()
-    optimization_header = 'iter, '//trim(problem_header)//&
-         ', KKTmax, KKTnorm2, scalaing factor'
-    call this%logger%set_header(trim(optimization_header))
-
-    ! Stamp the zeroth iteration
-    call mma_logger_assemble_data(log_data, 0, objective_value, &
+    ! Stamp the fist iteration
+    call mma_logger_assemble_data(log_data, 1, objective_value, &
          all_objectives, constraint_value, 0.0_rp, 0.0_rp, scalingfactor, &
          problem%get_n_objectives(), problem%get_n_constraints())
     call this%logger%write(log_data)
 
-    call problem%write(0)
+    call problem%write(1)
 
     associate(x => this%design%design_indicator%x)
 
-      do iter = 1, max_iter
+      do iter = 2, max_iter
          if (this%mma%get_residumax() .lt. tolerance) exit
 
          !Scaling

--- a/sources/optimizer/optimizer.f90
+++ b/sources/optimizer/optimizer.f90
@@ -8,11 +8,14 @@ module optimizer
   use problem, only: problem_t
   use topopt_design, only: topopt_design_t
   use num_types, only : rp
+  use csv_file, only : csv_file_t
   implicit none
   private
 
   !> Abstract optimizer class.
   type, abstract, public :: optimizer_t
+     !> A file writer to document the convergence history
+     type(csv_file_t) :: logger
 
    contains
      !> Initialize the optimizer, associate it with a specific problem

--- a/sources/problems/base_functional.f90
+++ b/sources/problems/base_functional.f90
@@ -57,7 +57,8 @@ module base_functional
      real(kind=rp) :: value
      !> Sensitivity field
      type(vector_t) :: sensitivity
-
+     !> Name of constraint/objective in the logfile
+     character(len=25) :: log_name
      !> containing a mask
      logical :: has_mask
      !> A mask for where the objective function is evaluated

--- a/sources/problems/base_functional.f90
+++ b/sources/problems/base_functional.f90
@@ -58,7 +58,7 @@ module base_functional
      !> Sensitivity field
      type(vector_t) :: sensitivity
      !> Name of constraint/objective in the logfile
-     character(len=25) :: log_name
+     character(len=25) :: name
      !> containing a mask
      logical :: has_mask
      !> A mask for where the objective function is evaluated

--- a/sources/problems/constraints/volume_constraint.f90
+++ b/sources/problems/constraints/volume_constraint.f90
@@ -264,10 +264,10 @@ contains
 
     volume = 0.0_rp
     select type (design)
-      type is (topopt_design_t)
+    type is (topopt_design_t)
        volume = volume_topopt_design(this, design)
 
-      class default
+    class default
        call neko_error('Volume constraint only works with topopt_design')
     end select
 

--- a/sources/problems/constraints/volume_constraint.f90
+++ b/sources/problems/constraints/volume_constraint.f90
@@ -132,7 +132,7 @@ contains
     call json_get(json, "limit", limit)
 
     call this%init_from_attributes(design, simulation, name, mask_name, &
-       is_max, limit)
+         is_max, limit)
   end subroutine volume_constraint_init_json
 
   !> The direct initializer from attributes.

--- a/sources/problems/constraints/volume_constraint.f90
+++ b/sources/problems/constraints/volume_constraint.f90
@@ -122,14 +122,17 @@ contains
     type(simulation_t), target, intent(inout) :: simulation
 
     character(len=:), allocatable :: mask_name
+    character(len=:), allocatable :: log_name
     logical :: is_max
     real(kind=rp) :: limit
 
     call json_get_or_default(json, "mask_name", mask_name, "")
+    call json_get_or_default(json, "log_name", log_name, "Volume constraint")
     call json_get_or_default(json, "is_max", is_max, .false.)
     call json_get(json, "limit", limit)
 
-    call this%init_from_attributes(design, simulation, mask_name, is_max, limit)
+    call this%init_from_attributes(design, simulation, log_name, mask_name, &
+       is_max, limit)
   end subroutine volume_constraint_init_json
 
   !> The direct initializer from attributes.
@@ -139,11 +142,12 @@ contains
   !! @param is_max whether it is a maximum volume constraint.
   !! @param limit The volume limit value.
   subroutine volume_constraint_init_attributes(this, design, simulation, &
-       mask_name, is_max, limit)
+       log_name, mask_name, is_max, limit)
     class(volume_constraint_t), intent(inout) :: this
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
     character(len=*), intent(in) :: mask_name
+    character(len=*), intent(in) :: log_name
     logical, intent(in) :: is_max
     real(kind=rp), intent(in) :: limit
 
@@ -153,6 +157,9 @@ contains
 
     ! Initialize the base class
     call this%init_base(design%size(), mask_name)
+
+    ! Assign the name to constraint
+    this%log_name = log_name 
 
     ! Store the attributes
     this%is_max = is_max

--- a/sources/problems/constraints/volume_constraint.f90
+++ b/sources/problems/constraints/volume_constraint.f90
@@ -159,7 +159,7 @@ contains
     call this%init_base(design%size(), mask_name)
 
     ! Assign the name to constraint
-    this%log_name = log_name 
+    this%log_name = log_name
 
     ! Store the attributes
     this%is_max = is_max

--- a/sources/problems/constraints/volume_constraint.f90
+++ b/sources/problems/constraints/volume_constraint.f90
@@ -122,16 +122,16 @@ contains
     type(simulation_t), target, intent(inout) :: simulation
 
     character(len=:), allocatable :: mask_name
-    character(len=:), allocatable :: log_name
+    character(len=:), allocatable :: name
     logical :: is_max
     real(kind=rp) :: limit
 
     call json_get_or_default(json, "mask_name", mask_name, "")
-    call json_get_or_default(json, "log_name", log_name, "Volume constraint")
+    call json_get_or_default(json, "name", name, "Volume constraint")
     call json_get_or_default(json, "is_max", is_max, .false.)
     call json_get(json, "limit", limit)
 
-    call this%init_from_attributes(design, simulation, log_name, mask_name, &
+    call this%init_from_attributes(design, simulation, name, mask_name, &
        is_max, limit)
   end subroutine volume_constraint_init_json
 
@@ -142,12 +142,12 @@ contains
   !! @param is_max whether it is a maximum volume constraint.
   !! @param limit The volume limit value.
   subroutine volume_constraint_init_attributes(this, design, simulation, &
-       log_name, mask_name, is_max, limit)
+       name, mask_name, is_max, limit)
     class(volume_constraint_t), intent(inout) :: this
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
     character(len=*), intent(in) :: mask_name
-    character(len=*), intent(in) :: log_name
+    character(len=*), intent(in) :: name
     logical, intent(in) :: is_max
     real(kind=rp), intent(in) :: limit
 
@@ -159,7 +159,7 @@ contains
     call this%init_base(design%size(), mask_name)
 
     ! Assign the name to constraint
-    this%log_name = log_name
+    this%name = name
 
     ! Store the attributes
     this%is_max = is_max

--- a/sources/problems/objective.f90
+++ b/sources/problems/objective.f90
@@ -89,18 +89,14 @@ contains
   !! @param design_size The number of design variables.
   !! @param weight The weight of the objective function.
   !! @param[optional] mask_name The name design the mask.
-  subroutine objective_init_base(this, design_size, weight, log_name, &
-     mask_name)
+  subroutine objective_init_base(this, design_size, weight, mask_name)
     class(objective_t), intent(inout) :: this
     integer, intent(in) :: design_size
     real(kind=rp), intent(in) :: weight
-    character(len=*), intent(in) :: log_name
     character(len=*), intent(in), optional :: mask_name
 
     this%value = 0.0_rp
     call this%sensitivity%init(design_size)
-
-    this%log_name = log_name
 
     this%weight = weight
 

--- a/sources/problems/objective.f90
+++ b/sources/problems/objective.f90
@@ -89,14 +89,18 @@ contains
   !! @param design_size The number of design variables.
   !! @param weight The weight of the objective function.
   !! @param[optional] mask_name The name design the mask.
-  subroutine objective_init_base(this, design_size, weight, mask_name)
+  subroutine objective_init_base(this, design_size, weight, log_name, &
+     mask_name)
     class(objective_t), intent(inout) :: this
     integer, intent(in) :: design_size
     real(kind=rp), intent(in) :: weight
+    character(len=*), intent(in) :: log_name
     character(len=*), intent(in), optional :: mask_name
 
     this%value = 0.0_rp
     call this%sensitivity%init(design_size)
+
+    this%log_name = log_name
 
     this%weight = weight
 

--- a/sources/problems/objectives/lube_term_objective.f90
+++ b/sources/problems/objectives/lube_term_objective.f90
@@ -172,10 +172,10 @@ contains
 
     ! Grab the brinkman amplitude for the lube term
     select type (design)
-      type is (topopt_design_t)
+    type is (topopt_design_t)
        this%brinkman_amplitude => design%brinkman_amplitude
 
-      class default
+    class default
        call neko_error('Minimum dissipation only works with topopt_design')
     end select
 

--- a/sources/problems/objectives/lube_term_objective.f90
+++ b/sources/problems/objectives/lube_term_objective.f90
@@ -132,16 +132,15 @@ contains
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
     character(len=:), allocatable :: mask_name
-    character(len=:), allocatable :: log_name
+    character(len=:), allocatable :: name
     real(kind=rp) :: weight, K
 
     call json_get_or_default(json, "weight", weight, 1.0_rp)
     call json_get_or_default(json, "mask_name", mask_name, "")
-    call json_get_or_default(json, "log_name", log_name, &
-         "out of plane stresses")
+    call json_get_or_default(json, "name", name, "Out of plane stresses")
     call json_get_or_default(json, "K", K, 1.0_rp)
 
-    call this%init_from_attributes(design, simulation, weight, log_name, &
+    call this%init_from_attributes(design, simulation, weight, name, &
          mask_name, K)
   end subroutine lube_term_init_json
 
@@ -152,13 +151,13 @@ contains
   !! @param mask_name the name of the mask.
   !! @param K the coefficient for the lube term.
   subroutine lube_term_init_attributes(this, design, simulation, weight, &
-       log_name, mask_name, K)
+       name, mask_name, K)
     class(lube_term_objective_t), intent(inout) :: this
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
     real(kind=rp), intent(in) :: weight
     character(len=*), intent(in) :: mask_name
-    character(len=*), intent(in) :: log_name
+    character(len=*), intent(in) :: name
     real(kind=rp), intent(in) :: K
     type(adjoint_lube_source_term_t) :: lube_term
 
@@ -166,7 +165,7 @@ contains
     call this%init_base(design%size(), weight, mask_name)
 
     ! Assign the name to objective
-    this%log_name = log_name
+    this%name = name
 
     ! Set the coefficient for the lube term
     this%K = K

--- a/sources/problems/objectives/lube_term_objective.f90
+++ b/sources/problems/objectives/lube_term_objective.f90
@@ -166,7 +166,7 @@ contains
     call this%init_base(design%size(), weight, mask_name)
 
     ! Assign the name to objective
-    this%log_name = "out of plane stresses"
+    this%log_name = log_name 
 
     ! Set the coefficient for the lube term
     this%K = K

--- a/sources/problems/objectives/lube_term_objective.f90
+++ b/sources/problems/objectives/lube_term_objective.f90
@@ -138,11 +138,11 @@ contains
     call json_get_or_default(json, "weight", weight, 1.0_rp)
     call json_get_or_default(json, "mask_name", mask_name, "")
     call json_get_or_default(json, "log_name", log_name, &
-       "out of plane stresses")
+         "out of plane stresses")
     call json_get_or_default(json, "K", K, 1.0_rp)
 
     call this%init_from_attributes(design, simulation, weight, log_name, &
-       mask_name, K)
+         mask_name, K)
   end subroutine lube_term_init_json
 
   !> The actual constructor.
@@ -166,7 +166,7 @@ contains
     call this%init_base(design%size(), weight, mask_name)
 
     ! Assign the name to objective
-    this%log_name = log_name 
+    this%log_name = log_name
 
     ! Set the coefficient for the lube term
     this%K = K

--- a/sources/problems/objectives/lube_term_objective.f90
+++ b/sources/problems/objectives/lube_term_objective.f90
@@ -132,13 +132,17 @@ contains
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
     character(len=:), allocatable :: mask_name
+    character(len=:), allocatable :: log_name
     real(kind=rp) :: weight, K
 
     call json_get_or_default(json, "weight", weight, 1.0_rp)
     call json_get_or_default(json, "mask_name", mask_name, "")
+    call json_get_or_default(json, "log_name", log_name, &
+       "out of plane stresses")
     call json_get_or_default(json, "K", K, 1.0_rp)
 
-    call this%init_from_attributes(design, simulation, weight, mask_name, K)
+    call this%init_from_attributes(design, simulation, weight, log_name, &
+       mask_name, K)
   end subroutine lube_term_init_json
 
   !> The actual constructor.
@@ -148,17 +152,21 @@ contains
   !! @param mask_name the name of the mask.
   !! @param K the coefficient for the lube term.
   subroutine lube_term_init_attributes(this, design, simulation, weight, &
-       mask_name, K)
+       log_name, mask_name, K)
     class(lube_term_objective_t), intent(inout) :: this
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
     real(kind=rp), intent(in) :: weight
     character(len=*), intent(in) :: mask_name
+    character(len=*), intent(in) :: log_name
     real(kind=rp), intent(in) :: K
     type(adjoint_lube_source_term_t) :: lube_term
 
     ! Call the base initializer
     call this%init_base(design%size(), weight, mask_name)
+
+    ! Assign the name to objective
+    this%log_name = "out of plane stresses"
 
     ! Set the coefficient for the lube term
     this%K = K

--- a/sources/problems/objectives/minimum_dissipation_objective.f90
+++ b/sources/problems/objectives/minimum_dissipation_objective.f90
@@ -124,13 +124,16 @@ contains
     type(json_file), intent(inout) :: json
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
+    character(len=:), allocatable :: log_name
     character(len=:), allocatable :: mask_name
     real(kind=rp) :: weight
 
     call json_get_or_default(json, "weight", weight, 1.0_rp)
     call json_get_or_default(json, "mask_name", mask_name, "")
+    call json_get_or_default(json, "log_name", log_name, "Dissipation")
 
-    call this%init_from_attributes(design, simulation, weight, mask_name)
+    call this%init_from_attributes(design, simulation, weight, log_name, &
+       mask_name)
   end subroutine minimum_dissipation_init_json
 
 !> The actual constructor.
@@ -139,16 +142,20 @@ contains
 !! @param weight the weight of the objective function.
 !! @param mask_name the name of the mask.
   subroutine minimum_dissipation_init_attributes(this, design, simulation, &
-       weight, mask_name)
+       weight, log_name, mask_name)
     class(minimum_dissipation_objective_t), intent(inout) :: this
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
     real(kind=rp), intent(in) :: weight
+    character(len=*), intent(in) :: log_name
     character(len=*), intent(in) :: mask_name
 
     type(adjoint_minimum_dissipation_source_term_t) :: adjoint_forcing
 
     call this%init_base(design%size(), weight, mask_name)
+
+    ! Assign the name to objective
+    this%log_name = log_name
 
     ! Save the simulation and design
     this%fluid => simulation%fluid_scheme

--- a/sources/problems/objectives/minimum_dissipation_objective.f90
+++ b/sources/problems/objectives/minimum_dissipation_objective.f90
@@ -124,16 +124,15 @@ contains
     type(json_file), intent(inout) :: json
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
-    character(len=:), allocatable :: log_name
+    character(len=:), allocatable :: name
     character(len=:), allocatable :: mask_name
     real(kind=rp) :: weight
 
     call json_get_or_default(json, "weight", weight, 1.0_rp)
     call json_get_or_default(json, "mask_name", mask_name, "")
-    call json_get_or_default(json, "log_name", log_name, "Dissipation")
+    call json_get_or_default(json, "name", name, "Dissipation")
 
-    call this%init_from_attributes(design, simulation, weight, log_name, &
-         mask_name)
+    call this%init_from_attributes(design, simulation, weight, name, mask_name)
   end subroutine minimum_dissipation_init_json
 
 !> The actual constructor.
@@ -142,12 +141,12 @@ contains
 !! @param weight the weight of the objective function.
 !! @param mask_name the name of the mask.
   subroutine minimum_dissipation_init_attributes(this, design, simulation, &
-       weight, log_name, mask_name)
+       weight, name, mask_name)
     class(minimum_dissipation_objective_t), intent(inout) :: this
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
     real(kind=rp), intent(in) :: weight
-    character(len=*), intent(in) :: log_name
+    character(len=*), intent(in) :: name
     character(len=*), intent(in) :: mask_name
 
     type(adjoint_minimum_dissipation_source_term_t) :: adjoint_forcing
@@ -155,7 +154,7 @@ contains
     call this%init_base(design%size(), weight, mask_name)
 
     ! Assign the name to objective
-    this%log_name = log_name
+    this%name = name
 
     ! Save the simulation and design
     this%fluid => simulation%fluid_scheme

--- a/sources/problems/objectives/minimum_dissipation_objective.f90
+++ b/sources/problems/objectives/minimum_dissipation_objective.f90
@@ -133,7 +133,7 @@ contains
     call json_get_or_default(json, "log_name", log_name, "Dissipation")
 
     call this%init_from_attributes(design, simulation, weight, log_name, &
-       mask_name)
+         mask_name)
   end subroutine minimum_dissipation_init_json
 
 !> The actual constructor.

--- a/sources/problems/problem.f90
+++ b/sources/problems/problem.f90
@@ -68,6 +68,7 @@ module problem
      integer :: n_objectives
      !> Number of constraints in the problem.
      integer :: n_constraints
+     !> Format for output log
 
      !> The objective of the problem.
      class(objective_wrapper_t), allocatable, dimension(:) :: objective_list
@@ -164,6 +165,11 @@ module problem
      procedure, pass(this) :: get_n_objectives => problem_get_num_objectives
      !> Return the number of constraints.
      procedure, pass(this) :: get_n_constraints => problem_get_num_constraints
+
+     !> Return the logfile header
+     procedure, pass(this) :: get_log_header => problem_get_log_header
+     !> Return the current logfile state
+     procedure, pass(this) :: get_log_state => problem_get_log_state
 
   end type problem_t
 
@@ -595,4 +601,77 @@ contains
     n = this%n_constraints
   end function problem_get_num_constraints
 
+  !> Return the header for the problem.
+  function problem_get_log_header(this) result(buff)
+    class(problem_t), intent(in) :: this
+    character(len=1024) :: buff
+    character(len=50) :: mini_buff 
+    integer :: i
+
+    ! When it comes to multi-objective optimization
+    ! (handled in the way that we do) we want to know the value of each
+    ! objective individually, not just the combined effect.
+    !
+    ! my vision is:
+    !
+    !      | Total F | F_1 | F_2 | ... | F_n | C_1 | C_2 | ... | C_m |
+    !
+    ! And then if we also want things like thie iteration or KKT they can be 
+    ! appended to the begining or end of this by the optimizer.
+    !
+    ! iter | Total F | F_1 | F_2 | ... | F_n | C_1 | C_2 | ... | C_m | KKT
+    buff = "Total objective function"
+    do i = 1, this%get_n_objectives()
+       mini_buff = ""
+       write(mini_buff, '(", ", A)') this%objective_list(i)%objective%log_name
+       buff = trim(buff)//trim(mini_buff)
+    end do
+
+    do i = 1, this%get_n_constraints()
+       mini_buff = ""
+       write(mini_buff, '(", ", A)') &
+          this%constraint_list(i)%constraint%log_name
+       buff = trim(buff)//trim(mini_buff)
+    end do
+
+  end function problem_get_log_header
+
+  !> Return the log for the current iteration.
+  function problem_get_log_state(this, real_format) result(buff)
+    class(problem_t), intent(in) :: this
+    character(len=*), intent(in) :: real_format
+    character(len=1024) :: buff
+    character(len=50) :: mini_buff 
+    character(len=30) :: formatting 
+    real(kind=rp) :: tmp_real
+    real(kind=rp), allocatable :: tmp_reals
+    integer :: i
+
+    formatting = '(", ",'//trim(real_format)//')' 
+
+    buff = ""
+    mini_buff = ""
+    tmp_real = 0.0_rp
+    do i = 1, this%n_objectives
+       tmp_real = tmp_real + &
+            this%objective_list(i)%objective%weight * &
+            this%objective_list(i)%objective%value
+    end do
+
+    write(mini_buff, formatting) tmp_real 
+    buff = trim(buff)//trim(mini_buff)
+
+    do i = 1, this%get_n_objectives()
+       mini_buff = ""
+       write(mini_buff, formatting) this%objective_list(i)%objective%value
+       buff = trim(buff)//trim(mini_buff)
+    end do
+
+    do i = 1, this%get_n_constraints()
+       mini_buff = ""
+       write(mini_buff, formatting) this%constraint_list(i)%constraint%value
+       buff = trim(buff)//trim(mini_buff)
+    end do
+    
+  end function problem_get_log_state
 end module problem

--- a/sources/problems/problem.f90
+++ b/sources/problems/problem.f90
@@ -148,6 +148,9 @@ module problem
      !> Return the objective.
      procedure, pass(this), public :: get_objective_value => &
           problem_get_objective_value
+     !> Return all components of the objective.
+     procedure, pass(this), public :: get_all_objective_values => &
+          problem_get_all_objective_values
      !> Return the constraints.
      procedure, pass(this), public :: get_constraint_values => &
           problem_get_constraint_values
@@ -506,6 +509,29 @@ contains
 
   end subroutine problem_get_objective_value
 
+  !> Construct and get the objective.
+  !!
+  !! This function returns all the indivual objectives comprising the
+  !! objective function
+  !! @param[out] all_objective_values A vector containing all objectives
+  subroutine problem_get_all_objective_values(this, all_objective_values)
+    class(problem_t), intent(inout) :: this
+    type(vector_t), intent(out) :: all_objective_values
+    integer :: i
+
+    call all_objective_values%init(this%n_objectives)
+
+    do i = 1, this%n_objectives
+       all_objective_values%x(i) = this%objective_list(i)%objective%value
+    end do
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_memcpy(all_objective_values%x, all_objective_values%x_d, &
+            this%n_objectives, HOST_TO_DEVICE, sync = .true.)
+    end if
+
+  end subroutine problem_get_all_objective_values
+
   !> Construct and get the constraints.
   !!
   !! This function constructs the constraint values from the individual
@@ -634,43 +660,4 @@ contains
     end do
 
   end function problem_get_log_header
-
-  !> Return the log for the current iteration.
-  function problem_get_log_state(this, real_format) result(buff)
-    class(problem_t), intent(in) :: this
-    character(len=*), intent(in) :: real_format
-    character(len=1024) :: buff
-    character(len=50) :: mini_buff
-    character(len=30) :: formatting
-    real(kind=rp) :: tmp_real
-    real(kind=rp), allocatable :: tmp_reals
-    integer :: i
-
-    formatting = '(", ",'//trim(real_format)//')'
-
-    buff = ""
-    mini_buff = ""
-    tmp_real = 0.0_rp
-    do i = 1, this%n_objectives
-       tmp_real = tmp_real + &
-            this%objective_list(i)%objective%weight * &
-            this%objective_list(i)%objective%value
-    end do
-
-    write(mini_buff, formatting) tmp_real
-    buff = trim(buff)//trim(mini_buff)
-
-    do i = 1, this%get_n_objectives()
-       mini_buff = ""
-       write(mini_buff, formatting) this%objective_list(i)%objective%value
-       buff = trim(buff)//trim(mini_buff)
-    end do
-
-    do i = 1, this%get_n_constraints()
-       mini_buff = ""
-       write(mini_buff, formatting) this%constraint_list(i)%constraint%value
-       buff = trim(buff)//trim(mini_buff)
-    end do
-
-  end function problem_get_log_state
 end module problem

--- a/sources/problems/problem.f90
+++ b/sources/problems/problem.f90
@@ -605,7 +605,7 @@ contains
   function problem_get_log_header(this) result(buff)
     class(problem_t), intent(in) :: this
     character(len=1024) :: buff
-    character(len=50) :: mini_buff 
+    character(len=50) :: mini_buff
     integer :: i
 
     ! When it comes to multi-objective optimization
@@ -616,7 +616,7 @@ contains
     !
     !      | Total F | F_1 | F_2 | ... | F_n | C_1 | C_2 | ... | C_m |
     !
-    ! And then if we also want things like thie iteration or KKT they can be 
+    ! And then if we also want things like thie iteration or KKT they can be
     ! appended to the begining or end of this by the optimizer.
     !
     ! iter | Total F | F_1 | F_2 | ... | F_n | C_1 | C_2 | ... | C_m | KKT
@@ -630,7 +630,7 @@ contains
     do i = 1, this%get_n_constraints()
        mini_buff = ""
        write(mini_buff, '(", ", A)') &
-          this%constraint_list(i)%constraint%log_name
+            this%constraint_list(i)%constraint%log_name
        buff = trim(buff)//trim(mini_buff)
     end do
 
@@ -641,13 +641,13 @@ contains
     class(problem_t), intent(in) :: this
     character(len=*), intent(in) :: real_format
     character(len=1024) :: buff
-    character(len=50) :: mini_buff 
-    character(len=30) :: formatting 
+    character(len=50) :: mini_buff
+    character(len=30) :: formatting
     real(kind=rp) :: tmp_real
     real(kind=rp), allocatable :: tmp_reals
     integer :: i
 
-    formatting = '(", ",'//trim(real_format)//')' 
+    formatting = '(", ",'//trim(real_format)//')'
 
     buff = ""
     mini_buff = ""
@@ -658,7 +658,7 @@ contains
             this%objective_list(i)%objective%value
     end do
 
-    write(mini_buff, formatting) tmp_real 
+    write(mini_buff, formatting) tmp_real
     buff = trim(buff)//trim(mini_buff)
 
     do i = 1, this%get_n_objectives()
@@ -672,6 +672,6 @@ contains
        write(mini_buff, formatting) this%constraint_list(i)%constraint%value
        buff = trim(buff)//trim(mini_buff)
     end do
-    
+
   end function problem_get_log_state
 end module problem

--- a/sources/problems/problem.f90
+++ b/sources/problems/problem.f90
@@ -68,7 +68,6 @@ module problem
      integer :: n_objectives
      !> Number of constraints in the problem.
      integer :: n_constraints
-     !> Format for output log
 
      !> The objective of the problem.
      class(objective_wrapper_t), allocatable, dimension(:) :: objective_list

--- a/sources/problems/problem.f90
+++ b/sources/problems/problem.f90
@@ -170,8 +170,6 @@ module problem
 
      !> Return the logfile header
      procedure, pass(this) :: get_log_header => problem_get_log_header
-     !> Return the current logfile state
-     procedure, pass(this) :: get_log_state => problem_get_log_state
 
   end type problem_t
 
@@ -648,14 +646,14 @@ contains
     buff = "Total objective function"
     do i = 1, this%get_n_objectives()
        mini_buff = ""
-       write(mini_buff, '(", ", A)') this%objective_list(i)%objective%log_name
+       write(mini_buff, '(", ", A)') this%objective_list(i)%objective%name
        buff = trim(buff)//trim(mini_buff)
     end do
 
     do i = 1, this%get_n_constraints()
        mini_buff = ""
        write(mini_buff, '(", ", A)') &
-            this%constraint_list(i)%constraint%log_name
+            this%constraint_list(i)%constraint%name
        buff = trim(buff)//trim(mini_buff)
     end do
 


### PR DESCRIPTION
I guess we discussed this a bit this morning, but this is what I had in mind.
I'm putting this in draft mode because I want comments before I move any further with this:

- Do we think we'll want this in other optimization? ie, would a `logger_t` be useful?
- Are we all happy with enforcing a log name to all constraints/objectives so we can write them out?

But perhaps more importantly, what I've written currently is pretty susceptible to truncation of that long string (buffer? is this the correct word? that was the intention of the variable name `buff`)

### Example output

```
n =     86400, m =         1, tolerance =  1.00000000000000002E-03              
iter, Total objective function, Dissipation, out of plane stresses, Volume constraint, KKTmax, KKTnorm2, scalaing factor
  0,     5.3696209634E+01,     4.0441625841E+01,     1.3254583793E+01,    -3.4113716238E-01,     1.7976931349+308,     1.7976931349+308,     1.0000000000E+00
  1,     5.3631210218E+01,     4.0441625841E+01,     1.3189584378E+01,    -3.4067827356E-01,     3.4063388244E-01,     1.8251180684E+00,     1.0000000000E+00
  2,     5.3266158113E+01,     4.0127814834E+01,     1.3138343279E+01,    -3.4021952588E-01,     3.4017508569E-01,     5.0791113981E+00,     1.0000000000E+00
  3,     5.2946050791E+01,     3.9894493099E+01,     1.3051557691E+01,    -3.3973026153E-01,     3.3968611728E-01,     4.1537413064E+00,     1.0000000000E+00
  4,     5.2488335978E+01,     3.9561169448E+01,     1.2927166530E+01,    -3.3922171690E-01,     3.3917795103E-01,     5.6123647507E+00,     1.0000000000E+00
  5,     5.1825567047E+01,     3.9082081599E+01,     1.2743485448E+01,    -3.3889046816E-01,     3.3884813432E-01,     7.9908112190E+00,     1.0000000000E+00
  6,     5.1000305086E+01,     3.8491289553E+01,     1.2509015532E+01,    -3.3852679847E-01,     3.3848677945E-01,     9.8497959414E+00,     1.0000000000E+00
  7,     5.0354702281E+01,     3.8025030555E+01,     1.2329671726E+01,    -3.3866646158E-01,     3.3862891930E-01,     7.8845237703E+00,     1.0000000000E+00
  8,     4.9785292383E+01,     3.7615237248E+01,     1.2170055135E+01,    -3.3902719413E-01,     3.3899308096E-01,     7.5623243319E+00,     1.0000000000E+00

```

### Example output using `csv_file_type`
```
iter, Total objective function, Dissipation, Out of plane stresses, Volume constraint, KKTmax, KKTnorm2, scalaing factor
0.0000000000000000,53.696209634065141,40.441625840817053,13.254583793248088,-0.34113716238378983,0.0000000000000000,0.0000000000000000,1.0000000000000000
1.0000000000000000,53.631210218451116,40.441625840817053,13.189584377634059,-0.34067827356064134,0.34063388243730330,1.8251180684119177,1.0000000000000000
2.0000000000000000,53.266158113095081,40.127814833617478,13.138343279477603,-0.34021952587850796,0.34017508568651300,5.0791113980976883,1.0000000000000000
3.0000000000000000,52.946050790610592,39.894493099386999,13.051557691223593,-0.33973026152689706,0.33968611727815884,4.1537413063900503,1.0000000000000000
4.0000000000000000,52.488335977948438,39.561169447724346,12.927166530224092,-0.33922171690237829,0.33917795102621462,5.6123647507375267,1.0000000000000000
5.0000000000000000,51.825567047220396,39.082081599088639,12.743485448131759,-0.33889046815908813,0.33884813432446081,7.9908112190203324,1.0000000000000000
6.0000000000000000,51.000305085635944,38.491289553207920,12.509015532428020,-0.33852679846645700,0.33848677945129146,9.8497959414055956,1.0000000000000000
7.0000000000000000,50.354702281281916,38.025030555367294,12.329671725914622,-0.33866646158438390,0.33862891930457578,7.8845237703490136,1.0000000000000000
8.0000000000000000,49.785292383215989,37.615237248149093,12.170055135066898,-0.33902719412641674,0.33899308096021136,7.5623243318792319,1.0000000000000000
```