### PR TITLE
Reduce memory leaks and fix bugs in classes

### DIFF
--- a/sources/designs/design.f90
+++ b/sources/designs/design.f90
@@ -92,11 +92,14 @@ module design
      !> Retrieve the design variables.
      procedure(design_get_values), public, pass(this), deferred :: get_values
      !> Retrieve the x location of the design variables.
-     generic :: get_x => design_get_x, design_get_x_i
+     procedure, pass(this) :: get_x => design_get_x
+     procedure, pass(this) :: x => design_get_x_i
      !> Retrieve the y location of the design variables.
-     generic :: get_y => design_get_y, design_get_y_i
+     procedure, pass(this) :: get_y => design_get_y
+     procedure, pass(this) :: y => design_get_y_i
      !> Retrieve the z location of the design variables.
-     generic :: get_z => design_get_z, design_get_z_i
+     procedure, pass(this) :: get_z => design_get_z
+     procedure, pass(this) :: z => design_get_z_i
 
      !> Update the design variables.
      procedure(design_update_design), public, pass(this), deferred :: &
@@ -167,11 +170,11 @@ module design
        class(design_t), intent(inout) :: this
      end subroutine design_free
 
-     function design_get_values(this) result(values)
+     subroutine design_get_values(this, values)
        import design_t, vector_t
        class(design_t), intent(in) :: this
-       type(vector_t) :: values
-     end function design_get_values
+       type(vector_t), intent(inout) :: values
+     end subroutine design_get_values
 
      subroutine design_update_design(this, values)
        import design_t, vector_t
@@ -265,11 +268,11 @@ contains
     n = this%n_global
   end function design_size_global
 
-  function design_get_x(this) result(values)
+  subroutine design_get_x(this, x)
     class(design_t), intent(in) :: this
-    type(vector_t) :: values
+    type(vector_t), intent(inout) :: x
     call neko_error("Design type does not support x retrieval")
-  end function design_get_x
+  end subroutine design_get_x
 
   function design_get_x_i(this, i) result(x_i)
     class(design_t), intent(in) :: this
@@ -279,11 +282,11 @@ contains
     call neko_error("Design type does not support x retrieval")
   end function design_get_x_i
 
-  function design_get_y(this) result(values)
+  subroutine design_get_y(this, y)
     class(design_t), intent(in) :: this
-    type(vector_t) :: values
+    type(vector_t), intent(inout) :: y
     call neko_error("Design type does not support y retrieval")
-  end function design_get_y
+  end subroutine design_get_y
 
   function design_get_y_i(this, i) result(y_i)
     class(design_t), intent(in) :: this
@@ -293,11 +296,11 @@ contains
     call neko_error("Design type does not support y retrieval")
   end function design_get_y_i
 
-  function design_get_z(this) result(values)
+  subroutine design_get_z(this, z)
     class(design_t), intent(in) :: this
-    type(vector_t) :: values
+    type(vector_t), intent(inout) :: z
     call neko_error("Design type does not support z retrieval")
-  end function design_get_z
+  end subroutine design_get_z
 
   function design_get_z_i(this, i) result(z_i)
     class(design_t), intent(in) :: this

--- a/sources/designs/design_brinkman.f90
+++ b/sources/designs/design_brinkman.f90
@@ -444,9 +444,9 @@ contains
 
   end subroutine brinkman_design_map_forward
 
-  function brinkman_design_get_design(this) result(values)
+  subroutine brinkman_design_get_design(this, values)
     class(brinkman_design_t), intent(in) :: this
-    type(vector_t) :: values
+    type(vector_t), intent(inout) :: values
     integer :: n
 
     n = this%size()
@@ -456,11 +456,11 @@ contains
        call device_copy(values%x_d, this%design_indicator%x_d, n)
     end if
 
-  end function brinkman_design_get_design
+  end subroutine brinkman_design_get_design
 
-  function brinkman_design_get_x(this) result(x)
+  subroutine brinkman_design_get_x(this, x)
     class(brinkman_design_t), intent(in) :: this
-    type(vector_t) :: x
+    type(vector_t), intent(inout) :: x
     integer :: n
 
     n = this%size()
@@ -470,7 +470,7 @@ contains
        call device_copy(x%x_d, this%design_indicator%dof%x_d, n)
     end if
 
-  end function brinkman_design_get_x
+  end subroutine brinkman_design_get_x
 
   function brinkman_design_get_x_i(this, i) result(x_i)
     class(brinkman_design_t), intent(in) :: this
@@ -487,9 +487,9 @@ contains
 
   end function brinkman_design_get_x_i
 
-  function brinkman_design_get_y(this) result(y)
+  subroutine brinkman_design_get_y(this, y)
     class(brinkman_design_t), intent(in) :: this
-    type(vector_t) :: y
+    type(vector_t), intent(inout) :: y
     integer :: n
 
     n = this%size()
@@ -499,7 +499,7 @@ contains
        call device_copy(y%x_d, this%design_indicator%dof%y_d, n)
     end if
 
-  end function brinkman_design_get_y
+  end subroutine brinkman_design_get_y
 
   function brinkman_design_get_y_i(this, i) result(y_i)
     class(brinkman_design_t), intent(in) :: this
@@ -516,9 +516,9 @@ contains
 
   end function brinkman_design_get_y_i
 
-  function brinkman_design_get_z(this) result(z)
+  subroutine brinkman_design_get_z(this, z)
     class(brinkman_design_t), intent(in) :: this
-    type(vector_t) :: z
+    type(vector_t), intent(inout) :: z
     integer :: n
 
     n = this%size()
@@ -528,7 +528,7 @@ contains
        call device_copy(z%x_d, this%design_indicator%dof%z_d, n)
     end if
 
-  end function brinkman_design_get_z
+  end subroutine brinkman_design_get_z
 
   function brinkman_design_get_z_i(this, i) result(z_i)
     class(brinkman_design_t), intent(in) :: this

--- a/sources/designs/design_simple.f90
+++ b/sources/designs/design_simple.f90
@@ -64,9 +64,9 @@ module simple_design
      private
 
      type(vector_t) :: values
-     type(vector_t) :: x
-     type(vector_t) :: y
-     type(vector_t) :: z
+     type(vector_t) :: x_coord
+     type(vector_t) :: y_coord
+     type(vector_t) :: z_coord
 
    contains
 
@@ -170,9 +170,9 @@ contains
     call this%init_base(name, n)
 
     call this%values%init(n)
-    this%x = x
-    this%y = y
-    this%z = z
+    this%x_coord = x
+    this%y_coord = y
+    this%z_coord = z
 
   end subroutine design_simple_init_from_components
 
@@ -182,9 +182,9 @@ contains
 
     call this%free_base()
     call this%values%free()
-    call this%x%free()
-    call this%y%free()
-    call this%z%free()
+    call this%x_coord%free()
+    call this%y_coord%free()
+    call this%z_coord%free()
 
   end subroutine design_simple_free
 
@@ -203,37 +203,37 @@ contains
 
   end subroutine design_simple_map_forward
 
-  function design_simple_get_values(this) result(values)
+  subroutine design_simple_get_values(this, values)
     class(simple_design_t), intent(in) :: this
-    type(vector_t) :: values
+    type(vector_t), intent(inout) :: values
 
     values = this%values
 
-  end function design_simple_get_values
+  end subroutine design_simple_get_values
 
-  function design_simple_get_x(this) result(x)
+  subroutine design_simple_get_x(this, x)
     class(simple_design_t), intent(in) :: this
-    type(vector_t) :: x
+    type(vector_t), intent(inout) :: x
 
-    x = this%x
+    x = this%x_coord
 
-  end function design_simple_get_x
+  end subroutine design_simple_get_x
 
-  function design_simple_get_y(this) result(y)
+  subroutine design_simple_get_y(this, y)
     class(simple_design_t), intent(in) :: this
-    type(vector_t) :: y
+    type(vector_t), intent(inout) :: y
 
-    y = this%y
+    y = this%y_coord
 
-  end function design_simple_get_y
+  end subroutine design_simple_get_y
 
-  function design_simple_get_z(this) result(z)
+  subroutine design_simple_get_z(this, z)
     class(simple_design_t), intent(in) :: this
-    type(vector_t) :: z
+    type(vector_t), intent(inout) :: z
 
-    z = this%z
+    z = this%z_coord
 
-  end function design_simple_get_z
+  end subroutine design_simple_get_z
 
   subroutine design_simple_update_design(this, values)
     class(simple_design_t), intent(inout) :: this

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -91,7 +91,7 @@ contains
          ', KKTmax, KKTnorm2, scaling factor'
     call this%logger%set_header(trim(optimization_header))
 
-    x = design%get_values()
+    call design%get_values(x)
 
     if (pe_rank .eq. 0) then
        print *, "Initializing mma_optimizer with steady_state_problem_t."
@@ -187,7 +187,7 @@ contains
           scaling_factor = abs(this%scale)
        end if
 
-       x = design%get_values()
+       call design%get_values(x)
 
        call vector_cmult(constraint_value, scaling_factor)
 

--- a/sources/problems/base_functional.f90
+++ b/sources/problems/base_functional.f90
@@ -158,10 +158,10 @@ contains
   end function functional_get_value
 
   !> Get the sensitivity of the function
-  function functional_get_sensitivity(this) result(sensitivity)
+  subroutine functional_get_sensitivity(this, sensitivity)
     class(base_functional_t), intent(in) :: this
-    type(vector_t) :: sensitivity
+    type(vector_t), intent(inout) :: sensitivity
 
     sensitivity = this%sensitivity
-  end function functional_get_sensitivity
+  end subroutine functional_get_sensitivity
 end module base_functional

--- a/sources/problems/objective.f90
+++ b/sources/problems/objective.f90
@@ -57,6 +57,8 @@ module objective
      procedure, pass(this) :: init_base => objective_init_base
      !> Destructor of the base class
      procedure, pass(this) :: free_base => objective_free_base
+     !> Get the weight of the objective
+     procedure, pass(this) :: get_weight => objective_get_weight
 
   end type objective_t
 
@@ -135,6 +137,13 @@ contains
        deallocate(this%objective)
     end if
   end subroutine objective_wrapper_free
+
+  !> Get the weight of the objective
+  pure function objective_get_weight(this) result(w)
+    class(objective_t), intent(in) :: this
+    real(kind=rp) :: w
+    w = this%weight
+  end function objective_get_weight
 
 end module objective
 

--- a/sources/problems/objectives/scalar_mixing_objective_function.f90
+++ b/sources/problems/objectives/scalar_mixing_objective_function.f90
@@ -188,7 +188,7 @@ contains
 
       ! Initialize the scalar mixing adjoint source term
       call adjoint_forcing%init_from_components(f_phi_adj, this%phi, &
-           this%weight, this%phi_ref, this%mask, this%has_mask, this%coef)
+           this%get_weight(), this%phi_ref, this%mask, this%has_mask, this%coef)
 
     end associate
 

--- a/sources/problems/problem.f90
+++ b/sources/problems/problem.f90
@@ -462,8 +462,8 @@ contains
     objective_value = 0.0_rp
     do i = 1, this%n_objectives
        objective_value = objective_value + &
-            this%objective_list(i)%objective%weight * &
-            this%objective_list(i)%objective%value
+            this%objective_list(i)%objective%get_weight() * &
+            this%objective_list(i)%objective%get_value()
     end do
 
   end subroutine problem_get_objective_value


### PR DESCRIPTION
Functions which return a complex type might produce large temporary variables in the best case, and memory leaks in the worst.

This PR eliminates some of them.