### PR TITLE
Add profiler regions for checkpoints and MMA optimizer

### DIFF
--- a/sources/checkpoint/checkpoint.f90
+++ b/sources/checkpoint/checkpoint.f90
@@ -42,6 +42,7 @@ module simulation_checkpoint
   use mpi_f08, only: MPI_WTIME
   use utils, only: neko_error
   use field_math, only: field_copy, field_rzero
+  use profiler, only: profiler_start_region, profiler_end_region
   implicit none
   private
 
@@ -269,6 +270,8 @@ contains
 
     if (.not. this%enabled) return
 
+    call profiler_start_region("Checkpoint save")
+
     ! Update the number of recorded timesteps
     this%n_timesteps = this%n_timesteps + 1
 
@@ -278,6 +281,8 @@ contains
     case default
        call neko_error("Unknown checkpoint algorithm: " // this%algorithm)
     end select
+
+    call profiler_end_region("Checkpoint save")
   end subroutine checkpoint_save
 
   !> Restore the forward simulation state
@@ -288,6 +293,8 @@ contains
     character(len=256) :: msg
 
     if (.not. this%enabled) return
+
+    call profiler_start_region("Checkpoint restore")
 
     if (tstep .lt. 1 .or. tstep .gt. this%n_timesteps) then
        write(msg, '(A,I0,A,I0,A)') "Requested timestep ", tstep, &
@@ -301,6 +308,8 @@ contains
     case default
        call neko_error("Unknown checkpoint algorithm: " // this%algorithm)
     end select
+
+    call profiler_end_region("Checkpoint restore")
   end subroutine checkpoint_restore
 
   ! ========================================================================== !

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -11,6 +11,7 @@ module mma_optimizer
   use design, only: design_t
   use field, only: field_t
   use field_registry, only: neko_field_registry
+  use profiler, only: profiler_start_region, profiler_end_region
 
   use vector, only: vector_t
   use matrix, only: matrix_t
@@ -142,6 +143,8 @@ contains
 
     type(vector_t) :: log_data
 
+    call profiler_start_region("Optimizer iteration 0")
+
     n = design%size()
     call MPI_Allreduce(n, nglobal, 1, MPI_INTEGER, mpi_sum, neko_comm, ierr)
 
@@ -176,9 +179,12 @@ contains
 
     if (present(simulation)) call simulation%write(0)
     call design%write(0)
+    call profiler_end_region("Optimizer iteration 0")
 
     do iter = 1, this%max_iterations
        if (this%mma%get_residumax() .lt. this%tolerance) exit
+
+       call profiler_start_region("Optimizer iteration")
 
        ! Scaling
        if (this%auto_scale .eqv. .true.) then
@@ -200,8 +206,10 @@ contains
        end if
 
        ! Use scaled sensitivities to update the design variable
+       call profiler_start_region("MMA update")
        call this%mma%update(iter, x, objective_sensitivities, &
             constraint_value, constraint_sensitivities)
+       call profiler_end_region("MMA update")
 
        call design%update_design(x)
 
@@ -214,8 +222,10 @@ contains
        call problem%get_constraint_sensitivities(constraint_sensitivities)
        call problem%get_all_objective_values(all_objectives)
 
+       call profiler_start_region("MMA KKT computation")
        call this%mma%KKT(x, objective_sensitivities, &
             constraint_value, constraint_sensitivities)
+       call profiler_end_region("MMA KKT computation")
 
        ! Stamp the i^th iteration
        call mma_logger_assemble_data(log_data, iter, objective_value, &
@@ -226,6 +236,8 @@ contains
 
        if (present(simulation)) call simulation%write(iter)
        call design%write(iter)
+
+       call profiler_end_region("Optimizer iteration")
     end do
 
     call this%validate(problem, design)

--- a/sources/simulation/simulation.f90
+++ b/sources/simulation/simulation.f90
@@ -64,7 +64,8 @@ module simulation_m
   use logger, only: LOG_SIZE, neko_log
   use mpi_f08, only: MPI_WTIME
   use jobctrl, only: jobctrl_time_limit
-  use profiler, only: profiler_start, profiler_stop
+  use profiler, only: profiler_start, profiler_stop, &
+       profiler_start_region, profiler_end_region
   use simulation_adjoint, only: simulation_adjoint_init, &
        simulation_adjoint_step, simulation_adjoint_finalize
   use simulation, only: simulation_init, simulation_step, simulation_finalize, &
@@ -132,6 +133,9 @@ contains
     call neko_init(this%neko_case)
     ! initialize the adjoint
     call adjoint_init(this%adjoint_case, this%neko_case)
+
+    ! Start the profiler
+    call profiler_start
 
     select type (fluid => this%neko_case%fluid)
     type is (fluid_pnpn_t)
@@ -202,6 +206,9 @@ contains
   subroutine simulation_free(this)
     class(simulation_t), intent(inout) :: this
 
+    ! Stop the profiler
+    call profiler_stop
+
     call this%checkpoint%free()
     call adjoint_free(this%adjoint_case)
     call neko_finalize(this%neko_case)
@@ -218,7 +225,7 @@ contains
 
     call simulation_init(this%neko_case, dt_controller)
 
-    call profiler_start
+    call profiler_start_region("Forward simulation")
     loop_start = MPI_WTIME()
     do while (this%neko_case%time%t .lt. this%neko_case%time%end_time)
        this%n_timesteps = this%n_timesteps + 1
@@ -227,7 +234,7 @@ contains
 
        call this%checkpoint%save(this%neko_case)
     end do
-    call profiler_stop
+    call profiler_end_region("Forward simulation")
 
     call simulation_finalize(this%neko_case)
 
@@ -245,18 +252,17 @@ contains
 
     call simulation_adjoint_init(this%adjoint_case, dt_controller)
 
-    call profiler_start
+    call profiler_start_region("Adjoint simulation")
     cfl = this%adjoint_case%fluid_adj%compute_cfl(this%adjoint_case%time%dt)
     loop_start = MPI_WTIME()
 
     do i = this%n_timesteps, 1, -1
        call this%checkpoint%restore(this%neko_case, i)
 
-
        call simulation_adjoint_step(this%adjoint_case, dt_controller, cfl, &
             loop_start)
     end do
-    call profiler_stop
+    call profiler_end_region("Adjoint simulation")
 
     call simulation_adjoint_finalize(this%adjoint_case)
 


### PR DESCRIPTION
Introduce profiler regions to enhance performance tracking during checkpoint saving, restoring, and MMA optimization iterations. This change aims to provide better insights into the execution time of critical operations.