### PR TITLE
Avoid built-in names and handle compilation errors

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -325,6 +325,12 @@ trap 'handler' SIGINT
 printf "\n\e[4mCompiling the examples.\e[0m\n"
 cmake --build $MAIN_DIR/build --target Examples --parallel
 
+# Check if the compilation was successful
+if [ $? -ne 0 ]; then
+    printf >&2 "\e[1;31mCompilation failed.\e[m\n"
+    exit 1
+fi
+
 # ============================================================================ #
 # Run the examples
 full_start=$(date +%s.%N)

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -228,9 +228,9 @@ function cleanup {
     for nek in $(find ./ -name "*.nek5000"); do
         printf "\t- %s\n" ${nek##*/}
 
-        basename=$(basename $nek)
+        base=$(basename $nek)
         directory=$(dirname $nek)
-        pattern=$directory/${basename%.*}
+        pattern=$directory/${base%.*}
 
         mkdir -p $pattern
         mv -t $pattern $nek ${nek%.*}.f*


### PR DESCRIPTION
Ensure variable names do not conflict with built-in names and exit with an error message if examples fail to compile.