### PR TITLE
avoid masked kernel launches when no GLL pts are in the mask

### DIFF
--- a/sources/neko_ext/math/bcknd/device/cuda/math_ext.cu
+++ b/sources/neko_ext/math/bcknd/device/cuda/math_ext.cu
@@ -51,7 +51,7 @@ void cuda_copy_mask(void* a, void* b, int* size, int* mask, int* mask_size) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
-    if(*mask_size == 0) return;
+    if (*mask_size == 0) return;
     copy_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, (real*)b, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
@@ -64,7 +64,7 @@ void cuda_cadd_mask(void* a, real* c, int* size, int* mask, int* mask_size) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
-    if(*mask_size == 0) return;
+    if (*mask_size == 0) return;
     cadd_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, *c, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
@@ -77,7 +77,7 @@ void cuda_invcol1_mask(void* a, int* size, int* mask, int* mask_size) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
-    if(*mask_size == 0) return;
+    if (*mask_size == 0) return;
     invcol1_mask_kernel<real>
         <<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
             (real*)a, *size, mask, *mask_size);
@@ -91,7 +91,7 @@ void cuda_col2_mask(void* a, void* b, int* size, int* mask, int* mask_size) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
-    if(*mask_size == 0) return;
+    if (*mask_size == 0) return;
     col2_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, (real*)b, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
@@ -105,7 +105,7 @@ void cuda_col3_mask(
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
-    if(*mask_size == 0) return;
+    if (*mask_size == 0) return;
     col3_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, (real*)b, (real*)c, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
@@ -119,7 +119,7 @@ void cuda_sub3_mask(
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
-    if(*mask_size == 0) return;
+    if (*mask_size == 0) return;
     sub3_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, (real*)b, (real*)c, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());

--- a/sources/neko_ext/math/bcknd/device/cuda/math_ext.cu
+++ b/sources/neko_ext/math/bcknd/device/cuda/math_ext.cu
@@ -51,6 +51,7 @@ void cuda_copy_mask(void* a, void* b, int* size, int* mask, int* mask_size) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
+    if(*mask_size == 0) return;
     copy_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, (real*)b, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
@@ -63,6 +64,7 @@ void cuda_cadd_mask(void* a, real* c, int* size, int* mask, int* mask_size) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
+    if(*mask_size == 0) return;
     cadd_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, *c, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
@@ -75,6 +77,7 @@ void cuda_invcol1_mask(void* a, int* size, int* mask, int* mask_size) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
+    if(*mask_size == 0) return;
     invcol1_mask_kernel<real>
         <<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
             (real*)a, *size, mask, *mask_size);
@@ -88,6 +91,7 @@ void cuda_col2_mask(void* a, void* b, int* size, int* mask, int* mask_size) {
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
+    if(*mask_size == 0) return;
     col2_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, (real*)b, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
@@ -101,6 +105,7 @@ void cuda_col3_mask(
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
+    if(*mask_size == 0) return;
     col3_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, (real*)b, (real*)c, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());
@@ -114,6 +119,7 @@ void cuda_sub3_mask(
     const dim3 nthrds(1024, 1, 1);
     const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
 
+    if(*mask_size == 0) return;
     sub3_mask_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
         (real*)a, (real*)b, (real*)c, *size, mask, *mask_size);
     CUDA_CHECK(cudaGetLastError());


### PR DESCRIPTION
This is small PR that was found as part of #162 but should be corrected for cuda first.

Essentially, if your partition contains no elements inside the mask, the you launch a kernel of zero size. This PR avoids this edge case.