### PR TITLE
Reset time for adjoint case in simulation reset

### DIFF
--- a/sources/simulation/simulation.f90
+++ b/sources/simulation/simulation.f90
@@ -208,6 +208,9 @@ contains
     ! TODO
     ! reset for the adjoint
     ! call reset(this%adjoint_case)
+    this%adjoint_case%time%t = 0.0_dp
+    this%adjoint_case%time%tstep = 0
+
     call field_rzero(this%adjoint_case%fluid_adj%u_adj)
     call field_rzero(this%adjoint_case%fluid_adj%v_adj)
     call field_rzero(this%adjoint_case%fluid_adj%w_adj)


### PR DESCRIPTION
Ensure that the time and time step for the adjoint case are reset to their initial values during the simulation reset process.