### PR TITLE
Realign file handling with neko PR 1945

### DIFF
--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -489,7 +489,7 @@ contains
     ! Build the header
     call json_get_or_default(params, 'output_file', &
          file_name, 'power_iterations.csv')
-    this%file_output = file_t(trim(file_name))
+    call this%file_output%init(trim(file_name))
     write(header_line, '(A)') 'Time, Norm, Scaling'
     call this%file_output%set_header(header_line)
 
@@ -1222,7 +1222,7 @@ contains
     end do
 
 
-    bdry_file = file_t('boundary_adjoint.fld')
+    call bdry_file%init('boundary_adjoint.fld')
     call bdry_file%write(bdry_field)
 
     call this%scratch%relinquish_field(temp_index)

--- a/sources/adjoint/simulation_adjoint.f90
+++ b/sources/adjoint/simulation_adjoint.f90
@@ -224,7 +224,7 @@ contains
     call C%case%params%get('case.restart_mesh_file', restart_mesh_file, found)
 
     if (found) then
-       previous_meshf = file_t(trim(restart_mesh_file))
+       call previous_meshf%init(trim(restart_mesh_file))
        call previous_meshf%read(C%fluid_adj%chkp%previous_mesh)
     end if
 
@@ -232,7 +232,7 @@ contains
 
     if (found) C%case%fluid%chkp%mesh2mesh_tol = tol
 
-    chkpf = file_t(trim(restart_file))
+    call chkpf%init(trim(restart_file))
     call chkpf%read(C%fluid_adj%chkp)
     C%time%dtlag = C%fluid_adj%chkp%dtlag
     C%time%tlag = C%fluid_adj%chkp%tlag
@@ -277,7 +277,7 @@ contains
           format_str = '.h5'
        end if
     end if
-    chkpf = file_t(C%case%output_directory // 'joblimit' // trim(format_str))
+    call chkpf%init(C%case%output_directory // 'joblimit' // trim(format_str))
     call chkpf%write(C%case%fluid%chkp, t)
     write(log_buf, '(A)') '! saving checkpoint >>>'
     call neko_log%message(log_buf)

--- a/sources/designs/set_optimization_ic.f90
+++ b/sources/designs/set_optimization_ic.f90
@@ -265,7 +265,7 @@ contains
     call filename_chsuffix(file_name, trim(file_name), 'fld')
 
     call fld_data%init()
-    f = file_t(trim(file_name))
+    call f%init(trim(file_name))
 
     if (interpolate) then
 


### PR DESCRIPTION
Refactor file initialization calls to use the `init` method instead of direct instantiation, improving consistency across the codebase.