### PR TITLE
add mapping

### DIFF
--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -74,13 +74,13 @@ module mapping_handler
      procedure, pass(this) :: free => mapping_handler_free
      !> Cycle through all the mapping_cascade and return the final field
      generic :: apply_forward => mapping_handler_apply_forward_field, &
-        mapping_handler_apply_forward_vector
-     procedure, pass(this) ::  mapping_handler_apply_forward_field
-     procedure, pass(this) ::  mapping_handler_apply_forward_vector
+          mapping_handler_apply_forward_vector
+     procedure, pass(this) :: mapping_handler_apply_forward_field
+     procedure, pass(this) :: mapping_handler_apply_forward_vector
      !> Cycle backwards through all the mapping_cascade and return the
      !! sensitivity
      generic :: apply_backward => mapping_handler_apply_backward_field, &
-     mapping_handler_apply_backward_vector
+          mapping_handler_apply_backward_vector
      procedure, pass(this) :: mapping_handler_apply_backward_field
      procedure, pass(this) :: mapping_handler_apply_backward_vector
      !> Generic interface to add a mapping to the list.
@@ -169,7 +169,6 @@ contains
     class(mapping_handler_t), intent(inout) :: this
     type(vector_t), intent(in) :: X_in
     type(vector_t), intent(inout) :: X_out
-    integer :: i
     type(field_t), pointer :: tmp_fld_in, tmp_fld_out
     integer :: temp_indices(2)
 
@@ -248,7 +247,6 @@ contains
     class(mapping_handler_t), intent(inout) :: this
     type(vector_t), intent(in) :: X_in
     type(vector_t), intent(inout) :: X_out
-    integer :: i
     type(field_t), pointer :: tmp_fld_in, tmp_fld_out
     integer :: temp_indices(2)
 

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -48,6 +48,8 @@ module mapping_handler
   use device_math, only: device_col2
   use scratch_registry, only: neko_scratch_registry
   use utils, only: neko_warning
+  use vector, only:vector_t
+  use neko_ext, only: field_to_vector, vector_to_field
   implicit none
   private
 
@@ -55,15 +57,13 @@ module mapping_handler
   !!
   !! @details
   !! This class is responsible for managing the mapping_cascade in a sequential
-  !! manor. It is also responsible for using the chain rule to propogate
+  !! manor. It is also responsible for using the chain rule to propagate
   !! sensitivity backwards throughout the system.
   type, public :: mapping_handler_t
      !> Array of mapping_cascade.
      !! @note the order really matter's here since they'll be executed in
      !! sequence.
      class(mapping_wrapper_t), allocatable :: mapping_cascade(:)
-     !> The right-hand side.
-     type(field_list_t) :: rhs_fields
      !> The coefficients of the (space, mesh) pair.
      type(coef_t), pointer :: coef
 
@@ -73,10 +73,16 @@ module mapping_handler
      !> Destructor.
      procedure, pass(this) :: free => mapping_handler_free
      !> Cycle through all the mapping_cascade and return the final field
-     procedure, pass(this) :: apply_forward => mapping_handler_apply_forward
+     generic :: apply_forward => mapping_handler_apply_forward_field, &
+        mapping_handler_apply_forward_vector
+     procedure, pass(this) ::  mapping_handler_apply_forward_field
+     procedure, pass(this) ::  mapping_handler_apply_forward_vector
      !> Cycle backwards through all the mapping_cascade and return the
      !! sensitivity
-     procedure, pass(this) :: apply_backward => mapping_handler_apply_backward
+     generic :: apply_backward => mapping_handler_apply_backward_field, &
+     mapping_handler_apply_backward_vector
+     procedure, pass(this) :: mapping_handler_apply_backward_field
+     procedure, pass(this) :: mapping_handler_apply_backward_vector
      !> Generic interface to add a mapping to the list.
      generic :: add => add_mapping, add_json_mappings
      !> Append a new mapping to the mapping_cascade array.
@@ -119,7 +125,7 @@ contains
   !! @param this The handler object
   !! @param X_out The mapped field (\f$\tilde{\rho}\f$)
   !! @param X_in The unmapped field (\f$\rho\f$)
-  subroutine mapping_handler_apply_forward(this, X_out, X_in)
+  subroutine mapping_handler_apply_forward_field(this, X_out, X_in)
     class(mapping_handler_t), intent(inout) :: this
     type(field_t), intent(in) :: X_in
     type(field_t), intent(inout) :: X_out
@@ -153,7 +159,31 @@ contains
     ! free the scratch.
     call neko_scratch_registry%relinquish_field(temp_indices)
 
-  end subroutine mapping_handler_apply_forward
+  end subroutine mapping_handler_apply_forward_field
+
+  !> apply the cascade of mapping_cascade.
+  !! @param this The handler object
+  !! @param X_out The mapped vector (\f$\tilde{\rho}\f$)
+  !! @param X_in The unmapped vector (\f$\rho\f$)
+  subroutine mapping_handler_apply_forward_vector(this, X_out, X_in)
+    class(mapping_handler_t), intent(inout) :: this
+    type(vector_t), intent(in) :: X_in
+    type(vector_t), intent(inout) :: X_out
+    integer :: i
+    type(field_t), pointer :: tmp_fld_in, tmp_fld_out
+    integer :: temp_indices(2)
+
+    call neko_scratch_registry%request_field(tmp_fld_in, temp_indices(1))
+    call neko_scratch_registry%request_field(tmp_fld_out, temp_indices(2))
+
+    call vector_to_field(tmp_fld_in, X_in)
+    call mapping_handler_apply_forward_field(this, tmp_fld_out, tmp_fld_in)
+    call field_to_vector(X_out, tmp_fld_out)
+
+    ! free the scratch.
+    call neko_scratch_registry%relinquish_field(temp_indices)
+
+  end subroutine mapping_handler_apply_forward_vector
 
   !> Apply the cascade of mapping_cascade.
   !! @param this The handler object
@@ -161,7 +191,7 @@ contains
   !! (\f$\frac{\partial F}{\partial \rho}\f$)
   !! @param sens_in The sensitivity before applying the chain rule
   !! (\f$\frac{\partial F}{\partial \tilde{\rho}}\f$)
-  subroutine mapping_handler_apply_backward(this, sens_out, sens_in)
+  subroutine mapping_handler_apply_backward_field(this, sens_out, sens_in)
     class(mapping_handler_t), intent(inout) :: this
     type(field_t), intent(inout) :: sens_out
     type(field_t), intent(in) :: sens_in
@@ -192,6 +222,13 @@ contains
 
     end if
 
+    ! post-multiply by mass matrix
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_col2(tmp_fld_out%x_d, this%coef%B_d, tmp_fld_out%size())
+    else
+       call col2(tmp_fld_out%x, this%coef%B, tmp_fld_out%size())
+    end if
+
     ! our final mapping should now live in tmp_fld_out
     call field_copy(sens_out, tmp_fld_out)
 
@@ -199,7 +236,33 @@ contains
     call neko_scratch_registry%relinquish_field(temp_indices)
 
 
-  end subroutine mapping_handler_apply_backward
+  end subroutine mapping_handler_apply_backward_field
+
+  !> apply the cascade of mapping_cascade.
+  !! @param this The handler object
+  !! @param sens_out The sensitivity after applying the chain rule
+  !! (\f$\frac{\partial F}{\partial \rho}\f$)
+  !! @param sens_in The sensitivity before applying the chain rule
+  !! (\f$\frac{\partial F}{\partial \tilde{\rho}}\f$)
+  subroutine mapping_handler_apply_backward_vector(this, X_out, X_in)
+    class(mapping_handler_t), intent(inout) :: this
+    type(vector_t), intent(in) :: X_in
+    type(vector_t), intent(inout) :: X_out
+    integer :: i
+    type(field_t), pointer :: tmp_fld_in, tmp_fld_out
+    integer :: temp_indices(2)
+
+    call neko_scratch_registry%request_field(tmp_fld_in, temp_indices(1))
+    call neko_scratch_registry%request_field(tmp_fld_out, temp_indices(2))
+
+    call vector_to_field(tmp_fld_in, X_in)
+    call mapping_handler_apply_backward_field(this, tmp_fld_out, tmp_fld_in)
+    call field_to_vector(X_out, tmp_fld_out)
+
+    ! free the scratch.
+    call neko_scratch_registry%relinquish_field(temp_indices)
+
+  end subroutine mapping_handler_apply_backward_vector
 
   !> Read from the json file and initialize the mapping_cascade.
   subroutine mapping_handler_add_json_mappings(this, json, name)

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -239,9 +239,9 @@ contains
 
   !> apply the cascade of mapping_cascade.
   !! @param this The handler object
-  !! @param sens_out The sensitivity after applying the chain rule
+  !! @param X_out The sensitivity after applying the chain rule
   !! (\f$\frac{\partial F}{\partial \rho}\f$)
-  !! @param sens_in The sensitivity before applying the chain rule
+  !! @param X_in The sensitivity before applying the chain rule
   !! (\f$\frac{\partial F}{\partial \tilde{\rho}}\f$)
   subroutine mapping_handler_apply_backward_vector(this, X_out, X_in)
     class(mapping_handler_t), intent(inout) :: this


### PR DESCRIPTION
This PR introduces an easy way to filter vector types.

The big change though is to always post-multiply by the mass matrix before entering MMA.