### PR TITLE
Allow quiet detection of BLAS, LAPACK, and MPI libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,11 +159,11 @@ endif()
 # Setup External Libraries
 # ............................................................................ #
 # Check for the required libraries.
-find_package(BLAS REQUIRED)
-find_package(LAPACK REQUIRED)
+find_package(BLAS QUIET)
+find_package(LAPACK QUIET)
 
 # Check for the optional libraries.
-find_package(MPI REQUIRED)
+find_package(MPI QUIET)
 
 # ............................................................................ #
 # Setup of JSON-Fortran

--- a/cmake/build_example.cmake
+++ b/cmake/build_example.cmake
@@ -112,16 +112,12 @@ function(build_example)
     # Link the executable to the required libraries.
 
     target_link_libraries(${EXAMPLE_NAME}
-        BLAS::BLAS
-        LAPACK::LAPACK
+        $<$<BOOL:${BLAS_FOUND}>:BLAS::BLAS>
+        $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK>
+        $<$<BOOL:${MPI_FOUND}>:MPI::MPI_Fortran>
         jsonfortran-gnu::jsonfortran
         PkgConfig::neko
     )
-
-    # If MPI is available, link the executable to the MPI library.
-    if(MPI_FOUND)
-        target_link_libraries(${EXAMPLE_NAME} MPI::MPI_Fortran)
-    endif()
 
     # Import the neko-top static library
     add_library(neko-top-a STATIC IMPORTED)

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -86,16 +86,17 @@ target_include_directories(neko-top
         ${CMAKE_Fortran_MODULE_DIRECTORY}
 )
 
+
+# ............................................................................ #
+# Link to the required libraries.
+
 target_link_libraries(neko-top
-    BLAS::BLAS
-    LAPACK::LAPACK
+    $<$<BOOL:${BLAS_FOUND}>:BLAS::BLAS>
+    $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK>
+    $<$<BOOL:${MPI_FOUND}>:MPI::MPI_Fortran>
     jsonfortran-gnu::jsonfortran
     PkgConfig::neko
 )
-
-if(MPI_FOUND)
-    target_link_libraries(neko-top MPI::MPI_Fortran)
-endif()
 
 # ============================================================================ #
 # Specify installation instructions


### PR DESCRIPTION
Enable the option to find BLAS, LAPACK, and MPI libraries without generating errors if they are not found. This change improves the flexibility of the build process.