### PR TITLE
Bring rugby ball up to date

### DIFF
--- a/examples/rugby_ball/driver.f90
+++ b/examples/rugby_ball/driver.f90
@@ -47,7 +47,12 @@ program usrneko
   ! Initialization of the components
 
   call simulation%init(parameters)
+
+  ! Todo: We are currently working on the design.
   call design%init(parameters, simulation)
+  call design%add_mapping(parameters, simulation)
+
+
   call problem%init(parameters, design, simulation)
   call optimizer_factory(optimizer, parameters, problem, design, simulation)
 
@@ -60,6 +65,8 @@ program usrneko
   ! Clean up the components
 
   call optimizer%free()
+  if (allocated(optimizer)) deallocate(optimizer)
+
   call problem%free()
   call design%free()
   call simulation%free()

--- a/examples/rugby_ball/rugby_ball.case
+++ b/examples/rugby_ball/rugby_ball.case
@@ -91,6 +91,26 @@
         ]
     },
     "optimization": {
+        "solver": {
+            "type": "mma",
+            "max_iterations": 5,
+            "tolerance": 1.0e-3,
+            "mma": {
+                "max_iter": 100,
+                "asyinit": 0.5,
+                "asyincr": 1.2,
+                "asydecr": 0.7,
+                "m": 1,
+                "scale": 1.0,
+                "auto_scale": false,
+                "xmin": 0.0,
+                "xmax": 1.0,
+                "a0": 1.0,
+                "a": 0.0,
+                "c": 100.0,
+                "d": 0.0
+            }
+        },
         "objectives": [
             {
                 "type": "minimum_dissipation",
@@ -99,7 +119,6 @@
             {
                 "type": "lube_term",
                 "weight": 1.0,
-                // "mask_name": "optimization_domain",
                 "K": 1.0
             }
         ],
@@ -112,19 +131,5 @@
             }
         ],
     },
-    "mma": {
-        "max_iter": 100,
-        "asyinit": 0.5,
-        "asyincr": 1.2,
-        "asydecr": 0.7,
-        "m": 1,
-        "scale": 1.0,
-        "auto_scale": false,
-        "xmin": 0.0,
-        "xmax": 1.0,
-        "a0": 1.0,
-        "a": 0.0,
-        "c": 100.0,
-        "d": 0.0
-    }
+
 }


### PR DESCRIPTION
Here I've just updated the case file and driver of `rugby_ball` to reflect the to updates in `rugby_verification`

**NOTE** 

This will fail on device at the 2nd iteration due to the KKT check at line 413 of `mma.f90`. Substituting 
```fortran
    if (NEKO_BCKND_DEVICE .eq. 0) then                                          
       call mma_KKT_cpu(this, x, df0dx, fval, dfdx)                             
    else                                                                        
       write(stderr, *) "Device not supported for MMA."                         
       error stop                                                               
    end if
```

with 
``` fortran 
    if (this%backend == 'cpu') then                                          
       call mma_KKT_cpu(this, x, df0dx, fval, dfdx)                             
    else                                                                        
       write(stderr, *) "Device not supported for MMA."                         
       error stop                                                               
    end if
```

Is how PR#79 was run