### PR TITLE
Fix typo in job target name

### DIFF
--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build documentation
         run: |
-          cmake --build build --target documentation
+          cmake --build build --target Documentation
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Corrected the target name from "documentation" to "Documentation" in the build job.