### PR TITLE
remove premultiply adjoint forcing with mass matrix

### DIFF
--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -769,19 +769,6 @@ contains
          !  call this%gradient_jump_penalty_w_adj%perform(f_z)
       end if
 
-      ! ====================================================================== !
-      ! Todo: This need to be verified
-
-      ! Pre-multiply the source terms with the mass matrix.
-      if (NEKO_BCKND_DEVICE .eq. 1) then
-         call device_opcolv(f_x%x_d, f_y%x_d, f_z%x_d, c_Xh%B_d, msh%gdim, n)
-      else
-         call opcolv(f_x%x, f_y%x, f_z%x, c_Xh%B, msh%gdim, n)
-      end if
-
-      ! End of section to be verified
-      ! ====================================================================== !
-
       if (oifs) then
          call neko_error("OIFS not implemented for adjoint")
          !  ! Add the advection operators to the right-hand-side.


### PR DESCRIPTION
The pre-multiplication is handled in the source term handler, we shouldn't have it here.