### PR TITLE
Align with new scratch interface of Neko

### DIFF
--- a/examples/mma/example_problem.f90
+++ b/examples/mma/example_problem.f90
@@ -44,7 +44,7 @@ module example_problem_mma
   use neko_config, only: NEKO_BCKND_DEVICE
   use vector_math, only: vector_sub2, vector_col2, vector_glsum, vector_cmult
 
-  use vector_scratch_registry, only: neko_vector_scratch_registry
+  use scratch_registry, only: neko_scratch_registry
 
   implicit none
   private
@@ -106,9 +106,9 @@ contains
     type(vector_t), pointer :: x_coordinate
     integer :: ind(2)
 
-    call neko_vector_scratch_registry%request_vector(design%size(), &
+    call neko_scratch_registry%request_vector(design%size(), &
          x_coordinate, ind(1))
-    call neko_vector_scratch_registry%request_vector(design%size(), &
+    call neko_scratch_registry%request_vector(design%size(), &
          difference, ind(2))
 
     call design%get_x(x_coordinate)
@@ -120,7 +120,7 @@ contains
     this%value = vector_glsum(difference, design%size()) / &
          real(design%size_global(), kind=rp)
 
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
   end subroutine mma_obj_update_value
 
   subroutine mma_obj_update_sensitivity(this, design)
@@ -131,9 +131,9 @@ contains
     type(vector_t), pointer :: x_coordinate
     integer :: ind(2)
 
-    call neko_vector_scratch_registry%request_vector(design%size(), &
+    call neko_scratch_registry%request_vector(design%size(), &
          x_coordinate, ind(1))
-    call neko_vector_scratch_registry%request_vector(design%size(), &
+    call neko_scratch_registry%request_vector(design%size(), &
          difference, ind(2))
 
     call design%get_x(x_coordinate)
@@ -144,7 +144,7 @@ contains
          real(design%size_global(), kind=rp), design%size())
     this%sensitivity = difference
 
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
   end subroutine mma_obj_update_sensitivity
 
 end module example_problem_mma

--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -51,6 +51,7 @@ module adjoint_fluid_pnpn
   use device_mathops, only: device_opcolv, device_opadd2cm
   use fluid_aux, only: fluid_step_info
   use time_scheme_controller, only: time_scheme_controller_t
+  use scratch_registry, only: neko_scratch_registry
   use projection, only: projection_t
   use projection_vel, only: projection_vel_t
   use device, only: device_memcpy, HOST_TO_DEVICE, device_event_sync, &
@@ -1130,7 +1131,7 @@ contains
     call neko_log%message(log_buf)
     call neko_log%end_section()
 
-    call this%scratch%request_field(bdry_field, temp_index)
+    call neko_scratch_registry%request_field(bdry_field, temp_index)
     bdry_field = 0.0_rp
 
 
@@ -1217,7 +1218,7 @@ contains
     call bdry_file%init('boundary_adjoint.fld')
     call bdry_file%write(bdry_field)
 
-    call this%scratch%relinquish_field(temp_index)
+    call neko_scratch_registry%relinquish_field(temp_index)
   end subroutine adjoint_fluid_pnpn_write_boundary_conditions
 
   ! End of section to verify

--- a/sources/adjoint/adjoint_fluid_scheme.f90
+++ b/sources/adjoint/adjoint_fluid_scheme.f90
@@ -52,7 +52,7 @@ module adjoint_fluid_scheme
   use time_step_controller, only: time_step_controller_t
   use field_list, only : field_list_t
   use interpolation, only: interpolator_t
-  use scratch_registry, only : scratch_registry_t
+  use field_scratch_registry, only : field_scratch_registry_t
 
   implicit none
   private
@@ -79,7 +79,7 @@ module adjoint_fluid_scheme
      !> Interpolator between the original and higher-order spaces
      type(interpolator_t) :: GLL_to_GL
      !> Scratch registry on the GL space
-     type(scratch_registry_t) :: scratch_GL
+     type(field_scratch_registry_t) :: scratch_GL
 
      type(time_scheme_controller_t), allocatable :: ext_bdf
 

--- a/sources/adjoint/adjoint_fluid_scheme.f90
+++ b/sources/adjoint/adjoint_fluid_scheme.f90
@@ -52,7 +52,7 @@ module adjoint_fluid_scheme
   use time_step_controller, only: time_step_controller_t
   use field_list, only : field_list_t
   use interpolation, only: interpolator_t
-  use field_scratch_registry, only : field_scratch_registry_t
+  use scratch_registry, only : scratch_registry_t
 
   implicit none
   private
@@ -79,7 +79,7 @@ module adjoint_fluid_scheme
      !> Interpolator between the original and higher-order spaces
      type(interpolator_t) :: GLL_to_GL
      !> Scratch registry on the GL space
-     type(field_scratch_registry_t) :: scratch_GL
+     type(scratch_registry_t) :: scratch_GL
 
      type(time_scheme_controller_t), allocatable :: ext_bdf
 

--- a/sources/adjoint/adjoint_fluid_scheme_incompressible.f90
+++ b/sources/adjoint/adjoint_fluid_scheme_incompressible.f90
@@ -57,7 +57,7 @@ module adjoint_fluid_scheme_incompressible
   use field_registry, only: neko_field_registry
   use json_utils, only: json_get, json_get_or_default
   use json_module, only: json_file
-  use scratch_registry, only: scratch_registry_t
+  use field_scratch_registry, only: field_scratch_registry_t
   use user_intf, only: user_t, dummy_user_material_properties, &
        user_material_properties_intf
   use utils, only: neko_error
@@ -103,7 +103,7 @@ module adjoint_fluid_scheme_incompressible
      integer(kind=i8) :: glb_n_points
      !> Global number of GLL points for the fluid (unique)
      integer(kind=i8) :: glb_unique_points
-     type(scratch_registry_t) :: scratch !< Manager for temporary fields
+     type(field_scratch_registry_t) :: scratch !< Manager for temporary fields
    contains
      !> Constructor for the base type
      procedure, pass(this) :: init_base => adjoint_fluid_scheme_init_base

--- a/sources/adjoint/adjoint_fluid_scheme_incompressible.f90
+++ b/sources/adjoint/adjoint_fluid_scheme_incompressible.f90
@@ -103,7 +103,6 @@ module adjoint_fluid_scheme_incompressible
      integer(kind=i8) :: glb_n_points
      !> Global number of GLL points for the fluid (unique)
      integer(kind=i8) :: glb_unique_points
-     type(field_scratch_registry_t) :: scratch !< Manager for temporary fields
    contains
      !> Constructor for the base type
      procedure, pass(this) :: init_base => adjoint_fluid_scheme_init_base
@@ -191,10 +190,7 @@ contains
     call this%GLL_to_GL%init(this%Xh_GL, this%Xh)
 
     ! Overintegration scratch registry (5 should be sufficient)
-    call this%scratch_GL%init(this%dm_Xh_GL, 5, 2)
-
-    ! Local scratch registry
-    call this%scratch%init(this%dm_Xh, 10, 2)
+    call this%scratch_GL%init(5, 2, this%dm_Xh_GL)
 
     ! Assign a name
     call json_get_or_default(params, 'case.fluid.name', this%name, "fluid")
@@ -420,7 +416,6 @@ contains
 
     call this%c_Xh%free()
 
-    call this%scratch%free()
     call this%scratch_GL%free()
 
     nullify(this%u_adj)

--- a/sources/adjoint/adjoint_fluid_scheme_incompressible.f90
+++ b/sources/adjoint/adjoint_fluid_scheme_incompressible.f90
@@ -57,7 +57,6 @@ module adjoint_fluid_scheme_incompressible
   use field_registry, only: neko_field_registry
   use json_utils, only: json_get, json_get_or_default
   use json_module, only: json_file
-  use field_scratch_registry, only: field_scratch_registry_t
   use user_intf, only: user_t, dummy_user_material_properties, &
        user_material_properties_intf
   use utils, only: neko_error

--- a/sources/optimizer/bcknd/device/mma_device.f90
+++ b/sources/optimizer/bcknd/device/mma_device.f90
@@ -45,7 +45,7 @@ submodule (mma) mma_device
        device_mma_gensub2, device_mattrans_v_mul, device_mma_dipsolvesub1, &
        device_mma_Ljjxinv, device_Hess
 
-  use neko_config, only: NEKO_BCKND_DEVICE
+  use neko_config, only: NEKO_BCKND_DEVICE, NEKO_DEVICE_MPI
   use device, only: DEVICE_TO_HOST
   use comm, only: neko_comm, pe_rank, mpi_real_precision
   use mpi_f08, only: MPI_IN_PLACE, MPI_MAX, MPI_MIN
@@ -129,7 +129,7 @@ contains
     this%residunorm = sqrt(device_norm(relambda%x_d, this%m)+ &
          device_norm(remu%x_d, this%m))
 
-    call neko_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish(ind)
   end subroutine mma_dip_KKT_device
 
   !> Implementation of the KKT residual computation for dual primal interior
@@ -211,7 +211,7 @@ contains
          device_norm(res%x_d, this%m) &
          ) + re_sq_norm)
 
-    call neko_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish(ind)
   end subroutine mma_dpip_KKT_device
 
   !============================================================================!
@@ -239,8 +239,6 @@ contains
     call neko_scratch_registry%request_vector(this%n, x_diff, ind)
 
     call device_sub3(x_diff%x_d, this%xmax%x_d, this%xmin%x_d, this%n)
-    call device_memcpy(x_diff%x, x_diff%x_d, this%n, &
-         DEVICE_TO_HOST, sync = .true.)
 
     ! ------------------------------------------------------------------------ !
     ! Setup the current asymptotes
@@ -270,15 +268,20 @@ contains
     call device_mma_gensub4(x, this%low%x_d, this%upp%x_d, this%pij%x_d, &
          this%qij%x_d, this%n, this%m, this%bi%x_d)
 
-    call device_memcpy(this%bi%x, this%bi%x_d, this%m, DEVICE_TO_HOST, &
-         sync = .true.)
-    call MPI_Allreduce(MPI_IN_PLACE, this%bi%x, this%m, &
-         mpi_real_precision, mpi_sum, neko_comm, ierr)
-    call device_memcpy(this%bi%x, this%bi%x_d, this%m, HOST_TO_DEVICE, &
-         sync = .true.)
+    if (NEKO_DEVICE_MPI) then
+       call MPI_Allreduce(MPI_IN_PLACE, this%bi%x_d, this%m, &
+            mpi_real_precision, mpi_sum, neko_comm, ierr)
+    else
+       call device_memcpy(this%bi%x, this%bi%x_d, this%m, DEVICE_TO_HOST, &
+            sync = .true.)
+       call MPI_Allreduce(MPI_IN_PLACE, this%bi%x, this%m, &
+            mpi_real_precision, mpi_sum, neko_comm, ierr)
+       call device_memcpy(this%bi%x, this%bi%x_d, this%m, HOST_TO_DEVICE, &
+            sync = .true.)
+    end if
     call device_sub2(this%bi%x_d, fval, this%m)
 
-    call neko_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish(ind)
   end subroutine mma_gensub_device
 
   !> solve the subproblem defined by this%pij, this%qij, etc. using dual-primal
@@ -298,14 +301,14 @@ contains
          delx, diagx, dx, dxsi, deta, xold, xsiold, etaold
 
     type(vector_t), pointer :: bb
-    type(matrix_t) :: GG
-    type(matrix_t) :: AA
+    type(matrix_t), pointer :: GG
+    type(matrix_t), pointer :: AA
 
     integer :: info
     integer, dimension(this%m+1) :: ipiv
     real(kind=rp) :: re_sq_norm
 
-    integer :: i, ind(33)
+    integer :: i, ind(35)
 
     real(kind=rp) :: minimal_epsilon
 
@@ -343,8 +346,8 @@ contains
     call neko_scratch_registry%request_vector(this%n, etaold, ind(32))
     call neko_scratch_registry%request_vector(this%m+1, bb, ind(33))
 
-    call GG%init(this%m, this%n)
-    call AA%init(this%m+1, this%m+1)
+    call neko_scratch_registry%request_matrix(this%m, this%n, GG, ind(34))
+    call neko_scratch_registry%request_matrix(this%m+1, this%m+1, AA, ind(35))
 
     ! ------------------------------------------------------------------------ !
     ! initial value for the parameters in the subsolve based on
@@ -406,12 +409,17 @@ contains
        ! Computing the norm of the residuals
 
        ! Complete the computations of lambda residuals
-       call device_memcpy(relambda%x, relambda%x_d, this%m, DEVICE_TO_HOST, &
-            sync = .true.)
-       call MPI_Allreduce(MPI_IN_PLACE, relambda%x, this%m, &
-            mpi_real_precision, mpi_sum, neko_comm, ierr)
-       call device_memcpy(relambda%x, relambda%x_d, this%m, HOST_TO_DEVICE, &
-            sync = .true.)
+       if (NEKO_DEVICE_MPI) then
+          call MPI_Allreduce(MPI_IN_PLACE, relambda%x_d, this%m, &
+               mpi_real_precision, mpi_sum, neko_comm, ierr)
+       else
+          call device_memcpy(relambda%x, relambda%x_d, this%m, DEVICE_TO_HOST, &
+               sync = .true.)
+          call MPI_Allreduce(MPI_IN_PLACE, relambda%x, this%m, &
+               mpi_real_precision, mpi_sum, neko_comm, ierr)
+          call device_memcpy(relambda%x, relambda%x_d, this%m, HOST_TO_DEVICE, &
+               sync = .true.)
+       end if
 
        call device_add2s2(relambda%x_d, this%a%x_d, -z, this%m)
        call device_sub2(relambda%x_d, y%x_d, this%m)
@@ -763,11 +771,7 @@ contains
     call device_copy(this%s%x_d, s%x_d, this%m)
 
     !free all the initiated variables in this subroutine
-    call neko_scratch_registry%relinquish_vector(ind)
-
-    call GG%free()
-    call AA%free()
-
+    call neko_scratch_registry%relinquish(ind)
   end subroutine mma_subsolve_dpip_device
 
   !> solve the subproblem defined by this%pij, this%qij, etc. using dual
@@ -785,11 +789,11 @@ contains
 
     ! inverse of a diag matrix:
     type(vector_t), pointer :: Ljjxinv ! [∇_x^2 Ljj]−1
-    type(matrix_t) :: hijx ! ∇_x hij
-    type(matrix_t) :: Hess
+    type(matrix_t), pointer :: hijx ! ∇_x hij
+    type(matrix_t), pointer :: Hess
     real(kind=rp) :: Hesstrace
 
-    integer :: info, ind(15)
+    integer :: info, ind(17)
     integer, dimension(this%m+1) :: ipiv
     integer :: i
 
@@ -812,10 +816,9 @@ contains
     call neko_scratch_registry%request_vector(this%n, qjlambda, ind(14))
 
     call neko_scratch_registry%request_vector(this%n, Ljjxinv, ind(15))
-    call hijx%init(this%m, this%n)
-    call Hess%init(this%m, this%m)
 
-    call device_cfill(zerom%x_d, 0.0_rp, this%m)
+    call neko_scratch_registry%request_matrix(this%m, this%n, hijx, ind(16))
+    call neko_scratch_registry%request_matrix(this%m, this%m, Hess, ind(17))
 
     ! ------------------------------------------------------------------------ !
     ! initial value for the parameters in the subsolve based on
@@ -1117,9 +1120,7 @@ contains
     call device_copy(this%lambda%x_d, lambda%x_d, this%m)
     call device_copy(this%mu%x_d, mu%x_d, this%m)
 
-    call neko_scratch_registry%relinquish_vector(ind)
-    call hijx%free()
-    call Hess%free()
+    call neko_scratch_registry%relinquish(ind)
   end subroutine mma_subsolve_dip_device
 
 end submodule mma_device

--- a/sources/optimizer/bcknd/device/mma_device.f90
+++ b/sources/optimizer/bcknd/device/mma_device.f90
@@ -50,7 +50,7 @@ submodule (mma) mma_device
   use comm, only: neko_comm, pe_rank, mpi_real_precision
   use mpi_f08, only: MPI_IN_PLACE, MPI_MAX, MPI_MIN
   use profiler, only: profiler_start_region, profiler_end_region
-  use vector_scratch_registry, only: neko_vector_scratch_registry
+  use scratch_registry, only: neko_scratch_registry
 
   implicit none
 
@@ -112,8 +112,8 @@ contains
     type(vector_t), pointer :: relambda, remu
     integer :: ind(2)
 
-    call neko_vector_scratch_registry%request_vector(this%m, relambda, ind(1))
-    call neko_vector_scratch_registry%request_vector(this%m, remu, ind(2))
+    call neko_scratch_registry%request_vector(this%m, relambda, ind(1))
+    call neko_scratch_registry%request_vector(this%m, remu, ind(2))
 
     ! relambda = fval - this%a%x * this%z - this%y%x + this%mu%x
     call device_add3s2(relambda%x_d, fval, this%a%x_d, 1.0_rp, -this%z, &
@@ -129,7 +129,7 @@ contains
     this%residunorm = sqrt(device_norm(relambda%x_d, this%m)+ &
          device_norm(remu%x_d, this%m))
 
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
   end subroutine mma_dip_KKT_device
 
   !> Implementation of the KKT residual computation for dual primal interior
@@ -144,14 +144,14 @@ contains
     integer :: ierr, ind(7)
     real(kind=rp) :: re_sq_norm
 
-    call neko_vector_scratch_registry%request_vector(this%m, rey, ind(1))
-    call neko_vector_scratch_registry%request_vector(this%m, relambda, ind(2))
-    call neko_vector_scratch_registry%request_vector(this%m, remu, ind(3))
-    call neko_vector_scratch_registry%request_vector(this%m, res, ind(4))
+    call neko_scratch_registry%request_vector(this%m, rey, ind(1))
+    call neko_scratch_registry%request_vector(this%m, relambda, ind(2))
+    call neko_scratch_registry%request_vector(this%m, remu, ind(3))
+    call neko_scratch_registry%request_vector(this%m, res, ind(4))
 
-    call neko_vector_scratch_registry%request_vector(this%n, rex, ind(5))
-    call neko_vector_scratch_registry%request_vector(this%n, rexsi, ind(6))
-    call neko_vector_scratch_registry%request_vector(this%n, reeta, ind(7))
+    call neko_scratch_registry%request_vector(this%n, rex, ind(5))
+    call neko_scratch_registry%request_vector(this%n, rexsi, ind(6))
+    call neko_scratch_registry%request_vector(this%n, reeta, ind(7))
 
     call device_kkt_rex(rex%x_d, df0dx, dfdx, this%xsi%x_d, &
          this%eta%x_d, this%lambda%x_d, this%n, this%m)
@@ -211,7 +211,7 @@ contains
          device_norm(res%x_d, this%m) &
          ) + re_sq_norm)
 
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
   end subroutine mma_dpip_KKT_device
 
   !============================================================================!
@@ -236,7 +236,7 @@ contains
     type(vector_t), pointer :: x_diff
     integer :: ind
 
-    call neko_vector_scratch_registry%request_vector(this%n, x_diff, ind)
+    call neko_scratch_registry%request_vector(this%n, x_diff, ind)
 
     call device_sub3(x_diff%x_d, this%xmax%x_d, this%xmin%x_d, this%n)
     call device_memcpy(x_diff%x, x_diff%x_d, this%n, &
@@ -278,7 +278,7 @@ contains
          sync = .true.)
     call device_sub2(this%bi%x_d, fval, this%m)
 
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
   end subroutine mma_gensub_device
 
   !> solve the subproblem defined by this%pij, this%qij, etc. using dual-primal
@@ -309,39 +309,39 @@ contains
 
     real(kind=rp) :: minimal_epsilon
 
-    call neko_vector_scratch_registry%request_vector(this%m, y, ind(1))
-    call neko_vector_scratch_registry%request_vector(this%m, lambda, ind(2))
-    call neko_vector_scratch_registry%request_vector(this%m, s, ind(3))
-    call neko_vector_scratch_registry%request_vector(this%m, mu, ind(4))
-    call neko_vector_scratch_registry%request_vector(this%m, rey, ind(5))
-    call neko_vector_scratch_registry%request_vector(this%m, relambda, ind(6))
-    call neko_vector_scratch_registry%request_vector(this%m, remu, ind(7))
-    call neko_vector_scratch_registry%request_vector(this%m, res, ind(8))
-    call neko_vector_scratch_registry%request_vector(this%m, dely, ind(9))
-    call neko_vector_scratch_registry%request_vector(this%m, dellambda, ind(10))
-    call neko_vector_scratch_registry%request_vector(this%m, dy, ind(11))
-    call neko_vector_scratch_registry%request_vector(this%m, dlambda, ind(12))
-    call neko_vector_scratch_registry%request_vector(this%m, ds, ind(13))
-    call neko_vector_scratch_registry%request_vector(this%m, dmu, ind(14))
-    call neko_vector_scratch_registry%request_vector(this%m, yold, ind(15))
-    call neko_vector_scratch_registry%request_vector(this%m, lambdaold, ind(16))
-    call neko_vector_scratch_registry%request_vector(this%m, sold, ind(17))
-    call neko_vector_scratch_registry%request_vector(this%m, muold, ind(18))
-    call neko_vector_scratch_registry%request_vector(this%n, x, ind(19))
-    call neko_vector_scratch_registry%request_vector(this%n, xsi, ind(20))
-    call neko_vector_scratch_registry%request_vector(this%n, eta, ind(21))
-    call neko_vector_scratch_registry%request_vector(this%n, rex, ind(22))
-    call neko_vector_scratch_registry%request_vector(this%n, rexsi, ind(23))
-    call neko_vector_scratch_registry%request_vector(this%n, reeta, ind(24))
-    call neko_vector_scratch_registry%request_vector(this%n, delx, ind(25))
-    call neko_vector_scratch_registry%request_vector(this%n, diagx, ind(26))
-    call neko_vector_scratch_registry%request_vector(this%n, dx, ind(27))
-    call neko_vector_scratch_registry%request_vector(this%n, dxsi, ind(28))
-    call neko_vector_scratch_registry%request_vector(this%n, deta, ind(29))
-    call neko_vector_scratch_registry%request_vector(this%n, xold, ind(30))
-    call neko_vector_scratch_registry%request_vector(this%n, xsiold, ind(31))
-    call neko_vector_scratch_registry%request_vector(this%n, etaold, ind(32))
-    call neko_vector_scratch_registry%request_vector(this%m+1, bb, ind(33))
+    call neko_scratch_registry%request_vector(this%m, y, ind(1))
+    call neko_scratch_registry%request_vector(this%m, lambda, ind(2))
+    call neko_scratch_registry%request_vector(this%m, s, ind(3))
+    call neko_scratch_registry%request_vector(this%m, mu, ind(4))
+    call neko_scratch_registry%request_vector(this%m, rey, ind(5))
+    call neko_scratch_registry%request_vector(this%m, relambda, ind(6))
+    call neko_scratch_registry%request_vector(this%m, remu, ind(7))
+    call neko_scratch_registry%request_vector(this%m, res, ind(8))
+    call neko_scratch_registry%request_vector(this%m, dely, ind(9))
+    call neko_scratch_registry%request_vector(this%m, dellambda, ind(10))
+    call neko_scratch_registry%request_vector(this%m, dy, ind(11))
+    call neko_scratch_registry%request_vector(this%m, dlambda, ind(12))
+    call neko_scratch_registry%request_vector(this%m, ds, ind(13))
+    call neko_scratch_registry%request_vector(this%m, dmu, ind(14))
+    call neko_scratch_registry%request_vector(this%m, yold, ind(15))
+    call neko_scratch_registry%request_vector(this%m, lambdaold, ind(16))
+    call neko_scratch_registry%request_vector(this%m, sold, ind(17))
+    call neko_scratch_registry%request_vector(this%m, muold, ind(18))
+    call neko_scratch_registry%request_vector(this%n, x, ind(19))
+    call neko_scratch_registry%request_vector(this%n, xsi, ind(20))
+    call neko_scratch_registry%request_vector(this%n, eta, ind(21))
+    call neko_scratch_registry%request_vector(this%n, rex, ind(22))
+    call neko_scratch_registry%request_vector(this%n, rexsi, ind(23))
+    call neko_scratch_registry%request_vector(this%n, reeta, ind(24))
+    call neko_scratch_registry%request_vector(this%n, delx, ind(25))
+    call neko_scratch_registry%request_vector(this%n, diagx, ind(26))
+    call neko_scratch_registry%request_vector(this%n, dx, ind(27))
+    call neko_scratch_registry%request_vector(this%n, dxsi, ind(28))
+    call neko_scratch_registry%request_vector(this%n, deta, ind(29))
+    call neko_scratch_registry%request_vector(this%n, xold, ind(30))
+    call neko_scratch_registry%request_vector(this%n, xsiold, ind(31))
+    call neko_scratch_registry%request_vector(this%n, etaold, ind(32))
+    call neko_scratch_registry%request_vector(this%m+1, bb, ind(33))
 
     call GG%init(this%m, this%n)
     call AA%init(this%m+1, this%m+1)
@@ -763,7 +763,7 @@ contains
     call device_copy(this%s%x_d, s%x_d, this%m)
 
     !free all the initiated variables in this subroutine
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
 
     call GG%free()
     call AA%free()
@@ -795,23 +795,23 @@ contains
 
     real(kind=rp) :: minimal_epsilon
 
-    call neko_vector_scratch_registry%request_vector(this%m, y, ind(1))
-    call neko_vector_scratch_registry%request_vector(this%m, lambda, ind(2))
-    call neko_vector_scratch_registry%request_vector(this%m, mu, ind(3))
-    call neko_vector_scratch_registry%request_vector(this%m, relambda, ind(4))
-    call neko_vector_scratch_registry%request_vector(this%m, remu, ind(5))
-    call neko_vector_scratch_registry%request_vector(this%m, dlambda, ind(6))
-    call neko_vector_scratch_registry%request_vector(this%m, dmu, ind(7))
-    call neko_vector_scratch_registry%request_vector(this%m, gradlambda, ind(8))
-    call neko_vector_scratch_registry%request_vector(this%m, zerom, ind(9))
-    call neko_vector_scratch_registry%request_vector(this%m, dd, ind(10))
-    call neko_vector_scratch_registry%request_vector(this%m, dummy_m, ind(11))
+    call neko_scratch_registry%request_vector(this%m, y, ind(1))
+    call neko_scratch_registry%request_vector(this%m, lambda, ind(2))
+    call neko_scratch_registry%request_vector(this%m, mu, ind(3))
+    call neko_scratch_registry%request_vector(this%m, relambda, ind(4))
+    call neko_scratch_registry%request_vector(this%m, remu, ind(5))
+    call neko_scratch_registry%request_vector(this%m, dlambda, ind(6))
+    call neko_scratch_registry%request_vector(this%m, dmu, ind(7))
+    call neko_scratch_registry%request_vector(this%m, gradlambda, ind(8))
+    call neko_scratch_registry%request_vector(this%m, zerom, ind(9))
+    call neko_scratch_registry%request_vector(this%m, dd, ind(10))
+    call neko_scratch_registry%request_vector(this%m, dummy_m, ind(11))
 
-    call neko_vector_scratch_registry%request_vector(this%n, x, ind(12))
-    call neko_vector_scratch_registry%request_vector(this%n, pjlambda,ind(13))
-    call neko_vector_scratch_registry%request_vector(this%n, qjlambda, ind(14))
+    call neko_scratch_registry%request_vector(this%n, x, ind(12))
+    call neko_scratch_registry%request_vector(this%n, pjlambda,ind(13))
+    call neko_scratch_registry%request_vector(this%n, qjlambda, ind(14))
 
-    call neko_vector_scratch_registry%request_vector(this%n, Ljjxinv, ind(15))
+    call neko_scratch_registry%request_vector(this%n, Ljjxinv, ind(15))
     call hijx%init(this%m, this%n)
     call Hess%init(this%m, this%m)
 
@@ -1117,7 +1117,7 @@ contains
     call device_copy(this%lambda%x_d, lambda%x_d, this%m)
     call device_copy(this%mu%x_d, mu%x_d, this%m)
 
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
     call hijx%free()
     call Hess%free()
   end subroutine mma_subsolve_dip_device

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -12,7 +12,7 @@ module mma_optimizer
   use brinkman_design, only: brinkman_design_t
   use field, only: field_t
   use field_registry, only: neko_field_registry
-  use vector_scratch_registry, only: neko_vector_scratch_registry
+  use scratch_registry, only: neko_scratch_registry
   use profiler, only: profiler_start_region, profiler_end_region
 
   use vector, only: vector_t
@@ -94,7 +94,7 @@ contains
     type(json_file) :: solver_parameters
     logical :: unconstrained_problem
 
-    call neko_vector_scratch_registry%request_vector(design%size(), x, ind)
+    call neko_scratch_registry%request_vector(design%size(), x, ind)
 
     call design%get_values(x)
 
@@ -116,7 +116,7 @@ contains
             solver_parameters, this%scale, this%auto_scale)
     end if
 
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
 
     call json_get_or_default(parameters, "optimization.solver.max_iterations", &
          max_iterations, 100)
@@ -192,12 +192,12 @@ contains
     end if
 
     ! Initialize the vectors
-    call neko_vector_scratch_registry%request_vector(n, x, ind(1))
-    call neko_vector_scratch_registry%request_vector( &
+    call neko_scratch_registry%request_vector(n, x, ind(1))
+    call neko_scratch_registry%request_vector( &
          problem%get_n_objectives(), all_objectives, ind(2))
-    call neko_vector_scratch_registry%request_vector( &
+    call neko_scratch_registry%request_vector( &
          problem%get_n_constraints(), constraint_value, ind(3))
-    call neko_vector_scratch_registry%request_vector(n, &
+    call neko_scratch_registry%request_vector(n, &
          objective_sensitivities, ind(4))
 
     call constraint_sensitivities%init(problem%get_n_constraints(), n)
@@ -325,8 +325,7 @@ contains
     end if
 
     ! Free local resources
-    call neko_vector_scratch_registry%relinquish_vector(ind)
-
+    call neko_scratch_registry%relinquish_vector(ind)
     call constraint_sensitivities%free()
 
   end subroutine mma_optimizer_run
@@ -340,7 +339,7 @@ contains
     type(vector_t), pointer :: constraint_values
     integer :: ind
 
-    call neko_vector_scratch_registry%request_vector( &
+    call neko_scratch_registry%request_vector( &
          problem%get_n_constraints(), constraint_values, ind)
 
     call problem%get_constraint_values(constraint_values)
@@ -355,7 +354,7 @@ contains
     end if
 
     ! Free local resources
-    call neko_vector_scratch_registry%relinquish_vector(ind)
+    call neko_scratch_registry%relinquish_vector(ind)
 
   end subroutine mma_optimizer_validate
 

--- a/sources/problems/constraints/volume_constraint.f90
+++ b/sources/problems/constraints/volume_constraint.f90
@@ -49,7 +49,6 @@ module volume_constraint
   use field, only: field_t
   use field_registry, only: neko_field_registry
   use scratch_registry, only: neko_scratch_registry
-  use vector_scratch_registry, only: neko_vector_scratch_registry
   use neko_config, only: NEKO_BCKND_DEVICE
   use mask_ops, only: mask_exterior_const
   use math, only: glsc2, copy, cmult
@@ -319,16 +318,16 @@ contains
     type(vector_t), pointer :: values, unmapped_values
     integer :: temp_indices, ind_value, ind_um_value
 
-    call neko_vector_scratch_registry%request_vector(design%size(), values, &
+    call neko_scratch_registry%request_vector(design%size(), values, &
          ind_value)
 
     volume = 0.0_rp
     if (this%if_mapping) then
-       call neko_vector_scratch_registry%request_vector(design%size(), &
+       call neko_scratch_registry%request_vector(design%size(), &
             unmapped_values, ind_um_value)
        call design%get_values(unmapped_values)
        call this%mapping%apply_forward(values, unmapped_values)
-       call neko_vector_scratch_registry%relinquish_vector(ind_um_value)
+       call neko_scratch_registry%relinquish_vector(ind_um_value)
     else
        call design%get_values(values)
     end if
@@ -358,7 +357,7 @@ contains
 
     end if
 
-    call neko_vector_scratch_registry%relinquish_vector(ind_value)
+    call neko_scratch_registry%relinquish_vector(ind_value)
 
   end function volume_brinkman_design
 

--- a/sources/problems/objectives/augmented_lagrangian_objective.f90
+++ b/sources/problems/objectives/augmented_lagrangian_objective.f90
@@ -35,8 +35,7 @@ module augmented_lagrangian_objective
   use num_types, only: rp
   use field, only: field_t
   use field_math, only: field_col3, field_addcol3, field_cmult
-  use scratch_registry, only: neko_scratch_registry
-  use field_scratch_registry, only: field_scratch_registry_t
+  use scratch_registry, only: neko_scratch_registry, scratch_registry_t
   use objective, only: objective_t
   use simulation_m, only: simulation_t
   use neko_config, only: NEKO_BCKND_DEVICE
@@ -86,7 +85,7 @@ module augmented_lagrangian_objective
      !> If dealiasing should be applied
      logical :: dealias
      !> GL scratch registry
-     type(field_scratch_registry_t), pointer :: scratch_GL
+     type(scratch_registry_t), pointer :: scratch_GL
 
    contains
      !> The common constructor using a JSON object.

--- a/sources/problems/objectives/augmented_lagrangian_objective.f90
+++ b/sources/problems/objectives/augmented_lagrangian_objective.f90
@@ -35,7 +35,8 @@ module augmented_lagrangian_objective
   use num_types, only: rp
   use field, only: field_t
   use field_math, only: field_col3, field_addcol3, field_cmult
-  use scratch_registry, only: scratch_registry_t, neko_scratch_registry
+  use scratch_registry, only: neko_scratch_registry
+  use field_scratch_registry, only: field_scratch_registry_t
   use objective, only: objective_t
   use simulation_m, only: simulation_t
   use neko_config, only: NEKO_BCKND_DEVICE
@@ -85,7 +86,7 @@ module augmented_lagrangian_objective
      !> If dealiasing should be applied
      logical :: dealias
      !> GL scratch registry
-     type(scratch_registry_t), pointer :: scratch_GL
+     type(field_scratch_registry_t), pointer :: scratch_GL
 
    contains
      !> The common constructor using a JSON object.

--- a/sources/problems/objectives/lube_term_objective.f90
+++ b/sources/problems/objectives/lube_term_objective.f90
@@ -69,8 +69,7 @@ module lube_term_objective
   use adjoint_fluid_pnpn, only: adjoint_fluid_pnpn_t
   use num_types, only: rp
   use field, only: field_t
-  use scratch_registry, only: neko_scratch_registry
-  use field_scratch_registry, only: field_scratch_registry_t
+  use scratch_registry, only: neko_scratch_registry, scratch_registry_t
   use neko_config, only: NEKO_BCKND_DEVICE
   use mask_ops, only: mask_exterior_const, compute_masked_volume
   use utils, only: neko_error
@@ -121,7 +120,7 @@ module lube_term_objective
      !> Interpolator between the original and higher-order spaces
      type(interpolator_t), pointer :: GLL_to_GL
      !> GL scratch registry
-     type(field_scratch_registry_t), pointer :: scratch_GL
+     type(scratch_registry_t), pointer :: scratch_GL
 
    contains
 

--- a/sources/problems/objectives/lube_term_objective.f90
+++ b/sources/problems/objectives/lube_term_objective.f90
@@ -69,7 +69,8 @@ module lube_term_objective
   use adjoint_fluid_pnpn, only: adjoint_fluid_pnpn_t
   use num_types, only: rp
   use field, only: field_t
-  use scratch_registry, only: scratch_registry_t, neko_scratch_registry
+  use scratch_registry, only: neko_scratch_registry
+  use field_scratch_registry, only: field_scratch_registry_t
   use neko_config, only: NEKO_BCKND_DEVICE
   use mask_ops, only: mask_exterior_const, compute_masked_volume
   use utils, only: neko_error
@@ -120,7 +121,7 @@ module lube_term_objective
      !> Interpolator between the original and higher-order spaces
      type(interpolator_t), pointer :: GLL_to_GL
      !> GL scratch registry
-     type(scratch_registry_t), pointer :: scratch_GL
+     type(field_scratch_registry_t), pointer :: scratch_GL
 
    contains
 

--- a/sources/source_terms/adjoint_lube_source_term.f90
+++ b/sources/source_terms/adjoint_lube_source_term.f90
@@ -60,7 +60,8 @@ module adjoint_lube_source_term
   use point_zone, only: point_zone_t
   use utils, only: neko_error
   use field_registry, only : neko_field_registry
-  use scratch_registry, only: scratch_registry_t, neko_scratch_registry
+  use scratch_registry, only: neko_scratch_registry
+  use field_scratch_registry, only: field_scratch_registry_t
   use neko_config, only: NEKO_BCKND_DEVICE
   use math, only: col2, invcol2
   use device_math, only: device_col2, device_invcol2
@@ -96,7 +97,7 @@ module adjoint_lube_source_term
      !> Interpolator between the original and higher-order spaces
      type(interpolator_t), pointer :: GLL_to_GL
      !> GL scratch registry
-     type(scratch_registry_t), pointer :: scratch_GL
+     type(field_scratch_registry_t), pointer :: scratch_GL
      !> Volume of the objective domain
      real(kind=rp) :: volume
 
@@ -167,7 +168,7 @@ contains
     type(interpolator_t), intent(in), target :: GLL_to_GL
     logical, intent(in) :: dealias
     real(kind=rp), intent(in) :: volume
-    type(scratch_registry_t), intent(in), target :: scratch_GL
+    type(field_scratch_registry_t), intent(in), target :: scratch_GL
     real(kind=rp) :: start_time
     real(kind=rp) :: end_time
     type(field_list_t) :: fields

--- a/sources/source_terms/adjoint_lube_source_term.f90
+++ b/sources/source_terms/adjoint_lube_source_term.f90
@@ -60,8 +60,7 @@ module adjoint_lube_source_term
   use point_zone, only: point_zone_t
   use utils, only: neko_error
   use field_registry, only : neko_field_registry
-  use scratch_registry, only: neko_scratch_registry
-  use field_scratch_registry, only: field_scratch_registry_t
+  use scratch_registry, only: neko_scratch_registry, scratch_registry_t
   use neko_config, only: NEKO_BCKND_DEVICE
   use math, only: col2, invcol2
   use device_math, only: device_col2, device_invcol2
@@ -97,7 +96,7 @@ module adjoint_lube_source_term
      !> Interpolator between the original and higher-order spaces
      type(interpolator_t), pointer :: GLL_to_GL
      !> GL scratch registry
-     type(field_scratch_registry_t), pointer :: scratch_GL
+     type(scratch_registry_t), pointer :: scratch_GL
      !> Volume of the objective domain
      real(kind=rp) :: volume
 
@@ -168,7 +167,7 @@ contains
     type(interpolator_t), intent(in), target :: GLL_to_GL
     logical, intent(in) :: dealias
     real(kind=rp), intent(in) :: volume
-    type(field_scratch_registry_t), intent(in), target :: scratch_GL
+    type(scratch_registry_t), intent(in), target :: scratch_GL
     real(kind=rp) :: start_time
     real(kind=rp) :: end_time
     type(field_list_t) :: fields

--- a/sources/source_terms/adjoint_scalar_convection_source_term.f90
+++ b/sources/source_terms/adjoint_scalar_convection_source_term.f90
@@ -45,8 +45,7 @@ module adjoint_scalar_convection_source_term
   use field_math, only: field_subcol3, field_sub2, field_col3
   use operators, only: grad, dudxyz
   use utils, only: neko_error
-  use scratch_registry, only: neko_scratch_registry
-  use field_scratch_registry, only: field_scratch_registry_t
+  use scratch_registry, only: neko_scratch_registry, scratch_registry_t
   use neko_config, only: NEKO_BCKND_DEVICE
   use math, only: col2, invcol2
   use device_math, only: device_col2, device_invcol2
@@ -80,7 +79,7 @@ module adjoint_scalar_convection_source_term
      !> if dealiasing should be applied
      logical :: dealias
      !> GL scratch registry
-     type(field_scratch_registry_t), pointer :: scratch_GL
+     type(scratch_registry_t), pointer :: scratch_GL
 
    contains
      !> The common constructor using a JSON object.
@@ -140,7 +139,7 @@ contains
     type(coef_t), intent(in), target :: c_Xh_GL
     type(interpolator_t), intent(in), target :: GLL_to_GL
     logical, intent(in) :: dealias
-    type(field_scratch_registry_t), intent(in), target :: scratch_GL
+    type(scratch_registry_t), intent(in), target :: scratch_GL
 
     type(field_list_t) :: fields
     real(kind=rp) :: start_time

--- a/sources/source_terms/adjoint_scalar_convection_source_term.f90
+++ b/sources/source_terms/adjoint_scalar_convection_source_term.f90
@@ -36,7 +36,6 @@ module adjoint_scalar_convection_source_term
   use num_types, only: rp
   use field_list, only: field_list_t
   use field, only: field_t
-  use scratch_registry, only: neko_scratch_registry
   use json_module, only: json_file
   use time_state, only: time_state_t
   use source_term, only: source_term_t
@@ -46,7 +45,8 @@ module adjoint_scalar_convection_source_term
   use field_math, only: field_subcol3, field_sub2, field_col3
   use operators, only: grad, dudxyz
   use utils, only: neko_error
-  use scratch_registry, only: scratch_registry_t, neko_scratch_registry
+  use scratch_registry, only: neko_scratch_registry
+  use field_scratch_registry, only: field_scratch_registry_t
   use neko_config, only: NEKO_BCKND_DEVICE
   use math, only: col2, invcol2
   use device_math, only: device_col2, device_invcol2
@@ -80,7 +80,7 @@ module adjoint_scalar_convection_source_term
      !> if dealiasing should be applied
      logical :: dealias
      !> GL scratch registry
-     type(scratch_registry_t), pointer :: scratch_GL
+     type(field_scratch_registry_t), pointer :: scratch_GL
 
    contains
      !> The common constructor using a JSON object.
@@ -140,7 +140,7 @@ contains
     type(coef_t), intent(in), target :: c_Xh_GL
     type(interpolator_t), intent(in), target :: GLL_to_GL
     logical, intent(in) :: dealias
-    type(scratch_registry_t), intent(in), target :: scratch_GL
+    type(field_scratch_registry_t), intent(in), target :: scratch_GL
 
     type(field_list_t) :: fields
     real(kind=rp) :: start_time

--- a/sources/source_terms/simple_brinkman_source_term.f90
+++ b/sources/source_terms/simple_brinkman_source_term.f90
@@ -48,7 +48,8 @@ module simple_brinkman_source_term
   use space, only: space_t, GL
   use math, only: col2, invcol2
   use device_math, only: device_col2, device_invcol2
-  use scratch_registry, only: scratch_registry_t, neko_scratch_registry
+  use scratch_registry, only: neko_scratch_registry
+  use field_scratch_registry, only: field_scratch_registry_t
   implicit none
   private
 
@@ -75,7 +76,7 @@ module simple_brinkman_source_term
      !> if dealiasing should be applied
      logical :: dealias
      !> GL scratch registry
-     type(scratch_registry_t), pointer :: scratch_GL
+     type(field_scratch_registry_t), pointer :: scratch_GL
 
    contains
      !> The common constructor using a JSON object.
@@ -136,7 +137,7 @@ contains
     real(kind=rp) :: end_time
     type(field_t), intent(in), target :: u, v, w
     type(field_t), intent(in), target :: chi
-    type(scratch_registry_t), intent(in), target :: scratch_GL
+    type(field_scratch_registry_t), intent(in), target :: scratch_GL
 
     ! I wish you didn't need a start time and end time...
     ! but I'm just going to set a super big number...

--- a/sources/source_terms/simple_brinkman_source_term.f90
+++ b/sources/source_terms/simple_brinkman_source_term.f90
@@ -48,8 +48,7 @@ module simple_brinkman_source_term
   use space, only: space_t, GL
   use math, only: col2, invcol2
   use device_math, only: device_col2, device_invcol2
-  use scratch_registry, only: neko_scratch_registry
-  use field_scratch_registry, only: field_scratch_registry_t
+  use scratch_registry, only: neko_scratch_registry, scratch_registry_t
   implicit none
   private
 
@@ -76,7 +75,7 @@ module simple_brinkman_source_term
      !> if dealiasing should be applied
      logical :: dealias
      !> GL scratch registry
-     type(field_scratch_registry_t), pointer :: scratch_GL
+     type(scratch_registry_t), pointer :: scratch_GL
 
    contains
      !> The common constructor using a JSON object.
@@ -137,7 +136,7 @@ contains
     real(kind=rp) :: end_time
     type(field_t), intent(in), target :: u, v, w
     type(field_t), intent(in), target :: chi
-    type(field_scratch_registry_t), intent(in), target :: scratch_GL
+    type(scratch_registry_t), intent(in), target :: scratch_GL
 
     ! I wish you didn't need a start time and end time...
     ! but I'm just going to set a super big number...


### PR DESCRIPTION
Update the code to use the new `field_scratch_registry` interface instead of the deprecated `scratch_registry`. This change ensures compatibility with the latest Neko framework updates.

Depends on #315