### PR TITLE
Add Krylov names to fluid and scalar results

### DIFF
--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -837,6 +837,11 @@ contains
            this%ksp_vel%max_iter)
       call profiler_end_region("Velocity_solve", 4)
 
+      ksp_results(1)%name = 'Adjoint Pressure'
+      ksp_results(2)%name = 'Adjoint Velocity U'
+      ksp_results(3)%name = 'Adjoint Velocity V'
+      ksp_results(4)%name = 'Adjoint Velocity W'
+
       call this%proj_vel%post_solving(du%x, dv%x, dw%x, Ax_vel, c_Xh, &
            this%bclst_du, this%bclst_dv, this%bclst_dw, gs_Xh, n, tstep, &
            dt_controller)

--- a/sources/adjoint/adjoint_scalar_pnpn.f90
+++ b/sources/adjoint/adjoint_scalar_pnpn.f90
@@ -436,6 +436,8 @@ contains
            c_Xh, this%bclst_ds, gs_Xh)
       call profiler_end_region('Adjoint_scalar_solve', 21)
 
+      ksp_results(1)%name = 'Adjoint Scalar'
+
       call this%proj_s%post_solving(ds_adj%x, Ax, c_Xh, this%bclst_ds, gs_Xh, &
            n, tstep, dt_controller)
 


### PR DESCRIPTION
Include missing Krylov names for adjoint pressure, velocity, and scalar results in the respective files.