### PR TITLE
reset timestep counter on reset

### DIFF
--- a/sources/simulation/simulation.f90
+++ b/sources/simulation/simulation.f90
@@ -281,6 +281,7 @@ contains
     ! call reset(this%adjoint_case)
     this%adjoint_case%time%t = 0.0_rp
     this%adjoint_case%time%tstep = 0
+    this%n_timesteps = 0
 
     call field_rzero(this%adjoint_case%fluid_adj%u_adj)
     call field_rzero(this%adjoint_case%fluid_adj%v_adj)


### PR DESCRIPTION
This restarts the total timestep counter when we reset the simulation.