### PR TITLE
Split functional type initializer for simulation handling

### DIFF
--- a/sources/problems/base_functional.f90
+++ b/sources/problems/base_functional.f90
@@ -34,10 +34,12 @@
 module base_functional
   use design, only: design_t
   use json_module, only: json_file
+  use json_utils, only: json_get
   use num_types, only: rp
   use point_zone, only: point_zone_t
   use simulation_m, only: simulation_t
   use vector, only: vector_t
+  use utils, only: neko_error
   implicit none
   private
 
@@ -69,8 +71,12 @@ module base_functional
      ! ----------------------------------------------------------------------- !
      ! Derived class interfaces
 
+     generic :: init => init_json, init_json_sim
+
      !> Constructor
-     procedure(functional_init), pass(this), deferred :: init_json
+     procedure, pass(this) :: init_json => functional_init_json
+     !> Constructor
+     procedure, pass(this) :: init_json_sim => functional_init_json_sim
      !> Destructor
      procedure(functional_free), pass(this), deferred :: free
 
@@ -86,15 +92,6 @@ module base_functional
   ! for the different types of objective functions.
 
   abstract interface
-
-     !> Initialize the objective function
-     subroutine functional_init(this, json, design, simulation)
-       import base_functional_t, design_t, simulation_t, json_file
-       class(base_functional_t), intent(inout) :: this
-       type(json_file), intent(inout) :: json
-       class(design_t), intent(in) :: design
-       type(simulation_t), target, intent(inout) :: simulation
-     end subroutine functional_init
 
      !> Destructor
      subroutine functional_free(this)
@@ -117,5 +114,32 @@ module base_functional
      end subroutine functional_update_sensitivity
 
   end interface
+
+contains
+
+  !> Initialize the objective function
+  subroutine functional_init_json(this, json, design)
+    class(base_functional_t), intent(inout) :: this
+    type(json_file), intent(inout) :: json
+    class(design_t), intent(in) :: design
+    character(len=:), allocatable :: type
+
+    call json_get(json, 'type', type)
+    call neko_error("Functional type: '" // type // &
+         "' does not support initialization without simulation")
+  end subroutine functional_init_json
+
+  !> Initialize the objective function
+  subroutine functional_init_json_sim(this, json, design, simulation)
+    class(base_functional_t), intent(inout) :: this
+    type(json_file), intent(inout) :: json
+    class(design_t), intent(in) :: design
+    type(simulation_t), target, intent(inout) :: simulation
+    character(len=:), allocatable :: type
+
+    call json_get(json, 'type', type)
+    call neko_error("Functional type: '" // type // &
+         "' does not support initialization with simulation")
+  end subroutine functional_init_json_sim
 
 end module base_functional

--- a/sources/problems/constraint.f90
+++ b/sources/problems/constraint.f90
@@ -74,7 +74,7 @@ module constraint
        class(constraint_t), allocatable, intent(inout) :: object
        type(json_file), intent(inout) :: json
        class(design_t), intent(in) :: design
-       type(simulation_t), target, intent(inout) :: simulation
+       type(simulation_t), target, optional, intent(inout) :: simulation
      end subroutine constraint_factory
   end interface
 

--- a/sources/problems/constraint_factory.f90
+++ b/sources/problems/constraint_factory.f90
@@ -59,7 +59,7 @@ contains
     class(constraint_t), allocatable, intent(inout) :: object
     type(json_file), intent(inout) :: json
     class(design_t), intent(in) :: design
-    type(simulation_t), target, intent(inout) :: simulation
+    type(simulation_t), target, optional, intent(inout) :: simulation
     character(len=:), allocatable :: type
 
     if (allocated(object)) then
@@ -75,7 +75,7 @@ contains
        call neko_type_error("Constraint", type, KNOWN_TYPES)
     end select
 
-    call object%init_json(json, design, simulation)
+    call object%init(json, design, simulation)
   end subroutine constraint_factory
 
 end submodule constraint_factory_mod

--- a/sources/problems/constraints/volume_constraint.f90
+++ b/sources/problems/constraints/volume_constraint.f90
@@ -76,8 +76,10 @@ module volume_constraint
      class(coef_t), pointer :: c_Xh => null()
 
    contains
+
      !> The common constructor using a JSON object.
-     procedure, public, pass(this) :: init_json => volume_constraint_init_json
+     procedure, public, pass(this) :: init_json_sim => &
+          volume_constraint_init_json_sim
      !> The direct initializer from attributes.
      procedure, public, pass(this) :: init_from_attributes => &
           volume_constraint_init_attributes
@@ -102,7 +104,7 @@ contains
   !! @param json the JSON object.
   !! @param design the design.
   !! @param simulation the simulation.
-  subroutine volume_constraint_init_json(this, json, design, simulation)
+  subroutine volume_constraint_init_json_sim(this, json, design, simulation)
     class(volume_constraint_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     class(design_t), intent(in) :: design
@@ -120,7 +122,7 @@ contains
 
     call this%init_from_attributes(design, simulation, name, mask_name, &
          is_max, limit)
-  end subroutine volume_constraint_init_json
+  end subroutine volume_constraint_init_json_sim
 
   !> The direct initializer from attributes.
   !! @param this the constraint.

--- a/sources/problems/objective.f90
+++ b/sources/problems/objective.f90
@@ -76,7 +76,7 @@ module objective
        class(objective_t), allocatable, intent(inout) :: object
        type(json_file), intent(inout) :: json
        class(design_t), intent(in) :: design
-       type(simulation_t), target, intent(inout) :: simulation
+       type(simulation_t), target, optional, intent(inout) :: simulation
      end subroutine objective_factory
   end interface
 

--- a/sources/problems/objective_factory.f90
+++ b/sources/problems/objective_factory.f90
@@ -63,7 +63,7 @@ contains
     class(objective_t), allocatable, intent(inout) :: object
     type(json_file), intent(inout) :: json
     class(design_t), intent(in) :: design
-    type(simulation_t), target, intent(inout) :: simulation
+    type(simulation_t), target, optional, intent(inout) :: simulation
     character(len=:), allocatable :: type
 
     if (allocated(object)) then
@@ -84,7 +84,7 @@ contains
        call neko_type_error("Objective", type, KNOWN_TYPES)
     end select
 
-    call object%init_json(json, design, simulation)
+    call object%init(json, design, simulation)
   end subroutine objective_factory
 
 end submodule objective_factory_mod

--- a/sources/problems/objectives/lube_term_objective.f90
+++ b/sources/problems/objectives/lube_term_objective.f90
@@ -108,7 +108,7 @@ module lube_term_objective
    contains
 
      !> The common constructor using a JSON object.
-     procedure, public, pass(this) :: init_json => lube_term_init_json
+     procedure, public, pass(this) :: init_json_sim => lube_term_init_json_sim
      !> The actual constructor.
      procedure, public, pass(this) :: init_from_attributes => &
           lube_term_init_attributes
@@ -130,11 +130,12 @@ contains
   !! @param json the JSON object.
   !! @param design the design.
   !! @param simulation the simulation.
-  subroutine lube_term_init_json(this, json, design, simulation)
+  subroutine lube_term_init_json_sim(this, json, design, simulation)
     class(lube_term_objective_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
+
     character(len=:), allocatable :: mask_name
     character(len=:), allocatable :: name
     real(kind=rp) :: weight, K
@@ -146,7 +147,7 @@ contains
 
     call this%init_from_attributes(design, simulation, weight, name, &
          mask_name, K)
-  end subroutine lube_term_init_json
+  end subroutine lube_term_init_json_sim
 
   !> The actual constructor.
   !! @param this The objective.

--- a/sources/problems/objectives/minimum_dissipation_objective.f90
+++ b/sources/problems/objectives/minimum_dissipation_objective.f90
@@ -112,7 +112,8 @@ module minimum_dissipation_objective
 
    contains
      !> The common constructor using a JSON object.
-     procedure, public, pass(this) :: init_json => minimum_dissipation_init_json
+     procedure, public, pass(this) :: init_json_sim => &
+          minimum_dissipation_init_json_sim
      !> The direct initializer from attributes.
      procedure, public, pass(this) :: init_from_attributes => &
           minimum_dissipation_init_attributes
@@ -134,11 +135,12 @@ contains
   !! @param json the JSON object.
   !! @param design the design.
   !! @param simulation the simulation.
-  subroutine minimum_dissipation_init_json(this, json, design, simulation)
+  subroutine minimum_dissipation_init_json_sim(this, json, design, simulation)
     class(minimum_dissipation_objective_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     class(design_t), intent(in) :: design
     type(simulation_t), target, intent(inout) :: simulation
+
     character(len=:), allocatable :: name
     character(len=:), allocatable :: mask_name
     real(kind=rp) :: weight
@@ -148,7 +150,7 @@ contains
     call json_get_or_default(json, "name", name, "Dissipation")
 
     call this%init_from_attributes(design, simulation, weight, name, mask_name)
-  end subroutine minimum_dissipation_init_json
+  end subroutine minimum_dissipation_init_json_sim
 
   !> The actual constructor.
   !! @param this the objective.

--- a/sources/problems/objectives/scalar_mixing_objective_function.f90
+++ b/sources/problems/objectives/scalar_mixing_objective_function.f90
@@ -80,7 +80,8 @@ module scalar_mixing_objective
    contains
 
      !> The common constructor using a JSON object.
-     procedure, public, pass(this) :: init_json => scalar_mixing_init_json
+     procedure, public, pass(this) :: init_json_sim => &
+          scalar_mixing_init_json_sim
      !> The actual constructor.
      procedure, public, pass(this) :: init_from_attributes => &
           scalar_mixing_init_attributes
@@ -102,7 +103,7 @@ contains
   !! @param json The JSON subdictionary corresponding to your objective
   !! @param design The design
   !! @param simulation The simulation
-  subroutine scalar_mixing_init_json(this, json, design, simulation)
+  subroutine scalar_mixing_init_json_sim(this, json, design, simulation)
     class(scalar_mixing_objective_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     class(design_t), intent(in) :: design
@@ -120,7 +121,7 @@ contains
     ! initialize
     call this%init_from_attributes(design, simulation, weight, name, &
          mask_name, phi_ref)
-  end subroutine scalar_mixing_init_json
+  end subroutine scalar_mixing_init_json_sim
 
   !> The actual constructor.
   !! @param this The object


### PR DESCRIPTION
Refactor the functional type initializer to separate initialization with and without simulation, enhancing clarity and usability. Update related modules to accommodate optional simulation parameters.