### PR TITLE
Set default projection space size to 0 for solvers

### DIFF
--- a/examples/brinkman_parameters/default_case/brinkman.template
+++ b/examples/brinkman_parameters/default_case/brinkman.template
@@ -21,14 +21,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },

--- a/examples/brinkman_parameters/default_case/idw.template
+++ b/examples/brinkman_parameters/default_case/idw.template
@@ -21,14 +21,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },

--- a/examples/brinkman_parameters/default_case/meshed.template
+++ b/examples/brinkman_parameters/default_case/meshed.template
@@ -21,14 +21,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },

--- a/examples/easy-E/easy-E_1.case
+++ b/examples/easy-E/easy-E_1.case
@@ -27,14 +27,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },
@@ -83,7 +81,6 @@
             "solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },

--- a/examples/easy-E/easy-E_10.case
+++ b/examples/easy-E/easy-E_10.case
@@ -27,14 +27,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },
@@ -83,7 +81,6 @@
             "solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },

--- a/examples/easy-E/easy-E_20.case
+++ b/examples/easy-E/easy-E_20.case
@@ -27,14 +27,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },
@@ -83,7 +81,6 @@
             "solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },

--- a/examples/mma/default.case
+++ b/examples/mma/default.case
@@ -37,14 +37,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },

--- a/examples/passive_scalar/passive_scalar.case
+++ b/examples/passive_scalar/passive_scalar.case
@@ -22,29 +22,27 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-4,
                 "max_iterations": 50
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-4,
                 "max_iterations": 50
             },
             "boundary_conditions": [
                 {
                     "type": "user_velocity_pointwise",
-                    "zone_indices": [1]
+                    "zone_indices": [ 1 ]
                 },
                 {
                     "type": "no_slip",
-                    "zone_indices": [3, 4, 5, 6]
+                    "zone_indices": [ 3, 4, 5, 6 ]
                 },
                 {
                     "type": "outflow",
-                    "zone_indices": [2]
+                    "zone_indices": [ 2 ]
                 }
             ],
             "output_control": "never",
@@ -55,7 +53,6 @@
             "solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-6,
                 "max_iterations": 50
             },
@@ -65,12 +62,12 @@
             "boundary_conditions": [
                 {
                     "type": "user_pointwise",
-                    "zone_indices": [1]
+                    "zone_indices": [ 1 ]
                 },
                 {
                     "type": "neumann",
                     "flux": 0,
-                    "zone_indices": [2, 3, 4, 5, 6]
+                    "zone_indices": [ 2, 3, 4, 5, 6 ]
                 },
             ],
         },
@@ -80,12 +77,12 @@
                 {
                     "type": "dirichlet",
                     "value": 0,
-                    "zone_indices": [1]
+                    "zone_indices": [ 1 ]
                 },
                 {
                     "type": "neumann",
                     "flux": 0,
-                    "zone_indices": [2, 3, 4, 5, 6]
+                    "zone_indices": [ 2, 3, 4, 5, 6 ]
                 }
             ],
             "initial_condition": {
@@ -96,17 +93,17 @@
         "adjoint_fluid": {
             "initial_condition": {
                 "type": "uniform",
-                "value": [0.0, 0.0, 0.0]
+                "value": [ 0.0, 0.0, 0.0 ]
             },
             "boundary_conditions": [
                 {
                     "type": "no_slip",
-                    "zone_indices": [1, 3, 4, 5, 6]
+                    "zone_indices": [ 1, 3, 4, 5, 6 ]
                 },
                 {
-                     "type": "outflow",
-                     "zone_indices": [2]
-                 }
+                    "type": "outflow",
+                    "zone_indices": [ 2 ]
+                }
             ],
         },
         "simulation_components": [
@@ -128,10 +125,10 @@
                 ],
                 "y_bounds": [
                     -1.0,
-                     3.0,
+                    3.0,
                 ],
                 "z_bounds": [
-                   -1.0,
+                    -1.0,
                     3.0,
                 ],
             },
@@ -144,10 +141,10 @@
                 ],
                 "y_bounds": [
                     -1.0,
-                     3.0,
+                    3.0,
                 ],
                 "z_bounds": [
-                   -1.0,
+                    -1.0,
                     3.0,
                 ],
             },
@@ -157,10 +154,10 @@
         "domain": {
             "type": "point_zone",
             "zone_name": "optimization_domain"
-            },
+        },
         "design": {
             "type": "brinkman",
-            "mapping" : [
+            "mapping": [
                 {
                     "type": "PDE_filter",
                     "r": 0.05

--- a/examples/power_iterations/ext_cyl.case
+++ b/examples/power_iterations/ext_cyl.case
@@ -30,14 +30,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-6,
                 "max_iterations": 800
             },

--- a/examples/rugby_ball/rugby_ball.case
+++ b/examples/rugby_ball/rugby_ball.case
@@ -41,14 +41,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-6,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-4,
                 "max_iterations": 800
             },
@@ -90,8 +88,8 @@
             {
                 "name": "initial_ball",
                 "geometry": "cylinder",
-                "start": [0.5, 0.5, -0.5],
-                "end": [0.5, 0.5, 1.5],
+                "start": [ 0.5, 0.5, -0.5 ],
+                "end": [ 0.5, 0.5, 1.5 ],
                 "radius": 0.25
             },
         ]

--- a/examples/rugby_verification/rugby_ball.case
+++ b/examples/rugby_verification/rugby_ball.case
@@ -36,14 +36,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-6,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-4,
                 "max_iterations": 800
             },
@@ -85,8 +83,8 @@
             {
                 "name": "initial_ball",
                 "geometry": "cylinder",
-                "start": [0.5, 0.5, -0.5],
-                "end": [0.5, 0.5, 1.5],
+                "start": [ 0.5, 0.5, -0.5 ],
+                "end": [ 0.5, 0.5, 1.5 ],
                 "radius": 0.25
             },
         ]
@@ -98,7 +96,7 @@
         },
         "design": {
             "type": "brinkman",
-            "mapping" : [
+            "mapping": [
                 {
                     "type": "PDE_filter",
                     "r": 0.01

--- a/examples/thermal_mix_channel/laminar.case
+++ b/examples/thermal_mix_channel/laminar.case
@@ -25,14 +25,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },
@@ -66,7 +64,6 @@
             "solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },

--- a/examples/thermal_mix_channel/turbulent.case
+++ b/examples/thermal_mix_channel/turbulent.case
@@ -25,14 +25,12 @@
             "velocity_solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },
             "pressure_solver": {
                 "type": "gmres",
                 "preconditioner": "hsmg",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-7,
                 "max_iterations": 800
             },
@@ -66,7 +64,6 @@
             "solver": {
                 "type": "cg",
                 "preconditioner": "jacobi",
-                "projection_space_size": 0,
                 "absolute_tolerance": 1e-8,
                 "max_iterations": 800
             },


### PR DESCRIPTION
Update the default projection space size to 0 in the configuration for both velocity and pressure solvers, simplifying the examples.