### PR TITLE
Fix verification run script and build examples from runner script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         # Warnings which for debug builds are errors
         $<$<COMPILE_LANGUAGE:Fortran>:-Wall>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wextra>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Werror>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wno-unused-dummy-argument>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wno-function-elimination>
         $<$<COMPILE_LANGUAGE:Fortran>:-Wno-missing-include-dirs>

--- a/examples/rugby_verification/run.sh
+++ b/examples/rugby_verification/run.sh
@@ -3,7 +3,6 @@
 # We aim to run on many different numbers of processors. But to avoid edge
 # cases, we will only run on prime numbers.
 NPROC=(7 5 3 2 1)
-NPROC=(7)
 
 for i in "${NPROC[@]}"; do
     echo "Running with $i processors"
@@ -15,17 +14,13 @@ for i in "${NPROC[@]}"; do
 
     target=$RPATH/rugby_verification/target_$i.csv
     echo "Comparing output to reference solution $target"
-    if [ ! -f $target ]; then
-        mv optimization_data.csv target_$i.csv
-        continue
+    if [ -f $target ]; then
+        diff -q $target optimization_data.csv
+        if [ $? -ne 0 ]; then
+            echo "Output $i does not match the reference solution. Exiting." >&2
+            exit 1
+        fi
     fi
 
-    # Check if the run was successful and the output is as expected. Compare
-    # the output to the reference solution.
-    diff -q $target optimization_data.csv
-    if [ $? -ne 0 ]; then
-        echo "Output $i does not match the reference solution. Exiting." >&2
-        exit 1
-    fi
-
+    mv optimization_data.csv target_$i.csv
 done

--- a/run.sh
+++ b/run.sh
@@ -320,6 +320,12 @@ function handler() {
 trap 'handler' SIGINT
 
 # ============================================================================ #
+# Compile the example executables
+
+printf "\n\e[4mCompiling the examples.\e[0m\n"
+cmake --build $MAIN_DIR/build --target Examples --parallel
+
+# ============================================================================ #
 # Run the examples
 full_start=$(date +%s.%N)
 QUEUE=""

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -15,7 +15,7 @@ module mma_optimizer
   use matrix, only: matrix_t
 
   !only to print nglobal when running in parallel
-  use comm, only: neko_comm
+  use comm, only: neko_comm, pe_rank
   use mpi_f08, only: MPI_INTEGER, mpi_sum, MPI_Allreduce
 
   use neko_config, only: NEKO_BCKND_DEVICE
@@ -98,7 +98,9 @@ contains
        call neko_error('Unknown design type for MMA Optimizer')
     end select
 
-    print *, "Initializing mma_optimizer with steady_state_problem_t."
+    if (pe_rank .eq. 0) then
+       print *, "Initializing mma_optimizer with steady_state_problem_t."
+    end if
 
     call json_get_subdict(parameters, "optimization.solver", solver_parameters)
     call this%mma%init_json(x%x, &
@@ -160,7 +162,10 @@ contains
 
     !>initializing the scaling factor
     scaling_factor = 1.0_rp
-    print *, "max_iterations for the optimization loop = ", this%max_iterations
+    if (pe_rank .eq. 0) then
+       print *, "max_iterations for the optimization loop = ", &
+            this%max_iterations
+    end if
 
     call simulation%run_forward()
     call problem%compute(design)
@@ -293,7 +298,9 @@ contains
     end do
 
     ! Final state after optimization
-    print*, "MMA Optimization completed after", iter-1, "iterations."
+    if (pe_rank .eq. 0) then
+       print *, "MMA Optimization completed after", iter-1, "iterations."
+    end if
 
     call constraint_value%free()
     call objective_sensitivities%free()


### PR DESCRIPTION
Streamline the execution process by building example executables from the runner script.

Update the verification example. New filenames were not used properly. Also the example will now check against the result folder, rather than a manually added reference.

Also added an MPI guard on a few print statements