### PR TITLE
factor of 1/2 in minimum dissipation

### DIFF
--- a/sources/problems/objectives/minimum_dissipation_objective.f90
+++ b/sources/problems/objectives/minimum_dissipation_objective.f90
@@ -272,6 +272,8 @@ contains
        end if
     end if
 
+    this%value = this%value * 0.5_rp
+
     call neko_scratch_registry%relinquish_field(temp_indices)
 
   end subroutine minimum_dissipation_update_value


### PR DESCRIPTION
This PR includes the factor of 1/2 in this minimum dissipation objective (as written in the documentation)

**note** this is now consistent with the `adjoint_minimum_dissipation_source_term` which should not contain this factor of 1/2.