### PR TITLE
Add regression tests and improve workflow for Neko-TOP library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,13 +160,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
 # ============================================================================ #
 
 # Setup testing
-include(CTest)
-if (BUILD_TESTING)
-    find_package(PFUNIT REQUIRED
-        HINTS ${PFUNIT_DIR}
-    )
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests)
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
 # ============================================================================ #
 # Write messages to the user about the options and paths if we are at the top

--- a/run.sh
+++ b/run.sh
@@ -455,7 +455,11 @@ done
 
 if [ -z "$CLUSTER" ]; then
     $MAIN_DIR/status.sh
+
+    # If status return an error, we exit with an error code
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
 fi
 
-printf "\n"
 # # EOF # #

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -267,7 +267,6 @@ function find_neko() {
     find_json_fortran
     find_gslib
     find_hdf5
-    [ "$TEST" == true ] && find_pfunit
 
     # Determine the Neko installation directory
     if [ ! -z "$1" ]; then
@@ -285,14 +284,13 @@ function find_neko() {
     fi
 
     # Check if Neko is installed, if not install it.
-    if [[ -z "$(find $1/lib*/ -name libneko.a)" || "$CLEAN" == true ]]; then
+    if [[ -z "$(find $NEKO_DIR/lib*/ -name libneko.a)" || "$CLEAN" == true ]]; then
 
         # Determine available features
         FEATURES="--enable-contrib "
         [ ! -z "$GSLIB_DIR" ] && FEATURES+="--with-gslib=$GSLIB_DIR"
         [ ! -z "$BLAS_DIR" ] && FEATURES+=" --with-blas=$BLAS_DIR"
         [ ! -z "$HDF5_DIR" ] && FEATURES+=" --with-hdf5=$HDF5_DIR"
-        [ "$TEST" == true ] && FEATURES+=" --with-pfunit=$PFUNIT_DIR"
 
         # Handle device specific features
         if [ "$DEVICE_TYPE" == "CUDA" ]; then
@@ -331,7 +329,6 @@ function find_neko() {
         fi
         [ "$CLEAN" == true ] && make clean
         [ "$QUIET" == true ] && make -s -j install || make -j install
-        [ "$TEST" == true ] && make check
 
         # Verify installation device type
         if [ "$DEVICE_TYPE" == "CUDA" ]; then

--- a/status.sh
+++ b/status.sh
@@ -125,6 +125,8 @@ done
 # ============================================================================ #
 # Print errors for all unfinished tests
 
+ERROR_OCCURRED=0
+
 for test in ${tests[@]}; do
     # Check if there were errors. Print them if there were.
     if [ -s $LPATH/$test/error.log ]; then
@@ -132,6 +134,8 @@ for test in ${tests[@]}; do
         if [ "$(head -n 1 $LPATH/$test/error.log)" = "Interrupted" ]; then
             continue
         fi
+
+        ERROR_OCCURRED=1
 
         # Print the header with example name
         printf '\n\e[4;31m%-s\e[m' "${test:0:79}"
@@ -160,4 +164,7 @@ printf "\n"
 
 # Remove all empty folders in the logs folder
 find $LPATH -type d -empty -delete
+
+# If an error occurred, return 1
+exit $ERROR_OCCURRED
 # # EOF # #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,60 +1,12 @@
-# ============================================================================ #
-# Neko-TOP tests
-# ============================================================================ #
-# This CMakeLists.txt file is used to define the tests for the Neko-TOP
-# library. The tests are defined using the pFUnit testing framework, which
-# is a Fortran testing framework that is used to test the Neko-TOP library.
-#
-# ============================================================================ #
-# Setup the Neko-TOP tests
-# ============================================================================ #
-# A couple of different types of tests can be setup and will be defined in this
-# file. The tests are defined in the following ways:
-#
-# 1. Simple tests: These test are just a single pfunit test that is completely
-#    self-contained and does not require any additional files.
-# 2. Complex tests: These tests are more complex and require additional files
-#    to be included in the test or require additional setup.
-#    Examples of complex tests are MPI tests and tests that require additional
-#    files to be included.
-#
-# Simple tests are located and added automatically, complex tests must have an
-# associated CMakeLists.txt file in the test directory. The CMakeLists.txt file
-# should define the test and any additional files that are required for the
-# test.
+# This file will define the tests for the Neko-TOP library.
+# Here we define the custom targets for the tests. Which allow us to build all
+# the tests by targetting the specific target.
 
-# Recursively find all folders in the test directory.
-file(GLOB_RECURSE folder_list
-    LIST_DIRECTORIES YES
-    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/*
-)
+# Add the custom target for the tests
+add_custom_target(Tests DEPENDS neko-top)
 
-foreach(folder ${folder_list})
-    if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${folder})
+# Add the unit tests
+add_subdirectory(unit)
 
-        # Check if a CMakeLists.txt file exists in the directory.
-        if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${folder}/CMakeLists.txt)
-            add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${folder})
-
-        else()
-
-            # Assign test name as the directory name, with "/" replaced by "-".
-            string(REPLACE "/" "-" test_name ${folder})
-
-            # Find all .pf files in the directory and add them as tests.
-            file(GLOB pf_files ${CMAKE_CURRENT_SOURCE_DIR}/${folder}/*.pf)
-            foreach(pf_file ${pf_files})
-                get_filename_component(pf_file_name ${pf_file} NAME_WE)
-                file(RELATIVE_PATH pf_file
-                    ${CMAKE_CURRENT_SOURCE_DIR} ${pf_file})
-                message(STATUS "Adding test: ${pf_file_name}")
-                message(STATUS "Adding test: ${pf_file}")
-                add_pfunit_ctest(${test_name}-${pf_file_name}
-                    TEST_SOURCES ${pf_file}
-                    LINK_LIBRARIES PkgConfig::neko MPI::MPI_Fortran neko-top
-                )
-            endforeach()
-        endif()
-    endif()
-endforeach()
+# Add the regression tests
+add_subdirectory(regression)

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,0 +1,5 @@
+# This file is used to define the regression tests for the Neko-TOP library.
+
+# Add the regression tests
+add_subdirectory(rugby_ball/)
+add_dependencies(Tests Tests-regression-rugby_ball)

--- a/tests/regression/rugby_ball/.gitignore
+++ b/tests/regression/rugby_ball/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all target files, they are machine dependent
+rugby_ball-tests
+*.log
+box.nmsh
+optimization_data.csv

--- a/tests/regression/rugby_ball/CMakeLists.txt
+++ b/tests/regression/rugby_ball/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Define the Rugby Ball regression test
+
+
+# Import the neko-top static library
+add_library(neko-top-a STATIC IMPORTED)
+set_target_properties(neko-top-a PROPERTIES
+    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/libneko-top.a"
+)
+
+
+add_executable(Tests-regression-rugby_ball EXCLUDE_FROM_ALL
+    ${CMAKE_CURRENT_SOURCE_DIR}/driver.f90
+)
+
+# Set the output directory for the tests
+set_target_properties(Tests-regression-rugby_ball
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(Tests-regression-rugby_ball
+    PkgConfig::neko
+    PkgConfig::json-fortran
+    neko-top-a
+    MPI::MPI_Fortran
+)
+
+target_include_directories(Tests-regression-rugby_ball
+    PRIVATE
+        ${CMAKE_BINARY_DIR}/modules
+        ${CMAKE_Fortran_MODULE_DIRECTORY}
+)

--- a/tests/regression/rugby_ball/README.md
+++ b/tests/regression/rugby_ball/README.md
@@ -1,0 +1,251 @@
+# Proof of concept for a steady state optimization problem
+
+Here we follow the classic "rugby ball" example by 
+[Borrvall & Petersson 2003](https://doi.org/10.1002/fld.426)
+
+Here we introduce the following new classes:
+
+
+## `design_variable`
+This could be any design variable in the optimization problem. eg :
+- coefficients
+- splines
+- levelsets
+- etc
+
+Currently,
+we only consider topology optimization and hence we just a type `topopt_design`.
+
+Hopefully, this can be a derived type of the more abstract `design_variable`.
+
+### `topopt_design`
+This contains the design field $\rho$ as well as the following key proceedures
+- `map_forward` maps the design varaible to coeffients (currently only the 
+Brinkman amplitude $\rho \mapsto \chi $)
+
+In the future, this should also contain filters $\rho \mapsto \tilde{\rho}
+\mapsto \chi$
+
+- `map_backwards` uses chain rule to map the sensitivity of the coefficents
+to the sensitivity to the design variable $\frac{\partial F}{\partial \chi}
+ \mapsto \frac{\partial F}{\partial \rho}$
+
+## Optimizer
+
+A generic type, optimizer, has been added. Currently, only the `mma_optimizer` 
+is supported, and all required parameters for the MMA solver are specified in 
+the JSON case file.
+
+### New Parameters
+1. **Scaling**  
+   Based on the [Svanberg MMA Method](https://people.kth.se/~krille/mmagcmma.pdf), MMA performs optimally
+   when function values are between 1 and 100. To achieve this:
+   - If `auto_scale` is set to `true` in the case file:
+     - The objective value is scaled at each iteration to 
+	   match the specified `scale` parameter value. The derivatives are also 
+	   scaled accordingly. (variable scaling factor)
+   - If `auto_scale` is set to `false`:
+     - The objective value and its derivatives are multiplied by the `scale` 
+	   parameter value before being passed to the optimizer. (constant scaling
+	   factor)
+2. **Impact of Scaling**  
+   Note that these scaling operations affect only the optimizer's internal 
+   computations. The original values of the objective function and its 
+   derivatives remain unchanged.
+
+
+## `problem`
+This contains a way to evaluate an optimization problem, ie, all objective
+functions and constraints. Currently, we only
+use gradient descent algorithms using first order gradient information, so
+the key proceedures are
+- `init` to initialize the type of optimization problem
+- `compute` this is to evalute all objective functions $F$ and constraints $C_i$ 
+- `compute_sensitivity` this is to evalute all the sensitivities
+$\frac{\partial F}{\partial \rho}$, $\frac{\partial C_1}{\partial \rho}$,
+$\frac{\partial C_2}{\partial \rho}$ etc.
+- in princple only the `compute` is required. (eg, gradient free algorithms) or
+more may be required (eg, `compute_hessian`)
+
+Within a `problem` we also contain fluid and adjoint schemes as well as instance
+ of the following classes.
+
+Currently we have only implemented a steady topologogy optimization case.
+
+
+
+### `objective_function`
+this could be either an objective function or a constraint.
+The key proceedures are
+- `init` allowing various source terms to be appended to the adjoint.
+- `compute` to compute the objective/constraint function value.
+- `compute_sensitivity` to compute the sensitivity of the objective/constraint
+with respect to the design.
+- `free` to free.
+
+Here we have made 2 derived types,
+
+`minimum_dissipation_objective function` for objectives
+$F = \int_\Omega |\nabla \mathbf{u}|^2 d\Omega + K \int_\Omega \chi |u|^2 d\Omega$
+
+`volume_constraint` for constraints either $V < V_{max}$ or $V > V_{min}$ where
+$V = \int_\Omega \tilde{\rho} d \Omega $.
+
+Note, it should be over $\Omega_O$ after masks are included.
+
+This is example is primarily used to summarize the list of remaining tasks.
+
+However, the source code is littered with TODO comments and further details.
+
+
+## Todo (in Neko):
+
+
+### Simcomp_handler 
+this would be like what Tim made for source terms. I feel like Tim is the man 
+for this job. Importantly, simulation components are initialized in `neko.f90` 
+by passing the case through. It would be nice to have functionality to append 
+simcomps, this way we can pass `C` or `adj`.
+
+The reason we need this is because currently computing an objective function or 
+sensitivity is done with a proceedure owned by the `objective_function_t`, and 
+is computed on the last step. When we move to unsteady calculations these will 
+be accumulated during the run, so a `simcomp_t` will be the perfect tool. 
+So then we can start appending simcomps that compute time averaged objective 
+functions and sensitivity.
+
+### Steady states
+I would preffer if this is done in Neko, because the simulation component 
+we have right now is a bit hacky. I suppose have a `am_I_done` function that 
+returns a boolean of y/n is a good idea!
+- Then in most cases this is just checking `t < t_final`
+- But then we could check norms etc
+- Other people could check converged statistics etc
+- could even have a usr defined stopping condition too.
+
+
+## Todo (in Neko-top):
+
+### Write the `problem` module
+You can see in `driver.f90` I've put a fair amount of the skeleton for the 
+`problem` module, which would hold everything. 
+But really this driver should only be calling:
+```fortran
+	problem%init()
+	problem%solve()
+	problem%free()
+```
+But we should have a discussion about how we want to lay out the case file 
+first for a neko-top case.
+
+Honestly, this bit ***really*** confuses me. Because in theory, a `problem` 
+can exist without a fluid, and it's only when we start defining certain 
+objective functions and constraints that we require a fluid simulation. 
+This level of abstraction/objected oriented thinking is beyond me, but I'm 
+sure we'll require some refactoring to make this right.
+
+### Masks
+This one is rather simple, just including masks on objective functions and 
+masks on the optimization domain. We could then compute volume based on the 
+optimization domain, not the computation domain.
+
+We should discuss though, how we define a mask. Could be point zones like you 
+suggested Tim. In `Nek5000` we filled up arrays the size of the mesh with 
+booleans. That's rather light, and we could still use all the point zone 
+functionality to initialize these masks.
+
+### incorporate the PDE filters
+We already have a branch in Neko where we did the PDE filters. Either we PR 
+that in neko, so it can be used with the standard Brinkman term there, or we 
+just migrate everything to neko-top. 
+Then we can start including it in the `design_t`.
+
+### Handle mapping to multiple coefficients 
+This is a BIG one, and we need to discuss the best way forward before 
+implementing anything. 
+
+Right now, a `design_t` only has the Brinkman term to map to. But in principle, 
+we may want to map to many coefficients, eg conductivity $\kappa$ etc for CHT. 
+So I'm thinking it would be better for us to have a `field_list_t` for all the 
+coefficients, and then each one has a unique subroutine for its mapping. 
+
+So when we call `design%map_forward()`, it loops through and maps all the 
+coefficients. I feel like this is going to be tricky to keep track of, but we 
+could use a `get_by_name` so that's nice. It's like our own little self 
+contained registry of sorts.
+
+Similarly, the `objective_function_t` type has a field to hold the sensitivity 
+wrt to the coefficient (for us, it's just the brinkman term $\chi$) 
+ie, $\frac{\partial F}{\partial \chi}$. This gets passed to the `design_t` 
+to chain rule backwards, ie, $\frac{\partial F}{\partial \rho}$. 
+
+But with more coefficients we'll need to pass a list back, 
+ie $\frac{\partial F}{\partial \chi}$, $\frac{\partial F}{\partial C}$, 
+$\frac{\partial F}{\partial \kappa}$ etc, 
+and some kind of instructions of how to assemble the sensitivity. 
+
+All in all, this is a bit tricky in my mind.
+
+### Handle multiple constraints (such that we have multiple sensitivities)
+In a similar vibe, we would want a design to have a `field_list_t` for the 
+sensitivities coming from the objective function $F$ and all the constraints 
+$C_i$. ie, $\frac{\partial F}{\partial \rho}$, 
+$\frac{\partial C_1}{\partial \rho}$, $\frac{\partial C_2}{\partial \rho}$  etc. 
+
+All the initialization and execution of all of these need to be wrapped up 
+nicely, similar to `source_terms` I guess.
+
+
+### log file to write with KKT, constraint values etc
+Of course we would still have the neko log file, but we should have a neko-top 
+log file that prints out all the usefull information at each optimization 
+iteration.
+
+### merge in the passive scalars
+We have most of the adjoint passive scalars written on a different branch, 
+but we haven't been able to test it since we don't have a driver.
+
+
+### ALL the JSON stuff
+You can see everything is hardcoded and we need to include a bunch of JSON stuff. 
+This can be done after we discuss the neko-top case file.
+
+### ALL the GPU backends!
+This can come at the end...
+
+### Adjoint solver
+There is still ALOT to do on the adjoint solver regarding the treatment of BCs 
+etc! Don't forget to come back to this!
+
+Also, this point should NEVER be removed from the readme, as there are frequent 
+updates in the `fluid_scheme.f90`, `fluid_pnpn.f90` etc, and these changes 
+should be reflected in `adjoint_scheme.f90` and `adjoint_pnpn.f90` etc.
+
+## Todo (in general):
+- There are a ton more minor comments written throughout the source code here, 
+so I'm sure some have been missed in this `readme.md`
+- Double check all non-dimensionalization and scalings
+- Implement the `adjoint_minimum_dissipation_source_term_t` correctly 
+(ie, in weak form)
+- Restart correctly (or maybe not! in steady calculations it can often be 
+faster if your initial condition is the final condition from the previous 
+iteration)
+- Nothing is freed correctly
+- Particularly regarding steady calculations, there's no reason to recalculate 
+the adjoint forcing each time, it will always be the same.
+- Obviously have MMA based ok KKT not number of itereations 
+- Having our own sampler (the one here is hardcoded, but as we introduce new 
+eqns and coeffients it will be different)
+- Update the `design_t` to include all the cool features Tim put in for 
+initializing a design... instead of this hard coded circle 
+- We have RAMP currently implemented, but we should also include SIMP, linear  
+- Format everything to `Neko` coding standard
+- there are ***MANY*** times that I've used `type` instead of `class`, 
+particularly regarding the `topopt_design_t`. I suppose these could also be 
+calculated differently if we have different `design_variable_t` coming. 
+This will need some untangling.
+- The mapping functions, eg `linear_mapping` or `ramp_mapping` all use 
+`field_math` but it's inefficient and reads poorly. I (Harry) call dibs on 
+writing the backend kernels if we decide to switch, because I'm hoping they're 
+easy.
+ For now, these get called so infrequently it doesn't matter...

--- a/tests/regression/rugby_ball/driver.f90
+++ b/tests/regression/rugby_ball/driver.f90
@@ -1,0 +1,70 @@
+program usrneko
+  use simulation_m, only: simulation_t
+  use design, only: design_t, design_factory
+  use problem, only: problem_t
+  use optimizer, only: optimizer_t, optimizer_factory
+
+  use json_module, only: json_file
+  use utils, only: neko_error
+  use json_utils_ext, only: json_read_file
+
+  use mpi_f08, only: MPI_Init
+  implicit none
+
+  ! JSON related arguments
+  integer :: argc
+  type(json_file) :: parameters
+  character(len=256) :: parameter_file
+
+  ! MPI parameters
+  integer :: ierr
+
+  !> The simulation we are working with
+  type(simulation_t) :: sim
+  !> The design type
+  class(design_t), allocatable :: des
+  !> The problem type
+  type(problem_t) :: prob
+  !> The optimizer (in this case mma)
+  class(optimizer_t), allocatable :: opt
+
+  ! -------------------------------------------------------------------------- !
+  ! Initialize the MPI environment
+
+  call MPI_Init(ierr)
+
+  ! -------------------------------------------------------------------------- !
+  ! Read the parameters file as the first terminal argument
+
+  argc = command_argument_count()
+  if (argc .lt. 1) call neko_error('Missing parameter file')
+  call get_command_argument(1, parameter_file)
+
+  ! Read the parameters file
+  parameters = json_read_file(trim(parameter_file))
+
+  ! -------------------------------------------------------------------------- !
+  ! Initialization of the components
+
+  call sim%init(parameters)
+  call design_factory(des, parameters, sim)
+  call prob%init(parameters, des, sim)
+  call optimizer_factory(opt, parameters, prob, des, sim)
+
+  ! -------------------------------------------------------------------------- !
+  ! Execute the optimization
+
+  call opt%run(prob, des, sim)
+
+  ! -------------------------------------------------------------------------- !
+  ! Clean up the components
+
+  call opt%free()
+  call prob%free()
+  call des%free()
+  call sim%free()
+
+  if (allocated(des)) deallocate(des)
+  if (allocated(opt)) deallocate(opt)
+
+end program usrneko

--- a/tests/regression/rugby_ball/prepare.sh
+++ b/tests/regression/rugby_ball/prepare.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/bash
+
+# ============================================================================ #
+# Define the help function
+
+function help() {
+    echo -e "run.sh case"
+    echo -e "  Generate a mesh."
+    echo -e "  The input arguments are the number of cells in the x, y, and z"
+    echo -e "  directions, respectively."
+    echo -e ""
+    echo -e "  If no input arguments are provided, the default mesh size is"
+    echo -e "  32x8x8."
+    echo -e ""
+    echo -e "  Example usage:"
+    echo -e "    run.sh -x32 -y8 -z8"
+    echo -e ""
+    echo -e " Options:"
+    echo -e "  -h, --help  Show this help message and exit."
+    echo -e "  -x#         Number of cells in the x direction."
+    echo -e "  -y#         Number of cells in the y direction."
+    echo -e "  -z#         Number of cells in the z direction."
+    echo -e ""
+    echo -e "  See Readme for additional details."
+    exit 0
+}
+
+# Handle options
+Nx=20 && Ny=20 && Nz=1
+for arg in "$@"; do
+    if [ "${arg:0:2}" == "--" ]; then
+        case ${arg:2} in
+        help) help ;;
+        *) echo -e "Invalid option: $arg" >&2 && help ;;
+        esac
+    elif [ "${arg:0:1}" == "-" ]; then
+        case ${arg:1:1} in
+        h) help ;;
+        x) Nx=${arg:2} ;;
+        y) Ny=${arg:2} ;;
+        z) Nz=${arg:2} ;;
+        *) echo -e "Invalid option: ${arg:1}" >&2 && help ;;
+        esac
+    fi
+done
+
+# ============================================================================ #
+# Ensure Neko can be found and set default mesh size
+
+if [ "$NEKO_DIR" ]; then
+    PATH=$NEKO_DIR/bin:$PATH
+fi
+
+if [[ -z $(which genmeshbox) ]]; then
+    echo -e "Neko tool 'genmeshbox' not found." >&2
+    echo -e "Please ensure Neko is installed and in your PATH." >&2
+    echo -e "Alternatively, set the NEKO_DIR environment variable." >&2
+    exit 1
+fi
+
+# ============================================================================ #
+# Generate mesh and run case
+
+echo "Generating mesh with dimensions: $Nx $Ny $Nz"
+genmeshbox 0 1 0 1 0 1 $Nx $Ny $Nz .false. .true. .true.
+
+# End of file
+# ============================================================================ #

--- a/tests/regression/rugby_ball/rugby_ball.case
+++ b/tests/regression/rugby_ball/rugby_ball.case
@@ -1,0 +1,133 @@
+{
+    "version": 1.0,
+    "case": {
+        "mesh_file": "box.nmsh",
+        "output_checkpoints": false,
+        "output_at_end": false,
+        "output_precision": "double",
+        "output_boundary": false,
+        "end_time": 1e-3,
+        "timestep": 1e-4,
+        "numerics": {
+            "time_order": 3,
+            "polynomial_order": 5,
+            "dealias": false
+        },
+        "adjoint_fluid": {
+            "initial_condition": {
+                "type": "uniform",
+                "value": [
+                    0.0, 0.0, 0.0
+                ]
+            },
+            "boundary_conditions": [
+                {
+                    "type": "no_slip",
+                    "zone_indices": [ 1, 2 ]
+                }
+            ],
+        },
+        "fluid": {
+            "scheme": "pnpn",
+            "Re": 2,
+            "initial_condition": {
+                "type": "uniform",
+                "value": [ 0.0, 0.0, 0.0 ]
+            },
+            "velocity_solver": {
+                "type": "cg",
+                "preconditioner": "jacobi",
+                "projection_space_size": 0,
+                "absolute_tolerance": 1e-6,
+                "max_iterations": 800
+            },
+            "pressure_solver": {
+                "type": "gmres",
+                "preconditioner": "hsmg",
+                "projection_space_size": 0,
+                "absolute_tolerance": 1e-4,
+                "max_iterations": 800
+            },
+            "boundary_conditions": [
+                {
+                    "type": "velocity_value",
+                    "value": [ 1, 0, 0 ],
+                    "zone_indices": [ 1, 2 ]
+                }
+            ],
+            "output_control": "never",
+        },
+        "simulation_components": [
+            {
+                "type": "steady",
+                "is_user": true,
+                "tol": 1e-2,
+                "compute_control": "tsteps",
+                "compute_value": 1
+            }
+        ],
+        "point_zones": [
+            {
+                "name": "optimization_domain",
+                "geometry": "box",
+                "x_bounds": [
+                    0.2,
+                    0.8,
+                ],
+                "y_bounds": [
+                    0.2,
+                    0.8,
+                ],
+                "z_bounds": [
+                    -1.0,
+                    1.0,
+                ],
+            }
+        ]
+    },
+    "optimization": {
+        "design": {
+            "type": "brinkman"
+        },
+        "solver": {
+            "type": "mma",
+            "max_iterations": 5,
+            "tolerance": 1.0e-3,
+            "mma": {
+                "max_iter": 100,
+                "asyinit": 0.5,
+                "asyincr": 1.2,
+                "asydecr": 0.7,
+                "m": 1,
+                "scale": 1.0,
+                "auto_scale": false,
+                "xmin": 0.0,
+                "xmax": 1.0,
+                "a0": 1.0,
+                "a": 0.0,
+                "c": 100.0,
+                "d": 0.0
+            }
+        },
+        "objectives": [
+            {
+                "type": "minimum_dissipation",
+                "weight": 1.0
+            },
+            {
+                "type": "lube_term",
+                "weight": 1.0,
+                "K": 1.0
+            }
+        ],
+        "constraints": [
+            {
+                "type": "volume",
+                "mask_name": "optimization_domain",
+                "limit": 0.2,
+                "is_max": false
+            }
+        ],
+    },
+
+}

--- a/tests/regression/rugby_ball/run.sh
+++ b/tests/regression/rugby_ball/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# We aim to run on many different numbers of processors. But to avoid edge
+# cases, we will only run on prime numbers.
+NPROC=(1 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47)
+
+CURRENT_DIR=$(pwd)
+
+TEST_DIR=$(realpath $(dirname $0))
+cd $TEST_DIR
+
+genmeshbox 0 1 0 1 0 0.05 20 20 1 .false. .true. .true.
+
+if [ $? -ne 0 ]; then
+    echo "genmeshbox failed. Exiting." >&2
+    exit 1
+fi
+
+# Determine number of physical cores
+PROC=$(lscpu | grep "Core(s) per socket" | awk '{print $4}')
+echo "Physical processors: $PROC"
+
+for i in "${NPROC[@]}"; do
+    [ $i -gt $PROC ] && continue # Skip if we don't have enough processors
+
+    echo "Running with $i processors"
+    export NEKO_LOG_FILE=neko_$i.log
+    [ -f optimization_data.csv ] && rm -f optimization_data.csv
+    mpirun -n $i ./rugby_ball-tests rugby_ball.case
+
+    if [ $? -ne 0 ]; then
+        echo "Test failed with $i processors. Exiting." >&2
+        exit 1
+    fi
+
+    # target=target_$i.csv
+    # echo "Comparing output to reference solution $target"
+    # if [ -f $target ]; then
+    #     diff -q $target optimization_data.csv
+    #     if [ $? -ne 0 ]; then
+    #         echo "Output $i does not match the reference solution. Exiting." >&2
+    #         exit 1
+    #     fi
+    # fi
+
+    rm -f optimization_data.csv
+done
+
+cd $CURRENT_DIR

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,69 @@
+# ============================================================================ #
+# Neko-TOP tests
+# ============================================================================ #
+# This CMakeLists.txt file is used to define the tests for the Neko-TOP
+# library. The tests are defined using the pFUnit testing framework, which
+# is a Fortran testing framework that is used to test the Neko-TOP library.
+#
+# ============================================================================ #
+# Setup the Neko-TOP tests
+# ============================================================================ #
+# A couple of different types of tests can be setup and will be defined in this
+# file. The tests are defined in the following ways:
+#
+# 1. Simple tests: These test are just a single pfunit test that is completely
+#    self-contained and does not require any additional files.
+# 2. Complex tests: These tests are more complex and require additional files
+#    to be included in the test or require additional setup.
+#    Examples of complex tests are MPI tests and tests that require additional
+#    files to be included.
+#
+# Simple tests are located and added automatically, complex tests must have an
+# associated CMakeLists.txt file in the test directory. The CMakeLists.txt file
+# should define the test and any additional files that are required for the
+# test.
+
+include(CTest)
+if (NOT BUILD_TESTING)
+    return ()
+endif()
+
+find_package(PFUNIT REQUIRED
+    HINTS ${PFUNIT_DIR}
+)
+
+# Recursively find all folders in the test directory.
+file(GLOB_RECURSE folder_list
+    LIST_DIRECTORIES YES
+    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/*
+)
+
+foreach(folder ${folder_list})
+    if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${folder})
+
+        # Check if a CMakeLists.txt file exists in the directory.
+        if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${folder}/CMakeLists.txt)
+            add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${folder})
+
+        else()
+
+            # Assign test name as the directory name, with "/" replaced by "-".
+            string(REPLACE "/" "-" test_name ${folder})
+
+            # Find all .pf files in the directory and add them as tests.
+            file(GLOB pf_files ${CMAKE_CURRENT_SOURCE_DIR}/${folder}/*.pf)
+            foreach(pf_file ${pf_files})
+                get_filename_component(pf_file_name ${pf_file} NAME_WE)
+                file(RELATIVE_PATH pf_file
+                    ${CMAKE_CURRENT_SOURCE_DIR} ${pf_file})
+                message(STATUS "Adding test: ${pf_file_name}")
+                message(STATUS "Adding test: ${pf_file}")
+                add_pfunit_ctest(${test_name}-${pf_file_name}
+                    TEST_SOURCES ${pf_file}
+                    LINK_LIBRARIES PkgConfig::neko MPI::MPI_Fortran neko-top
+                )
+            endforeach()
+        endif()
+    endif()
+endforeach()


### PR DESCRIPTION
Introduce regression tests for the Rugby Ball case, enhance caching mechanisms, and streamline the workflow for building and testing the Neko-TOP library. Adjustments include improved error handling and environment variable management.

Please note, this test of the rugby ball does not check the values of outputs yet. It merely executes the code and ensures it can run on the specified number of processors. 
Since we do not expect a bitwise identical result on different hardware we need to define the test so that it meaningfully tests the values.

My suggestion is to let that happen in a separate PR.

Depends on: #120