### PR TITLE
Allow specification of processor count for execution

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -32,6 +32,10 @@ function help() {
     printf "  -%-1s, --%-10s %-60s\n" " " "dry-run" "Dry run the script."
     printf "  -%-1s, --%-10s %-60s\n" "r" "re-run" "Re-run the examples."
 
+    printf "\n\e[4mEnvironment:\e[0m\n"
+    printf "  -%-1s %-60s\n" "NEKO_DIR" "Path to the Neko installation."
+    printf "  -%-1s %-60s\n" "NPROCS" "Number of processors to use."
+
     printf "\n\e[4mAvailable case files:\e[0m\n"
     for case in $(find $EPATH -name "*.case" 2>/dev/null); do
         printf '  - %-s\n' ${case#$EPATH/}

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -49,19 +49,21 @@ function run {
 
     else
         # Look for the number of cores to use
-        if [ ! -z "$CUDA_VISIBLE_DEVICES" ]; then
+        if [ ! -z "$NPROCS" ]; then
+            ncores=$NPROCS
+        elif [ ! -z "$CUDA_VISIBLE_DEVICES" ]; then
             ncores=$(echo $CUDA_VISIBLE_DEVICES | tr "," "\n" | wc -l)
         elif [ ! -z "$LSB_DJOB_NUMPROC" ]; then
             ncores=$LSB_DJOB_NUMPROC
-        fi
-
-        if [ -z "$ncores" ]; then
+        else
             nsockets="$(lscpu | grep "Socket(s)" | awk '{print $2}')"
             ncores="$(lscpu | grep "Core(s) per socket" | awk '{print $4}')"
             ncores=$((nsockets * ncores))
         fi
 
-        ncores=1
+        if [ -z "$ncores" ]; then
+            ncores=1
+        fi
 
         mpirun -n $ncores $neko $casefile 2>error.log
 


### PR DESCRIPTION
Introduce the ability to specify the number of processors to use via the `NPROCS` environment variable, enhancing flexibility in resource allocation during script execution.