### PR TITLE
Fix scaling of diffusion factor `r`

### DIFF
--- a/sources/mapping_functions/PDE_filter_mapping.f90
+++ b/sources/mapping_functions/PDE_filter_mapping.f90
@@ -150,7 +150,7 @@ contains
     character(len=*), intent(in) :: ksp_solver, precon_type
     integer :: n
 
-    this%r = r
+    this%r = r / (2.0_rp * sqrt(3.0_rp))
     this%abstol_filt = tol
     this%ksp_max_iter = max_iter
     this%ksp_solver = ksp_solver


### PR DESCRIPTION
`r` now directly specify the intended filter radius, not the diffusion factor.