### PR TITLE
minimal changes to the scalar example

### DIFF
--- a/examples/passive_scalar/passive_scalar.case
+++ b/examples/passive_scalar/passive_scalar.case
@@ -7,7 +7,7 @@
         "output_boundary": false,
         "time": {
             "end_time": 5.0,
-            "timestep": 2e-4
+            "timestep": 5e-3
         },
         "numerics": {
             "time_order": 1,
@@ -39,7 +39,7 @@
             },
             "boundary_conditions": [
                 {
-                    "type": "user_velocity_pointwise",
+                    "type": "user_velocity",
                     "zone_indices": [ 1 ]
                 },
                 {
@@ -55,7 +55,7 @@
         },
         "scalar": {
             "enabled": true,
-            "Pe": 5000.0,
+            "Pe": 500.0,
             "solver": {
                 "type": "cg",
                 "preconditioner": {
@@ -69,7 +69,7 @@
             },
             "boundary_conditions": [
                 {
-                    "type": "user_pointwise",
+                    "type": "user",
                     "zone_indices": [ 1 ]
                 },
                 {
@@ -163,11 +163,12 @@
             "mapping": [
                 {
                     "type": "PDE_filter",
-                    "r": 0.05
+                    "r": 0.05,
+                    "tol": 1e-15
                 },
                 {
                     "type": "RAMP",
-                    "f_max": 1000
+                    "f_max": 100
                 }
             ],
             "initial_distribution": {
@@ -182,9 +183,8 @@
         "solver": {
             "type": "mma",
             "max_iterations": 100,
-            "tolerance": 1.0e-3,
+            "tolerance": 1.0e-13,
             "mma": {
-                "m": 0,
                 "scale": 1000.0,
                 "xmin": 0.0,
                 "xmax": 1.0
@@ -198,6 +198,13 @@
                 "weight": 1.0
             }
         ],
-        "constraints": [ ]
+        "constraints": [
+            {
+                "type": "volume",
+                "mask_name": "optimization_domain",
+                "limit": 0.05,
+                "is_max": false
+            }
+        ],
     }
 }

--- a/examples/passive_scalar/user.f90
+++ b/examples/passive_scalar/user.f90
@@ -15,6 +15,7 @@ module user
   use neko_config, only: NEKO_BCKND_DEVICE
   use operators, only: curl
   use scratch_registry, only : neko_scratch_registry
+  use device, only: HOST_TO_DEVICE, device_memcpy
   implicit none
   !> Case parameters
   ! To define the initial boundary conditions we don't wish to introduce a
@@ -72,6 +73,12 @@ contains
           w%x(idx, 1, 1, 1) = 0._rp
        end do
 
+       if (NEKO_BCKND_DEVICE .eq. 1) then
+          call device_memcpy(u%x, u%x_d, u%size(), HOST_TO_DEVICE, sync=.false.)
+          call device_memcpy(v%x, v%x_d, v%size(), HOST_TO_DEVICE, sync=.false.)
+          call device_memcpy(w%x, w%x_d, w%size(), HOST_TO_DEVICE, sync=.false.)
+       end if
+
     else
        s => fields%get("s")
 
@@ -81,6 +88,9 @@ contains
           ! Inflow scalar profile is a sigmoid separating the two species
           s%x(idx, 1, 1, 1) = L / (1.0_rp + exp(-k*(z - z_0)))
        end do
+       if (NEKO_BCKND_DEVICE .eq. 1) then
+          call device_memcpy(s%x, s%x_d, s%size(), HOST_TO_DEVICE, sync=.false.)
+       end if
     end if
   end subroutine user_bc
 
@@ -91,13 +101,18 @@ contains
     type(field_t), pointer :: s
     integer :: i
 
-    if (scheme_name .ne. 'scalar') return
+    if (scheme_name .eq. 'fluid') return
 
     ! Initial scalar profile is a sigmoid separating the two species
     s => fields%get("s")
     do i = 1, s%dof%size()
        s%x(i,1,1,1) = L / (1.0_rp + exp(-k*(s%dof%z(i,1,1,1) - z_0)))
     end do
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_memcpy(s%x, s%x_d, s%size(), HOST_TO_DEVICE, sync=.false.)
+    end if
+
 
   end subroutine scalar_ic
 

--- a/sources/drivers/topopt-user.f90
+++ b/sources/drivers/topopt-user.f90
@@ -57,7 +57,7 @@ program topopt_user
   call sim%init(parameters)
 
   ! initialize the design
-  call design_factory(des, parameters, sim)
+  call design_factory(des, design_parameters, sim)
 
   ! initialize the problem
   call prob%init(parameters, des, sim)


### PR DESCRIPTION
These were the minimal changes to the scalar example to run on LUMI.
NOTE: I mean run :sweat_smile: .
To run correctly I would wait for #247 
To run without the need for a volume constraint we wait for #284 
Also everything eventually diverged because the timestep was too large for the mesh I was testing.