### PR TITLE
Align with new KSP in neko

### DIFF
--- a/sources/adjoint/adjoint_fluid_scheme.f90
+++ b/sources/adjoint/adjoint_fluid_scheme.f90
@@ -44,8 +44,7 @@ module adjoint_fluid_scheme
   use space, only: space_t, GLL
   use dofmap, only: dofmap_t
   use zero_dirichlet, only: zero_dirichlet_t
-  use krylov, only: ksp_t, krylov_solver_factory, krylov_solver_destroy, &
-       KSP_MAX_ITER
+  use krylov, only: ksp_t, krylov_solver_factory, KSP_MAX_ITER
   use coefs, only: coef_t
   use usr_inflow, only: usr_inflow_t, usr_inflow_eval
   use dirichlet, only: dirichlet_t
@@ -717,12 +716,12 @@ contains
     call this%Xh%free()
 
     if (allocated(this%ksp_vel)) then
-       call krylov_solver_destroy(this%ksp_vel)
+       call this%ksp_vel%free()
        deallocate(this%ksp_vel)
     end if
 
     if (allocated(this%ksp_prs)) then
-       call krylov_solver_destroy(this%ksp_prs)
+       call this%ksp_prs%free()
        deallocate(this%ksp_prs)
     end if
 
@@ -1037,7 +1036,7 @@ contains
     if (.not. associated(user%material_properties, dummy_mp_ptr)) then
 
        write(log_buf, '(A)') "Material properties must be set in the user&
-            & file!"
+       & file!"
        call neko_log%message(log_buf)
        call user%material_properties(0.0_rp, 0, this%rho, this%mu, &
             dummy_cp, dummy_lambda, params)
@@ -1048,16 +1047,16 @@ contains
             (params%valid_path('case.fluid.mu') .or. &
             params%valid_path('case.fluid.rho'))) then
           call neko_error("To set the material properties for the fluid,&
-               & either provide Re OR mu and rho in the case file.")
+          & either provide Re OR mu and rho in the case file.")
 
           ! Non-dimensional case
        else if (params%valid_path('case.fluid.Re')) then
 
           write(log_buf, '(A)') 'Non-dimensional fluid material properties &
-               & input.'
+          & input.'
           call neko_log%message(log_buf, lvl = NEKO_LOG_VERBOSE)
           write(log_buf, '(A)') 'Density will be set to 1, dynamic viscosity to&
-               & 1/Re.'
+          & 1/Re.'
           call neko_log%message(log_buf, lvl = NEKO_LOG_VERBOSE)
 
           ! Read Re into mu for further manipulation.

--- a/sources/mapping_functions/PDE_filter_mapping.f90
+++ b/sources/mapping_functions/PDE_filter_mapping.f90
@@ -39,8 +39,7 @@ module PDE_filter
   use field, only: field_t
   use coefs, only: coef_t
   use ax_product, only: ax_t, ax_helm_factory
-  use krylov, only: ksp_t, ksp_monitor_t, krylov_solver_factory, &
-       krylov_solver_destroy
+  use krylov, only: ksp_t, ksp_monitor_t, krylov_solver_factory
   use precon, only: pc_t, precon_factory, precon_destroy
   use bc_list, only: bc_list_t
   use neumann, only: neumann_t
@@ -174,7 +173,7 @@ contains
     end if
 
     if (allocated(this%ksp_filt)) then
-       call krylov_solver_destroy(this%ksp_filt)
+       call this%ksp_filt%free()
        deallocate(this%ksp_filt)
     end if
 


### PR DESCRIPTION
Update the usage of the Krylov solver to align with the new KSP interface, replacing calls to `krylov_solver_destroy` with the appropriate `free` method for memory management.