### PR TITLE
Add size mismatch checks in design retrieval subroutines

### DIFF
--- a/examples/1d_beam/example_problem.f90
+++ b/examples/1d_beam/example_problem.f90
@@ -126,8 +126,9 @@ contains
     real(rp) :: Le, u_global
 
     ! Local design values
-    call design%get_values(h)
     n = design%size()
+    call h%init(n)
+    call design%get_values(h)
 
     ! Project design variables to physical height h = (h_max - h_min)*x + h_min
     call vector_cmult(h, (h_max - h_min), n)

--- a/sources/designs/design_3dto1d.f90
+++ b/sources/designs/design_3dto1d.f90
@@ -135,6 +135,10 @@ contains
     class(design_3dto1d_t), intent(in) :: this
     type(vector_t), intent(inout) :: values
 
+    if (this%size() .ne. values%size()) then
+       call neko_error('Get design: size mismatch')
+    end if
+
     values = this%values
 
   end subroutine design_3dto1d_get_values

--- a/sources/designs/design_3dto1d.f90
+++ b/sources/designs/design_3dto1d.f90
@@ -50,6 +50,7 @@ module design_3dto1d
   use simulation_m, only: simulation_t
   use json_module, only: json_file
   use json_utils, only: json_get
+  use utils, only: neko_error
 
   use vector, only: vector_t
   use math, only: copy

--- a/sources/designs/design_brinkman.f90
+++ b/sources/designs/design_brinkman.f90
@@ -446,6 +446,10 @@ contains
     integer :: n
 
     n = this%size()
+    if (n .ne. values%size()) then
+       call neko_error('Get design: size mismatch')
+    end if
+
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_copy(values%x_d, this%design_indicator%x_d, n)
     else
@@ -460,6 +464,10 @@ contains
     integer :: n
 
     n = this%size()
+    if (n .ne. values%size()) then
+       call neko_error('Get design: size mismatch')
+    end if
+
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_copy(values%x_d, this%sensitivity%x_d, n)
     else
@@ -474,6 +482,10 @@ contains
     integer :: n
 
     n = this%size()
+    if (n .ne. x%size()) then
+       call neko_error('Get x: size mismatch')
+    end if
+
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_copy(x%x_d, this%design_indicator%dof%x_d, n)
     else
@@ -503,6 +515,10 @@ contains
     integer :: n
 
     n = this%size()
+    if (n .ne. y%size()) then
+       call neko_error('Get y: size mismatch')
+    end if
+
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_copy(y%x_d, this%design_indicator%dof%y_d, n)
     else
@@ -532,6 +548,10 @@ contains
     integer :: n
 
     n = this%size()
+    if (n .ne. z%size()) then
+       call neko_error('Get z: size mismatch')
+    end if
+
     if (NEKO_BCKND_DEVICE .eq. 1) then
        call device_copy(z%x_d, this%design_indicator%dof%z_d, n)
     else

--- a/sources/designs/design_simple.f90
+++ b/sources/designs/design_simple.f90
@@ -227,6 +227,9 @@ contains
     class(simple_design_t), intent(in) :: this
     type(vector_t), intent(inout) :: values
 
+    if (this%size() .ne. values%size()) then
+       call neko_error('Get design: size mismatch')
+    end if
     values = this%values
 
   end subroutine design_simple_get_values
@@ -235,6 +238,9 @@ contains
     class(simple_design_t), intent(in) :: this
     type(vector_t), intent(inout) :: x
 
+    if (this%size() .ne. x%size()) then
+       call neko_error('Get x: size mismatch')
+    end if
     x = this%x_coord
 
   end subroutine design_simple_get_x
@@ -243,6 +249,9 @@ contains
     class(simple_design_t), intent(in) :: this
     type(vector_t), intent(inout) :: y
 
+    if (this%size() .ne. y%size()) then
+       call neko_error('Get y: size mismatch')
+    end if
     y = this%y_coord
 
   end subroutine design_simple_get_y
@@ -251,6 +260,9 @@ contains
     class(simple_design_t), intent(in) :: this
     type(vector_t), intent(inout) :: z
 
+    if (this%size() .ne. z%size()) then
+       call neko_error('Get z: size mismatch')
+    end if
     z = this%z_coord
 
   end subroutine design_simple_get_z
@@ -259,6 +271,9 @@ contains
     class(simple_design_t), intent(inout) :: this
     type(vector_t), intent(inout) :: values
 
+    if (this%size() .ne. values%size()) then
+       call neko_error('Update design: size mismatch')
+    end if
     this%values = values
 
   end subroutine design_simple_update_design

--- a/sources/designs/design_simplefield.f90
+++ b/sources/designs/design_simplefield.f90
@@ -54,6 +54,7 @@ module simplefield_design
   use simple_brinkman_source_term, only: simple_brinkman_source_term_t
   use vector, only: vector_t
   use math, only: copy
+  use utils, only: neko_error
 
   use fld_file_output, only: fld_file_output_t
 

--- a/sources/designs/design_simplefield.f90
+++ b/sources/designs/design_simplefield.f90
@@ -175,6 +175,9 @@ contains
     class(simplefield_design_t), intent(in) :: this
     type(vector_t), intent(inout) :: x
 
+    if (this%size() .ne. x%size()) then
+       call neko_error('Get x: size mismatch')
+    end if
     x = this%x_coord
   end subroutine design_simple_get_x
 
@@ -182,6 +185,9 @@ contains
     class(simplefield_design_t), intent(in) :: this
     type(vector_t), intent(inout) :: y
 
+    if (this%size() .ne. y%size()) then
+       call neko_error('Get y: size mismatch')
+    end if
     y = this%y_coord
   end subroutine design_simple_get_y
 
@@ -189,6 +195,9 @@ contains
     class(simplefield_design_t), intent(in) :: this
     type(vector_t), intent(inout) :: z
 
+    if (this%size() .ne. z%size()) then
+       call neko_error('Get z: size mismatch')
+    end if
     z = this%z_coord
   end subroutine design_simple_get_z
 


### PR DESCRIPTION
Implement checks for size mismatches in several design retrieval subroutines to ensure data integrity and prevent errors during execution.