### PR TITLE
Realign with Neko PR #1954

### DIFF
--- a/examples/mma/mma_simcomp.f90
+++ b/examples/mma/mma_simcomp.f90
@@ -82,7 +82,7 @@ module mma_simcomp
 contains
   ! Constructor from json.
   subroutine simcomp_test_init_from_json(this, json, case)
-    class(mma_comp_t), intent(inout) :: this
+    class(mma_comp_t), intent(inout), target :: this
     type(json_file), intent(inout) :: json
     class(case_t), intent(inout), target :: case
     integer :: nloc

--- a/examples/mma_cpu/mma_simcomp.f90
+++ b/examples/mma_cpu/mma_simcomp.f90
@@ -82,7 +82,7 @@ module mma_simcomp
 contains
   ! Constructor from json.
   subroutine simcomp_test_init_from_json(this, json, case)
-    class(mma_comp_t), intent(inout) :: this
+    class(mma_comp_t), intent(inout), target :: this
     type(json_file), intent(inout) :: json
     class(case_t), intent(inout), target :: case
     integer :: nloc

--- a/sources/simulation_components/steady_simcomp.f90
+++ b/sources/simulation_components/steady_simcomp.f90
@@ -86,7 +86,7 @@ contains
 
   ! Constructor from json.
   subroutine steady_simcomp_init_from_json(this, json, case)
-    class(steady_simcomp_t), intent(inout) :: this
+    class(steady_simcomp_t), intent(inout), target :: this
     type(json_file), intent(inout) :: json
     class(case_t), intent(inout), target :: case
     real(kind=dp) :: tol


### PR DESCRIPTION
Update the `this` parameter in constructors to include the `target` attribute for better compatibility with the Neko changes.