### PR TITLE
Sync formatting to neko standards

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -57,7 +57,7 @@ jobs:
             if [[ ${file: -4} != ".f90" && ${file: -4} != ".F90" ]]; then
               continue
             fi
-            findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k5 --ws_remred --indent_ampersand --openmp=0 < $file > $file.tmp
+            findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k5 --ws_remred --openmp=0 < $file > $file.tmp
             mv -f $file.tmp $file
           done
 
@@ -68,7 +68,7 @@ jobs:
             echo "" >&2
             echo "Please run the following commands to fix the formatting:" >&2
             echo "pip install findent" >&2
-            echo "findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k5 --ws_remred --indent_ampersand --openmp=0 <file.f90 >file.f90.tmp" >&2
+            echo "findent -Rr -i2 -d3 -f3 -s3 -c3 -w3 -t3 -j3 -k5 --ws_remred --openmp=0 <file.f90 >file.f90.tmp" >&2
             echo "mv file.f90.tmp file.f90" >&2
             git diff >&2
             exit 1


### PR DESCRIPTION
Update formatting commands to align with neko's specifications.

Continuation lines starting with a `&` is not indented to 0 compared to their current scope.

This is commonly used to break long strings.