### PR TITLE
Make simulation optional in Problem and Optimizer

### DIFF
--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -66,14 +66,14 @@ contains
 
   !> Initialize the MMA optimizer from JSON file
   subroutine mma_optimizer_init_from_json(this, parameters, problem, design, &
-       simulation, max_iterations, tolerance)
+       max_iterations, tolerance, simulation)
     class(mma_optimizer_t), intent(inout) :: this
     type(json_file), intent(inout) :: parameters
     class(problem_t), intent(in) :: problem
     class(design_t), intent(in) :: design
-    type(simulation_t), intent(in) :: simulation
     integer, intent(in) :: max_iterations
     real(kind=rp), intent(in) :: tolerance
+    type(simulation_t), optional, intent(in) :: simulation
 
     character(len=1024) :: optimization_header
     character(len=1024) :: problem_header
@@ -101,21 +101,21 @@ contains
     call this%mma%init(x%x, design%size(), problem%get_n_constraints(), &
          solver_parameters, this%scale, this%auto_scale)
 
-    call this%init_from_components(problem, design, simulation, &
-         max_iterations, tolerance)
+    call this%init_from_components(problem, design, &
+         max_iterations, tolerance, simulation)
 
     call x%free()
   end subroutine mma_optimizer_init_from_json
 
   !> Initialize the MMA optimizer from JSON file
   subroutine mma_optimizer_init_from_components(this, problem, design, &
-       simulation, max_iterations, tolerance)
+       max_iterations, tolerance, simulation)
     class(mma_optimizer_t), intent(inout) :: this
     class(problem_t), intent(in) :: problem
     class(design_t), intent(in) :: design
-    type(simulation_t), intent(in) :: simulation
     integer, intent(in) :: max_iterations
     real(kind=rp), intent(in) :: tolerance
+    type(simulation_t), intent(in), optional :: simulation
 
     call this%init_base(max_iterations, tolerance)
 
@@ -126,7 +126,7 @@ contains
     class(mma_optimizer_t), intent(inout) :: this
     class(problem_t), intent(inout) :: problem
     class(design_t), intent(inout) :: design
-    type(simulation_t), intent(inout) :: simulation
+    type(simulation_t), optional, intent(inout) :: simulation
 
     type(vector_t) :: x
 
@@ -141,7 +141,6 @@ contains
 
     type(vector_t) :: log_data
 
-
     n = design%size()
     call MPI_Allreduce(n, nglobal, 1, MPI_INTEGER, mpi_sum, neko_comm, ierr)
 
@@ -152,10 +151,11 @@ contains
             this%max_iterations
     end if
 
-    call simulation%run_forward()
+    if (present(simulation)) call simulation%run_forward()
+
     call problem%compute(design)
 
-    call simulation%run_backward()
+    if (present(simulation)) call simulation%run_backward()
     call problem%compute_sensitivity(design)
 
     call problem%get_objective_value(objective_value)
@@ -170,7 +170,8 @@ contains
          problem%get_n_objectives(), problem%get_n_constraints())
     call this%logger%write(log_data)
 
-    call simulation%write(0)
+    if (present(simulation)) call simulation%write(0)
+
     call design%write(0)
 
     do iter = 1, this%max_iterations
@@ -192,10 +193,10 @@ contains
 
        call design%update_design(x)
 
-       call simulation%run_forward()
+       if (present(simulation)) call simulation%run_forward()
        call problem%compute(design)
 
-       call simulation%run_backward()
+       if (present(simulation)) call simulation%run_backward()
        call problem%compute_sensitivity(design)
 
        call problem%get_objective_value(objective_value)
@@ -214,9 +215,9 @@ contains
             problem%get_n_objectives(), problem%get_n_constraints())
        call this%logger%write(log_data)
 
-       call simulation%write(iter)
+       if (present(simulation)) call simulation%write(iter)
        call design%write(iter)
-       call simulation%reset()
+       if (present(simulation)) call simulation%reset()
     end do
 
     ! Final state after optimization

--- a/sources/optimizer/optimizer.f90
+++ b/sources/optimizer/optimizer.f90
@@ -46,15 +46,15 @@ module optimizer
   abstract interface
      !> Interface for optimizer initialization
      subroutine optimizer_init_from_json(this, parameters, problem, design, &
-          simulation, max_iterations, tolerance)
+          max_iterations, tolerance, simulation)
        import optimizer_t, json_file, simulation_t, problem_t, design_t, rp
        class(optimizer_t), intent(inout) :: this
        type(json_file), intent(inout) :: parameters
        class(problem_t), intent(in) :: problem
        class(design_t), intent(in) :: design
-       type(simulation_t), intent(in) :: simulation
        integer, intent(in) :: max_iterations
        real(kind=rp), intent(in) :: tolerance
+       type(simulation_t), optional, intent(in) :: simulation
      end subroutine optimizer_init_from_json
 
      !> Interface for running the optimization loop
@@ -63,7 +63,7 @@ module optimizer
        class(optimizer_t), intent(inout) :: this
        class(problem_t), intent(inout) :: problem
        class(design_t), intent(inout) :: design
-       type(simulation_t), intent(inout) :: simulation
+       type(simulation_t), optional, intent(inout) :: simulation
      end subroutine optimizer_run
 
      !> Interface for freeing resources
@@ -89,7 +89,7 @@ module optimizer
        type(json_file), intent(inout) :: parameters
        class(problem_t), intent(in) :: problem
        class(design_t), intent(in) :: design
-       class(simulation_t), intent(in) :: simulation
+       class(simulation_t), optional, intent(in) :: simulation
      end subroutine optimizer_factory
   end interface optimizer_factory
 

--- a/sources/optimizer/optimizer_factory.f90
+++ b/sources/optimizer/optimizer_factory.f90
@@ -32,7 +32,7 @@ contains
     type(json_file), intent(inout) :: parameters
     class(problem_t), intent(in) :: problem
     class(design_t), intent(in) :: design
-    class(simulation_t), intent(in) :: simulation
+    class(simulation_t), optional, intent(in) :: simulation
 
     character(len=:), allocatable :: type
     integer :: max_iterations
@@ -59,8 +59,9 @@ contains
        call neko_type_error("Optimizer", type, KNOWN_TYPES)
     end select
 
-    call object%init_from_json(parameters, problem, design, simulation, &
-         max_iterations, tolerance)
+    call object%init_from_json(parameters, problem, design, &
+         max_iterations, tolerance, simulation)
+
   end subroutine optimizer_factory
 
 

--- a/sources/problems/problem.f90
+++ b/sources/problems/problem.f90
@@ -169,17 +169,17 @@ contains
     class(problem_t), intent(inout) :: this
     type(json_file), intent(inout) :: parameters
     class(design_t), intent(in) :: design
-    type(simulation_t), intent(inout) :: simulation
+    type(simulation_t), optional, intent(inout) :: simulation
 
     this%n_design = design%size()
     this%n_objectives = 0
     this%n_constraints = 0
 
     ! minimum dissipation objective function
-    call this%read_objectives(parameters, simulation, design)
+    call this%read_objectives(parameters, design, simulation)
 
     ! volume constraint
-    call this%read_constraints(parameters, simulation, design)
+    call this%read_constraints(parameters, design, simulation)
 
   end subroutine problem_init
 
@@ -216,12 +216,12 @@ contains
   ! Handling constraints and objectives
 
   !> Read the objective from a parameters file.
-  subroutine problem_read_objectives(this, parameters, simulation, design)
+  subroutine problem_read_objectives(this, parameters, design, simulation)
     class(problem_t), intent(inout) :: this
     type(json_file), intent(inout) :: parameters
-    type(simulation_t), intent(inout) :: simulation
     class(design_t), intent(in) :: design
     class(objective_t), allocatable :: objective
+    type(simulation_t), optional, intent(inout) :: simulation
 
     ! A single objective term as its own json_file.
     character(len=:), allocatable :: path, type
@@ -232,30 +232,31 @@ contains
 
     ! Get the number of objectives.
     path = "optimization.objectives"
-    call parameters%info(path, n_children = n_objectives)
+    if (parameters%valid_path(path)) then
+       call parameters%info(path, n_children = n_objectives)
 
-    ! Grab a single parameters entry and create a constraint from it.
-    do i = 1, n_objectives
-       call json_extract_item(parameters, path, i, objective_json)
-       call json_get(objective_json, "type", type)
-       call neko_log%message(type)
+       ! Grab a single parameters entry and create a constraint from it.
+       do i = 1, n_objectives
+          call json_extract_item(parameters, path, i, objective_json)
+          call json_get(objective_json, "type", type)
+          call neko_log%message(type)
 
-       call objective_factory(objective, objective_json, design, simulation)
-       call this%add_objective(objective)
-
-    end do
+          call objective_factory(objective, objective_json, design, simulation)
+          call this%add_objective(objective)
+       end do
+    end if
 
     call neko_log%end_section()
 
   end subroutine problem_read_objectives
 
   !> Read the constraint from a parameters file.
-  subroutine problem_read_constraints(this, parameters, simulation, design)
+  subroutine problem_read_constraints(this, parameters, design, simulation)
     class(problem_t), intent(inout) :: this
     type(json_file), intent(inout) :: parameters
-    type(simulation_t), intent(inout) :: simulation
     class(design_t), intent(in) :: design
     class(constraint_t), allocatable :: constraint
+    type(simulation_t), optional, intent(inout) :: simulation
 
     ! A single constraint term as its own json_file.
     character(len=:), allocatable :: path, type
@@ -266,18 +267,20 @@ contains
 
     ! Get the number of constraints.
     path = "optimization.constraints"
-    call parameters%info(path, n_children = n_constraints)
 
-    ! Grab a single parameters entry and create a constraint from it.
-    do i = 1, n_constraints
-       call json_extract_item(parameters, path, i, constraint_json)
-       call json_get(constraint_json, "type", type)
-       call neko_log%message(type)
+    if (parameters%valid_path(path)) then
+       call parameters%info(path, n_children = n_constraints)
 
-       call constraint_factory(constraint, constraint_json, design, simulation)
-       call this%add_constraint(constraint)
+       ! Grab a single parameters entry and create a constraint from it.
+       do i = 1, n_constraints
+          call json_extract_item(parameters, path, i, constraint_json)
+          call json_get(constraint_json, "type", type)
+          call neko_log%message(type)
 
-    end do
+          call constraint_factory(constraint, constraint_json, design, simulation)
+          call this%add_constraint(constraint)
+       end do
+    end if
 
     call neko_log%end_section()
 
@@ -286,7 +289,7 @@ contains
   !> Add an objective to the list.
   subroutine problem_add_objective(this, objective)
     class(problem_t), intent(inout) :: this
-    class(objective_t), allocatable, intent(inout) :: objective
+    class(objective_t), intent(inout) :: objective
     class(objective_wrapper_t), allocatable, dimension(:) :: temp_list
     integer :: i, n
 
@@ -305,14 +308,14 @@ contains
        allocate(this%objective_list(1))
     end if
 
-    call move_alloc(objective, this%objective_list(n + 1)%objective)
+    this%objective_list(n + 1)%objective = objective
     this%n_objectives = n + 1
   end subroutine problem_add_objective
 
   !> Add an objective to the list.
   subroutine problem_add_constraint(this, constraint)
     class(problem_t), intent(inout) :: this
-    class(constraint_t), allocatable, intent(inout) :: constraint
+    class(constraint_t), intent(inout) :: constraint
     class(constraint_wrapper_t), allocatable, dimension(:) :: temp_list
     integer :: i, n
 
@@ -331,7 +334,7 @@ contains
        allocate(this%constraint_list(1))
     end if
 
-    call move_alloc(constraint, this%constraint_list(n + 1)%constraint)
+    this%constraint_list(n + 1)%constraint = constraint
     this%n_constraints = n + 1
   end subroutine problem_add_constraint
 


### PR DESCRIPTION
This PR now contain the refactor to make a simulation optional in a given optimizer and problem setup.
Additionally we guard against some missing JSON keys to make sure an empty problem is supported for the user to programmatically construct the problem.