### PR TITLE
Realign source term initialization with Neko PR #1947

### DIFF
--- a/sources/source_terms/adjoint_lube_source_term.f90
+++ b/sources/source_terms/adjoint_lube_source_term.f90
@@ -97,11 +97,13 @@ contains
   !! @param json The JSON object for the source.
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
-  subroutine adjoint_lube_source_term_init_from_json(this, json, fields, coef)
+  subroutine adjoint_lube_source_term_init_from_json(this, json, fields, coef, &
+       variable_name)
     class(adjoint_lube_source_term_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     type(field_list_t), intent(in), target :: fields
     type(coef_t), intent(in), target :: coef
+    character(len=*), intent(in) :: variable_name
     ! real(kind=rp), allocatable :: values(:)
     ! real(kind=rp) :: start_time, end_time
 

--- a/sources/source_terms/adjoint_lube_source_term.f90
+++ b/sources/source_terms/adjoint_lube_source_term.f90
@@ -97,6 +97,7 @@ contains
   !! @param json The JSON object for the source.
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
+  !! @param variable_name The name of the variable where the source term acts.
   subroutine adjoint_lube_source_term_init_from_json(this, json, fields, coef, &
        variable_name)
     class(adjoint_lube_source_term_t), intent(inout) :: this

--- a/sources/source_terms/adjoint_minimum_dissipation_source_term.f90
+++ b/sources/source_terms/adjoint_minimum_dissipation_source_term.f90
@@ -103,11 +103,12 @@ contains
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
   subroutine adjoint_minimum_dissipation_source_term_init_from_json(this, &
-       json, fields, coef)
+       json, fields, coef, variable_name)
     class(adjoint_minimum_dissipation_source_term_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     type(field_list_t), intent(in), target :: fields
     type(coef_t), intent(in), target :: coef
+    character(len=*), intent(in) :: variable_name
 
     ! we shouldn't be initializing this from JSON
     ! maybe throw an error?

--- a/sources/source_terms/adjoint_minimum_dissipation_source_term.f90
+++ b/sources/source_terms/adjoint_minimum_dissipation_source_term.f90
@@ -102,6 +102,7 @@ contains
   !! @param this The source term.
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
+  !! @param variable_name The name of the variable where the source term acts.
   subroutine adjoint_minimum_dissipation_source_term_init_from_json(this, &
        json, fields, coef, variable_name)
     class(adjoint_minimum_dissipation_source_term_t), intent(inout) :: this

--- a/sources/source_terms/adjoint_mixing_scalar_source_term.f90
+++ b/sources/source_terms/adjoint_mixing_scalar_source_term.f90
@@ -90,6 +90,7 @@ contains
   !! @param json The JSON object for the source.
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
+  !! @param variable_name The name of the variable where the source term acts.
   subroutine adjoint_mixing_scalar_source_term_init_from_json(this, &
        json, fields, coef, variable_name)
     class(adjoint_mixing_scalar_source_term_t), intent(inout) :: this

--- a/sources/source_terms/adjoint_mixing_scalar_source_term.f90
+++ b/sources/source_terms/adjoint_mixing_scalar_source_term.f90
@@ -91,11 +91,12 @@ contains
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
   subroutine adjoint_mixing_scalar_source_term_init_from_json(this, &
-       json, fields, coef)
+       json, fields, coef, variable_name)
     class(adjoint_mixing_scalar_source_term_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     type(field_list_t), intent(in), target :: fields
     type(coef_t), intent(in), target :: coef
+    character(len=*), intent(in) :: variable_name
 
 
   end subroutine adjoint_mixing_scalar_source_term_init_from_json

--- a/sources/source_terms/adjoint_scalar_convection_source_term.f90
+++ b/sources/source_terms/adjoint_scalar_convection_source_term.f90
@@ -80,6 +80,7 @@ contains
   !! @param json The JSON object for the source.
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
+  !! @param variable_name The name of the variable where the source term acts.
   subroutine adjoint_scalar_convection_source_term_init_from_json(this, &
        json, fields, coef, variable_name)
     class(adjoint_scalar_convection_source_term_t), intent(inout) :: this

--- a/sources/source_terms/adjoint_scalar_convection_source_term.f90
+++ b/sources/source_terms/adjoint_scalar_convection_source_term.f90
@@ -81,11 +81,12 @@ contains
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
   subroutine adjoint_scalar_convection_source_term_init_from_json(this, &
-       json, fields, coef)
+       json, fields, coef, variable_name)
     class(adjoint_scalar_convection_source_term_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     type(field_list_t), intent(in), target :: fields
     type(coef_t), intent(in), target :: coef
+    character(len=*), intent(in) :: variable_name
 
     ! this is a bit weird... because I don't think this should come from the
     ! JSON.

--- a/sources/source_terms/simple_brinkman_source_term.f90
+++ b/sources/source_terms/simple_brinkman_source_term.f90
@@ -77,6 +77,7 @@ contains
   !! @param json The JSON object for the source.
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
+  !! @param variable_name The name of the variable where the source term acts.
   subroutine simple_brinkman_source_term_init_from_json(this, json, fields, &
        coef, variable_name)
     class(simple_brinkman_source_term_t), intent(inout) :: this

--- a/sources/source_terms/simple_brinkman_source_term.f90
+++ b/sources/source_terms/simple_brinkman_source_term.f90
@@ -78,11 +78,12 @@ contains
   !! @param fields A list of fields for adding the source values.
   !! @param coef The SEM coeffs.
   subroutine simple_brinkman_source_term_init_from_json(this, json, fields, &
-       coef)
+       coef, variable_name)
     class(simple_brinkman_source_term_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
     type(field_list_t), intent(in), target :: fields
     type(coef_t), intent(in), target :: coef
+    character(len=*), intent(in) :: variable_name
 
 
     ! we shouldn't be initializing this from JSON


### PR DESCRIPTION
Update the initialization subroutines for various source terms to include a new parameter, `variable_name`, aligning with changes made in Neko PR #1947. This enhances the flexibility of the initialization process.