### PR TITLE
Reintroduce support for ParMETIS

### DIFF
--- a/.github/actions/setup_neko/action.yml
+++ b/.github/actions/setup_neko/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "The directory where the JSON-Fortran library was installed."
     required: true
 
+  parmetis-dir:
+    description: "The directory where the ParMETIS library was installed."
+    required: true
+
   os:
     description: "The operating system to use."
     required: false
@@ -144,6 +148,7 @@ runs:
         BACKEND: ${{ inputs.backend }}
         BACKEND_PATH: ${{ inputs.backend-path }}
         RP: ${{ inputs.precision }}
+        PARMETIS_DIR: ${{ inputs.parmetis-dir }}
       run: |
         BACKEND_FLAGS=""
         if [ "$BACKEND" == "CUDA" ]; then
@@ -158,6 +163,7 @@ runs:
         CONFIG_FLAGS="--prefix=$INSTALL_DIR"
         [ -n "$BACKEND_FLAGS" ] && CONFIG_FLAGS="$CONFIG_FLAGS $BACKEND_FLAGS"
         [ -n "$RP" ] && CONFIG_FLAGS="$CONFIG_FLAGS --enable-real=$RP"
+        [ -n "$PARMETIS_DIR" ] && CONFIG_FLAGS="$CONFIG_FLAGS --with-parmetis=$PARMETIS_DIR"
 
         cd $WORKING_DIR
         ./regen.sh

--- a/.github/actions/setup_parmetis/action.yml
+++ b/.github/actions/setup_parmetis/action.yml
@@ -89,7 +89,7 @@ runs:
         mkdir -p $WORKING_DIR
         cd $WORKING_DIR
         wget https://github.com/mfem/tpls/raw/refs/heads/gh-pages/parmetis-4.0.3.tar.gz
-        tar xzf parmetis-4.0.3.tar.gz && rm -fr parmetis-4.0.3.tar.gz
+        tar xzf parmetis-4.0.3.tar.gz
         cd parmetis-4.0.3
 
     - name: Build METIS
@@ -98,12 +98,11 @@ runs:
       env:
         PARMETIS_DIR: ${{ inputs.install-dir }}
         CMAKE_GENERATOR: "Unix Makefiles"
+        WORKING_DIR: ${{ inputs.working-dir }}
       run: |
-        # Compile the bundled metis library
-        cd metis
+        cd $WORKING_DIR/parmetis-4.0.3/metis
         make config prefix=${PARMETIS_DIR}
         make -j && make install
-        cd ../
 
     - name: Build ParMETIS
       if: ${{ steps.cache-ParMETIS.outputs.cache-hit != 'true' }}
@@ -112,6 +111,7 @@ runs:
         PARMETIS_DIR: ${{ inputs.install-dir }}
         CMAKE_GENERATOR: "Unix Makefiles"
       run: |
+        cd $WORKING_DIR/parmetis-4.0.3
         make config prefix=${PARMETIS_DIR}
         make -j && make install
 

--- a/.github/actions/setup_parmetis/action.yml
+++ b/.github/actions/setup_parmetis/action.yml
@@ -110,6 +110,7 @@ runs:
       env:
         PARMETIS_DIR: ${{ inputs.install-dir }}
         CMAKE_GENERATOR: "Unix Makefiles"
+        WORKING_DIR: ${{ inputs.working-dir }}
       run: |
         cd $WORKING_DIR/parmetis-4.0.3
         make config prefix=${PARMETIS_DIR}

--- a/.github/actions/setup_parmetis/action.yml
+++ b/.github/actions/setup_parmetis/action.yml
@@ -1,0 +1,134 @@
+name: Setup the ParMETIS library
+description: |
+  This action sets up the ParMETIS library for use in the main workflow.
+
+# ---------------------------------------------------------------------------- #
+# Define the inputs and outputs for this action. The inputs are used to
+# configure the action, while the outputs are used to pass information
+# back to the caller.
+
+inputs:
+  install-dir:
+    description: "The directory to install the ParMETIS library."
+    required: false
+    default: "/home/runner/pkg/ParMETIS"
+
+  working-dir:
+    description: "The directory to work in."
+    required: false
+    default: "/home/runner/tmp/ParMETIS"
+
+  os:
+    description: "The operating system to use."
+    required: false
+    default: "${{ runner.os }}"
+
+  build-options:
+    description: "The build option to use."
+    required: false
+    default: "--parallel $(nproc)"
+
+  version:
+    description: "The version of the ParMETIS library to use."
+    required: false
+    default: "v1.0.8"
+
+outputs:
+  install-dir:
+    description: "The directory where the ParMETIS library was installed."
+    value: ${{ steps.set-output.outputs.install-dir }}
+
+# ---------------------------------------------------------------------------- #
+# Define the steps that will be run in this action.
+
+runs:
+  using: composite
+  steps:
+    # ------------------------------------------------------------------------ #
+    # Setup the cache for the ParMETIS library and clone the repository.
+
+    - name: Create cache key based on version, OS, and compiler
+      id: create-key
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        OS: ${{ inputs.os }}
+        COMPILER: ${{ inputs.compiler }}
+        COMPILER_FLAGS: ${{ inputs.compiler-flags }}
+        REPO: https://github.com/Nek5000/ParMETIS.git
+      run: |
+        # Get the GIT sha for the current commit
+        key="ParMETIS-$OS-$COMPILER-${COMPILER_FLAGS// /_}"
+        printf "key=%s\n" "$key" | tee -a $GITHUB_OUTPUT
+
+    - name: Cache
+      id: cache-ParMETIS
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.install-dir }}
+        key: ${{ steps.create-key.outputs.key }}
+
+    # ------------------------------------------------------------------------ #
+    # Setup the system for building the ParMETIS library
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        sudo apt install openmpi-bin libopenmpi-dev
+
+    # ------------------------------------------------------------------------ #
+    # Configure, build, and install the ParMETIS library.
+
+    - name: Download and extract ParMETIS
+      if: ${{ steps.cache-ParMETIS.outputs.cache-hit != 'true' }}
+      shell: bash
+      env:
+        PARMETIS_DIR: ${{ inputs.install-dir }}
+        WORKING_DIR: ${{ inputs.working-dir }}
+      run: |
+        mkdir -p $WORKING_DIR
+        cd $WORKING_DIR
+        wget https://github.com/mfem/tpls/raw/refs/heads/gh-pages/parmetis-4.0.3.tar.gz
+        tar xzf parmetis-4.0.3.tar.gz && rm -fr parmetis-4.0.3.tar.gz
+        cd parmetis-4.0.3
+
+    - name: Build METIS
+      if: ${{ steps.cache-ParMETIS.outputs.cache-hit != 'true' }}
+      shell: bash
+      env:
+        PARMETIS_DIR: ${{ inputs.install-dir }}
+        CMAKE_GENERATOR: "Unix Makefiles"
+      run: |
+        # Compile the bundled metis library
+        cd metis
+        make config prefix=${PARMETIS_DIR}
+        make -j && make install
+        cd ../
+
+    - name: Build ParMETIS
+      if: ${{ steps.cache-ParMETIS.outputs.cache-hit != 'true' }}
+      shell: bash
+      env:
+        PARMETIS_DIR: ${{ inputs.install-dir }}
+        CMAKE_GENERATOR: "Unix Makefiles"
+      run: |
+        make config prefix=${PARMETIS_DIR}
+        make -j && make install
+
+    - name: Cleanup
+      if: ${{ steps.cache-ParMETIS.outputs.cache-hit != 'true' }}
+      shell: bash
+      env:
+        WORKING_DIR: ${{ inputs.working-dir }}
+      run: |
+        cd $WORKING_DIR
+        rm -rf parmetis-4.0.3 parmetis-4.0.3.tar.gz
+
+    # ------------------------------------------------------------------------ #
+    # Cleanup the working directory if necessary and set the output.
+
+    - name: Set output
+      shell: bash
+      id: set-output
+      run: |
+        echo "install-dir=$(echo ${{ inputs.install-dir }})" >> $GITHUB_OUTPUT

--- a/.github/actions/setup_parmetis/action.yml
+++ b/.github/actions/setup_parmetis/action.yml
@@ -8,30 +8,45 @@ description: |
 # back to the caller.
 
 inputs:
-  install-dir:
-    description: "The directory to install the ParMETIS library."
-    required: false
-    default: "/home/runner/pkg/ParMETIS"
+    install-dir:
+      description: "The directory to install the ParMetis library."
+      required: false
+      default: "/home/runner/pkg/parmetis"
 
-  working-dir:
-    description: "The directory to work in."
-    required: false
-    default: "/home/runner/tmp/ParMETIS"
+    working-dir:
+      description: "The directory to work in."
+      required: false
+      default: "/home/runner/tmp/parmetis"
 
-  os:
-    description: "The operating system to use."
-    required: false
-    default: "${{ runner.os }}"
+    os:
+      description: "The operating system to use."
+      required: false
+      default: "${{ runner.os }}"
 
-  build-options:
-    description: "The build option to use."
-    required: false
-    default: "--parallel $(nproc)"
+    compiler:
+      description: "The compiler to use."
+      required: false
+      default: "gfortran"
 
-  version:
-    description: "The version of the ParMETIS library to use."
-    required: false
-    default: "v1.0.8"
+    compiler-flags:
+      description: "The compiler flag to use."
+      required: false
+      default: "-O3"
+
+    build-options:
+      description: "The build option to use."
+      required: false
+      default: "--parallel"
+
+    install-options:
+      description: "The install option to use."
+      required: false
+      default: ""
+
+    version:
+      description: "The version of the ParMetis library to use."
+      required: false
+      default: "4.0.3"
 
 outputs:
   install-dir:
@@ -55,10 +70,8 @@ runs:
         OS: ${{ inputs.os }}
         COMPILER: ${{ inputs.compiler }}
         COMPILER_FLAGS: ${{ inputs.compiler-flags }}
-        REPO: https://github.com/Nek5000/ParMETIS.git
       run: |
-        # Get the GIT sha for the current commit
-        key="ParMETIS-$OS-$COMPILER-${COMPILER_FLAGS// /_}"
+        key="parmetis-$VERSION-$OS-$COMPILER-${COMPILER_FLAGS// /_}"
         printf "key=%s\n" "$key" | tee -a $GITHUB_OUTPUT
 
     - name: Cache
@@ -85,12 +98,13 @@ runs:
       env:
         PARMETIS_DIR: ${{ inputs.install-dir }}
         WORKING_DIR: ${{ inputs.working-dir }}
+        VERSION: ${{ inputs.version }}
       run: |
         mkdir -p $WORKING_DIR
         cd $WORKING_DIR
-        wget https://github.com/mfem/tpls/raw/refs/heads/gh-pages/parmetis-4.0.3.tar.gz
-        tar xzf parmetis-4.0.3.tar.gz
-        cd parmetis-4.0.3
+        wget https://github.com/mfem/tpls/raw/refs/heads/gh-pages/parmetis-$VERSION.tar.gz
+        tar xzf parmetis-$VERSION.tar.gz
+        cd parmetis-$VERSION
 
     - name: Build METIS
       if: ${{ steps.cache-ParMETIS.outputs.cache-hit != 'true' }}
@@ -99,8 +113,9 @@ runs:
         PARMETIS_DIR: ${{ inputs.install-dir }}
         CMAKE_GENERATOR: "Unix Makefiles"
         WORKING_DIR: ${{ inputs.working-dir }}
+        VERSION: ${{ inputs.version }}
       run: |
-        cd $WORKING_DIR/parmetis-4.0.3/metis
+        cd $WORKING_DIR/parmetis-$VERSION/metis
         make config prefix=${PARMETIS_DIR}
         make -j && make install
 
@@ -111,8 +126,9 @@ runs:
         PARMETIS_DIR: ${{ inputs.install-dir }}
         CMAKE_GENERATOR: "Unix Makefiles"
         WORKING_DIR: ${{ inputs.working-dir }}
+        VERSION: ${{ inputs.version }}
       run: |
-        cd $WORKING_DIR/parmetis-4.0.3
+        cd $WORKING_DIR/parmetis-$VERSION
         make config prefix=${PARMETIS_DIR}
         make -j && make install
 
@@ -121,9 +137,10 @@ runs:
       shell: bash
       env:
         WORKING_DIR: ${{ inputs.working-dir }}
+        VERSION: ${{ inputs.version }}
       run: |
         cd $WORKING_DIR
-        rm -rf parmetis-4.0.3 parmetis-4.0.3.tar.gz
+        rm -rf parmetis-$VERSION parmetis-$VERSION.tar.gz
 
     # ------------------------------------------------------------------------ #
     # Cleanup the working directory if necessary and set the output.

--- a/.github/actions/setup_parmetis/readme.md
+++ b/.github/actions/setup_parmetis/readme.md
@@ -1,0 +1,55 @@
+# Installation and caching of pFUnit
+
+This action uses caching to accelerate the building of pFUnit. The action will
+download the pFUnit source code and build it using the provided compiler. The
+action will also cache the build to speed up future builds.
+
+## Inputs
+
+| Name             | Optional | Description                                  | Default                   |
+| ---------------- | -------- | -------------------------------------------- | ------------------------- |
+| `install-dir`    | Yes      | The directory to install the pFUnit library. | `/home/runner/pkg/pfunit` |
+| `working-dir`    | Yes      | The directory to work in.                    | `/home/runner/tmp/pfunit` |
+| `os`             | Yes      | The operating system to use.                 | `${{ runner.os }}`        |
+| `compiler`       | Yes      | The compiler to use.                         | `mpif90`                  |
+| `compiler-flags` | Yes      | The compiler flag to use.                    | `-O3`                     |
+| `build-options`  | Yes      | The build option to use.                     | `--parallel $(nproc)`     |
+| `version`        | Yes      | The version of the pFUnit library to use.    | `v4.8.0`                  |
+
+## Outputs
+
+| Name          | Description                               |
+| ------------- | ----------------------------------------- |
+| `install-dir` | The directory where pFUnit was installed. |
+
+## Example usage
+
+The following example uses the pFUnit action to build pFUnit using the `gfortran`
+compiler with the `-O3` optimization level and the `--parallel 4` cmake build
+option.
+
+Additionally the next step will capture the install location and print where the
+pFUnit was installed.
+
+```yaml
+name: Build pFUnit
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Setup pFUnit
+      uses: ./.github/actions/setup_neko
+      with:
+        compiler: 'gfortran'
+        compiler-options: '-O3'
+        build-options: '--parallel=4'
+
+    - name: Echo install directory
+      env: 
+        PFUNIT_DIR: ${{ steps.setup-pfunit.outputs.install-dir }}
+      run: echo "pfunit was installed to $PFUNIT_DIR"
+```

--- a/.github/actions/setup_parmetis/readme.md
+++ b/.github/actions/setup_parmetis/readme.md
@@ -1,38 +1,41 @@
-# Installation and caching of pFUnit
+# Installation and caching of ParMetis
 
-This action uses caching to accelerate the building of pFUnit. The action will
-download the pFUnit source code and build it using the provided compiler. The
+This action uses caching to accelerate the building of ParMetis. The action will
+download the ParMetis source code and build it using the provided compiler. The
 action will also cache the build to speed up future builds.
+
+It should be noted that the download is done using wget from a github reference
+mentioned by the Neko documentation.
 
 ## Inputs
 
-| Name             | Optional | Description                                  | Default                   |
-| ---------------- | -------- | -------------------------------------------- | ------------------------- |
-| `install-dir`    | Yes      | The directory to install the pFUnit library. | `/home/runner/pkg/pfunit` |
-| `working-dir`    | Yes      | The directory to work in.                    | `/home/runner/tmp/pfunit` |
-| `os`             | Yes      | The operating system to use.                 | `${{ runner.os }}`        |
-| `compiler`       | Yes      | The compiler to use.                         | `mpif90`                  |
-| `compiler-flags` | Yes      | The compiler flag to use.                    | `-O3`                     |
-| `build-options`  | Yes      | The build option to use.                     | `--parallel $(nproc)`     |
-| `version`        | Yes      | The version of the pFUnit library to use.    | `v4.8.0`                  |
+| Name             | Optional | Description                                    | Default                     |
+| ---------------- | -------- | ---------------------------------------------- | --------------------------- |
+| `install-dir`    | Yes      | The directory to install the ParMetis library. | `/home/runner/pkg/parmetis` |
+| `working-dir`    | Yes      | The directory to work in.                      | `/home/runner/tmp/parmetis` |
+| `os`             | Yes      | The operating system to use.                   | `${{ runner.os }}`          |
+| `compiler`       | Yes      | The compiler to use.                           | `mpif90`                    |
+| `compiler-flags` | Yes      | The compiler flag to use.                      | `-O3`                       |
+| `build-options`  | Yes      | The build option to use.                       | `--parallel $(nproc)`       |
+| `version`        | Yes      | The version of the ParMetis library to use.    | `4.0.3`                     |
 
 ## Outputs
 
-| Name          | Description                               |
-| ------------- | ----------------------------------------- |
-| `install-dir` | The directory where pFUnit was installed. |
+| Name          | Description                                 |
+| ------------- | ------------------------------------------- |
+| `install-dir` | The directory where ParMetis was installed. |
 
 ## Example usage
 
-The following example uses the pFUnit action to build pFUnit using the `gfortran`
+The following example uses the ParMetis action to build ParMetis using the `gfortran`
 compiler with the `-O3` optimization level and the `--parallel 4` cmake build
 option.
 
 Additionally the next step will capture the install location and print where the
-pFUnit was installed.
+ParMetis was installed.
 
 ```yaml
-name: Build pFUnit
+name: Build ParMetis
 
 on: [push, pull_request]
 
@@ -41,8 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Setup pFUnit
-      uses: ./.github/actions/setup_neko
+    - name: Setup ParMetis
+      id: setup-parmetis
+      uses: ./.github/actions/setup_parmetis
       with:
         compiler: 'gfortran'
         compiler-options: '-O3'
@@ -50,6 +54,6 @@ jobs:
 
     - name: Echo install directory
       env: 
-        PFUNIT_DIR: ${{ steps.setup-pfunit.outputs.install-dir }}
-      run: echo "pfunit was installed to $PFUNIT_DIR"
+        PARMETIS_DIR: ${{ steps.setup-parmetis.outputs.install-dir }}
+      run: echo "parmetis was installed to $PARMETIS_DIR"
 ```

--- a/.github/workflows/check_compile.yml
+++ b/.github/workflows/check_compile.yml
@@ -171,6 +171,7 @@ jobs:
         env:
           NEKO_DIR: ${{ steps.get-neko.outputs.install-dir }}
           JSON_FORTRAN_DIR: ${{ steps.get-json-fortran.outputs.install-dir }}
+          PARMETIS_DIR: ${{ steps.get-parmetis.outputs.install-dir }}
         run: |
           # Adjust the end time and max iterations for the rugby ball case
           sed -i -r 's/"end_time":.*/"end_time": 1e-3,/g' examples/rugby_ball/rugby_ball.case

--- a/.github/workflows/check_compile.yml
+++ b/.github/workflows/check_compile.yml
@@ -105,11 +105,18 @@ jobs:
           version: ${{ inputs.json-fortran-version }}
           compiler: ${{ matrix.compiler }}
 
+      - name: Get ParMETIS
+        id: get-parmetis
+        uses: ./.github/actions/setup_parmetis
+        with:
+          compiler: ${{ matrix.compiler }}
+
       - name: Get neko
         id: get-neko
         uses: ./.github/actions/setup_neko
         with:
           json-fortran-dir: ${{ steps.get-json-fortran.outputs.install-dir }}
+          parmetis-dir: ${{ steps.get-parmetis.outputs.install-dir }}
           version: ${{ inputs.neko-version }}
           precision: ${{ matrix.precision }}
           compiler: ${{ matrix.compiler }}

--- a/.github/workflows/check_scripts.yml
+++ b/.github/workflows/check_scripts.yml
@@ -115,12 +115,18 @@ jobs:
         with:
           version: ${{ inputs.json-fortran-version }}
 
+      - name: Get parmetis
+        id: get-parmetis
+        uses: ./.github/actions/setup_parmetis
+
       - name: Get neko
         id: get-neko
         uses: ./.github/actions/setup_neko
         with:
           json-fortran-dir: ${{ steps.get-json-fortran.outputs.install-dir }}
+          parmetis-dir: ${{ steps.get-parmetis.outputs.install-dir }}
           version: ${{ inputs.neko-version }}
+
 
       # ---------------------------------------------------------------------- #
       # Build and test the code
@@ -140,6 +146,7 @@ jobs:
         env:
           NEKO_DIR: ${{ steps.get-neko.outputs.install-dir }}
           JSON_FORTRAN_DIR: ${{ steps.get-json-fortran.outputs.install-dir }}
+          PARMETIS_DIR: ${{ steps.get-parmetis.outputs.install-dir }}
         run: |
           # Adjust the end time and max iterations for the rugby ball case
           sed -i -r 's/"end_time":.*/"end_time": 1e-3,/g' examples/rugby_ball/rugby_ball.case

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -294,6 +294,64 @@ function find_hdf5() {
 }
 
 # ============================================================================ #
+# Ensure ParMETIS is installed, if not install it.
+
+function find_parmetis() {
+
+    # Determine the Parmetis installation directory
+    check_external_dir
+    if [[ $# -ge 1 ]]; then
+        PARMETIS_DIR="$1"
+    elif [ -z "$PARMETIS_DIR" ]; then
+        PARMETIS_DIR="parmetis"
+    fi
+
+    if [[ "${PARMETIS_DIR:0:1}" != "/" && "${PARMETIS_DIR:0:1}" != "~" ]]; then
+        PARMETIS_DIR="$(realpath $EXTERNAL_DIR/$PARMETIS_DIR)"
+    fi
+
+    if [[ -z "$(find $PARMETIS_DIR -name libparmetis.a)" ]]; then
+        [ -z "$CURRENT_DIR" ] && CURRENT_DIR=$(pwd)
+        CMAKE_GENERATOR_OLD=$CMAKE_GENERATOR
+        CMAKE_GENERATOR="Unix Makefiles"
+
+        # Download and install ParMETIS
+        mkdir -p $PARMETIS_DIR && cd $PARMETIS_DIR
+        wget https://github.com/mfem/tpls/raw/refs/heads/gh-pages/parmetis-4.0.3.tar.gz
+        tar xzf parmetis-4.0.3.tar.gz
+        cd parmetis-4.0.3
+
+        # Compile the bundled metis library
+        cd metis
+        make config prefix=${PARMETIS_DIR}
+        make -j && make install
+        cd ../
+
+        # Compile parmetis
+        make config prefix=${PARMETIS_DIR}
+        make -j && make install
+        cd ../
+        rm -rf parmetis-4.0.3 parmetis-4.0.3.tar.gz
+        CMAKE_GENERATOR=$CMAKE_GENERATOR_OLD
+        cd $CURRENT_DIR
+    fi
+
+    PARMETIS_LIB=$(find $PARMETIS_DIR -type d -name 'lib*' \
+        -exec test -f '{}'/libparmetis.a \; -print)
+    if [ -z "$PARMETIS_LIB" ]; then
+        error "ParMETIS not found at:"
+        error "\t$PARMETIS_DIR"
+        error "Please set PARMETIS_DIR to the directory containing"
+        error "the ParMETIS source code."
+        error "You can download the source code from:"
+        error "\thttps://github.com/KarypisLab/ParMETIS.git"
+        exit 1
+    fi
+
+    export PARMETIS_DIR=$(realpath $PARMETIS_DIR)
+}
+
+# ============================================================================ #
 # Ensure Neko is installed, if not install it.
 function find_neko() {
     check_external_dir
@@ -302,6 +360,7 @@ function find_neko() {
     find_json_fortran $JSON_FORTRAN_DIR
     find_gslib $GSLIB_DIR
     find_hdf5 $HDF5_DIR
+    find_parmetis $PARMETIS_DIR
 
     # Determine the Neko installation directory
     if [[ $# -ge 1 ]]; then
@@ -328,6 +387,7 @@ function find_neko() {
         [ -n "$GSLIB_DIR" ] && FEATURES+=" --with-gslib=$GSLIB_DIR"
         [ -n "$BLAS_DIR" ] && FEATURES+=" --with-blas=$BLAS_DIR"
         [ -n "$HDF5_DIR" ] && FEATURES+=" --with-hdf5=$HDF5_DIR"
+        [ -n "$PARMETIS_DIR" ] && FEATURES+=" --with-parmetis=$PARMETIS_DIR"
 
         # Handle device specific features
         if [ "$DEVICE_TYPE" == "CUDA" ]; then


### PR DESCRIPTION
Restore functionality to find and install ParMETIS, ensuring it is properly integrated into the build process.

This allows "load_balancing" in case files from Neko, and the "prepart" tool for offline balancing.