### PR TITLE
Fix ramp mapping kernel

### DIFF
--- a/sources/mapping_functions/bcknd/device/cuda/RAMP_mapping_kernel.h
+++ b/sources/mapping_functions/bcknd/device/cuda/RAMP_mapping_kernel.h
@@ -48,7 +48,7 @@ __global__ void convex_down_RAMP_mapping_apply_kernel(
 
     for (int i = idx; i < n; i += str) {
         X_out_d[i] = f_min 
-            + (f_max - f_min) * X_in_d[i] / (1.0 + q * (1.0 + X_in_d[i]));
+            + (f_max - f_min) * X_in_d[i] / (1.0 + q * (1.0 - X_in_d[i]));
     }
 }
 


### PR DESCRIPTION
corrects a sign error in ramp kernel:

CPU:
```fortran
       do i = 1, n
          X_out%x(i,1,1,1) = f_min + (f_max - f_min) * &
               X_in%x(i,1,1,1) / (1.0_rp + q * (1.0_rp - X_in%x(i,1,1,1) ) )
       end do
```