### PR TITLE
Fix argument changes in fluid and scalar step info calls

### DIFF
--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -853,7 +853,7 @@ contains
 
       end if
 
-      call fluid_step_info(tstep, t, dt, ksp_results, &
+      call fluid_step_info(time, ksp_results, &
            this%full_stress_formulation, this%strict_convergence)
 
     end associate

--- a/sources/adjoint/adjoint_scalar_pnpn.f90
+++ b/sources/adjoint/adjoint_scalar_pnpn.f90
@@ -446,7 +446,7 @@ contains
          call add2s2(s_adj%x, ds_adj%x, 1.0_rp, n)
       end if
 
-      call scalar_step_info(tstep, t, dt, ksp_results)
+      call scalar_step_info(time, ksp_results)
 
     end associate
     call profiler_end_region('Scalar', 2)


### PR DESCRIPTION
Update the calls to `fluid_step_info` and `scalar_step_info` to use `time` instead of `tstep`, `t`, and `dt`, aligning with changes made in the Neko PR #1968.