### PR TITLE
Fix user singleton references in adjoint case

### DIFF
--- a/sources/adjoint/adjoint_case.f90
+++ b/sources/adjoint/adjoint_case.f90
@@ -141,7 +141,7 @@ contains
     call json_get(neko_case%params, 'case.numerics.polynomial_order', lx)
     lx = lx + 1 ! add 1 to get number of gll points
     call this%fluid_adj%init(neko_case%msh, lx, neko_case%params, &
-         neko_case%usr, neko_case%fluid%ext_bdf)
+         neko_case%user, neko_case%fluid%ext_bdf)
     !
     ! Setup adjoint scalar
     !
@@ -162,7 +162,7 @@ contains
        ! this%scalar_adj%chkp%tlag => neko_case%tlag
        ! this%scalar_adj%chkp%dtlag => neko_case%dtlag
        call this%scalar_adj%init(neko_case%msh, neko_case%fluid%c_Xh, &
-            neko_case%fluid%gs_Xh, neko_case%params, neko_case%usr, &
+            neko_case%fluid%gs_Xh, neko_case%params, neko_case%user, &
             neko_case%fluid%ulag, neko_case%fluid%vlag, &
             neko_case%fluid%wlag, neko_case%fluid%ext_bdf, neko_case%fluid%rho)
 
@@ -218,13 +218,13 @@ contains
     !    call json_get(neko_case%params, 'case.fluid.inflow_condition.type', &
     !         string_val)
     !    if (trim(string_val) .eq. 'user') then
-    !       call neko_case%fluid%set_usr_inflow(neko_case%usr%fluid_user_if)
+    !       call neko_case%fluid%set_usr_inflow(neko_case%user%fluid_user_if)
     !    end if
     ! end if
 
     ! Setup user boundary conditions for the scalar.
     ! if (scalar_adj) then
-    !    call neko_case%scalar_adj%set_user_bc(neko_case%usr%scalar_user_bc)
+    !    call neko_case%scalar_adj%set_user_bc(neko_case%user%scalar_user_bc)
     ! end if
 
     !
@@ -245,7 +245,7 @@ contains
        call set_flow_ic( &
             this%fluid_adj%u_adj, this%fluid_adj%v_adj, this%fluid_adj%w_adj, &
             this%fluid_adj%p_adj, this%fluid_adj%c_Xh, this%fluid_adj%gs_Xh, &
-            neko_case%usr%fluid_user_ic, neko_case%params)
+            neko_case%user%fluid_user_ic, neko_case%params)
     end if
 
     call neko_log%end_section()

--- a/sources/adjoint/simulation_adjoint.f90
+++ b/sources/adjoint/simulation_adjoint.f90
@@ -95,7 +95,7 @@ contains
     ! HARRY
     ! ok this I guess this is techincally where we set the initial condition
     ! of adjoint yeh?
-    call this%case%usr%user_init_modules(t_adj, this%fluid_adj%u_adj, &
+    call this%case%user%user_init_modules(t_adj, this%fluid_adj%u_adj, &
          this%fluid_adj%v_adj, this%fluid_adj%w_adj,&
          this%fluid_adj%p_adj, this%fluid_adj%c_Xh, this%case%params)
     call neko_log%end_section()
@@ -166,7 +166,7 @@ contains
        call simulation_joblimit_chkp(this%case, t_adj)
     end if
 
-    call this%case%usr%user_finalize_modules(t_adj, this%case%params)
+    call this%case%user%user_finalize_modules(t_adj, this%case%params)
 
     call neko_log%end_section('Normal end.')
 

--- a/sources/drivers/neko-user.f90
+++ b/sources/drivers/neko-user.f90
@@ -7,7 +7,7 @@ program usrneko
   type(case_t), target :: C
 
   call neko_top_register_types()
-  call user_setup(C%usr)
+  call user_setup(C%user)
   call neko_init(C)
   call neko_solve(C)
   call neko_finalize(C)

--- a/sources/drivers/topopt-user.f90
+++ b/sources/drivers/topopt-user.f90
@@ -49,7 +49,7 @@ program topopt_user
   ! Initialization of the components
 
   ! initialize the user additions for the forward (through the neko interface)
-  call user_setup(sim%neko_case%usr)
+  call user_setup(sim%neko_case%user)
 
   ! initialize the simulation
   call sim%init(parameters)

--- a/sources/neko_ext/neko_ext.f90
+++ b/sources/neko_ext/neko_ext.f90
@@ -116,7 +116,7 @@ contains
     else
        call set_flow_ic(u, v, w, p, &
             neko_case%fluid%c_Xh, neko_case%fluid%gs_Xh, &
-            neko_case%usr%fluid_user_ic, neko_case%params)
+            neko_case%user%fluid_user_ic, neko_case%params)
     end if
 
     ! ------------------------------------------------------------------------ !
@@ -140,7 +140,7 @@ contains
        else
           call set_scalar_ic(s, &
                neko_case%scalar%c_Xh, neko_case%scalar%gs_Xh, &
-               neko_case%usr%scalar_user_ic, &
+               neko_case%user%scalar_user_ic, &
                neko_case%params)
        end if
     end if

--- a/sources/topology_optimization/user_module.f90
+++ b/sources/topology_optimization/user_module.f90
@@ -40,7 +40,7 @@ contains
     type(case_t), intent(inout) :: neko_case
 
     ! Set the properties for the fluid
-    neko_case%usr%scalar_user_ic => scalar_z_split_ic
+    neko_case%user%scalar_user_ic => scalar_z_split_ic
 
   end subroutine neko_user_init
 


### PR DESCRIPTION
Update references from `usr` to `user` in the adjoint case initialization and related functions to ensure consistency and correctness in the codebase.