### PR TITLE
Allow overwriting mma checkpoints.

### DIFF
--- a/sources/mma/bcknd/mma_io_hdf5.f90
+++ b/sources/mma/bcknd/mma_io_hdf5.f90
@@ -48,16 +48,20 @@ contains
   !! vectors and matrices, then perform the write. Currently the low-level
   !! HDF5 write is delegated to the project's I/O layer. If no I/O layer is
   !! available at link time a runtime error will be raised.
-  module subroutine mma_write_hdf5(this, filename)
+  module subroutine mma_write_hdf5(this, filename, overwrite)
     class(mma_t), intent(inout) :: this
     character(len=*), intent(in) :: filename
+    logical, intent(in), optional :: overwrite
     integer(hid_t) :: fapl_id, xf_id, file_id, dset_id, filespace, memspace, &
          attr_id, grp_id, mma_grp_id, str_type
     integer(hid_t) :: H5T_NEKO_REAL
     integer(hsize_t), dimension(1) :: ddim, dcount, doffset
     integer :: ierr, info, drank
     integer(kind=8) :: local_n8, prefix8, total_n8
+    logical :: file_exists, mma_exists, overwrite_flag
 
+    overwrite_flag = .false.
+    if (present(overwrite)) overwrite_flag = overwrite
 
     ! Ensure device state is on host
     call this%copy_from(DEVICE_TO_HOST, sync = .true.)
@@ -74,13 +78,46 @@ contains
        call neko_error('mma: unsupported real kind for HDF5')
     end select
 
-    ! Create file with MPIO access
+    ! Prepare the HDF5 settings for MPIO access
     call h5pcreate_f(H5P_FILE_ACCESS_F, fapl_id, ierr)
     info = MPI_INFO_NULL%mpi_val
     call h5pset_fapl_mpio_f(fapl_id, NEKO_COMM%mpi_val, info, ierr)
 
-    call h5fcreate_f(trim(filename), H5F_ACC_TRUNC_F, file_id, ierr, &
-         access_prp = fapl_id)
+    ! Handle overwriting if the file exists
+    file_exists = .false.
+    inquire(file=trim(filename), exist=file_exists)
+    if (file_exists) then
+
+       ! Check for existing MMA group
+       mma_exists = .false.
+       call h5fopen_f(trim(filename), H5F_ACC_RDONLY_F, file_id, ierr, &
+            access_prp = fapl_id)
+       call h5lexists_f(file_id, "MMA", mma_exists, ierr)
+
+       call h5fclose_f(file_id, ierr)
+
+       if (mma_exists .and. overwrite_flag) then
+
+          call h5fopen_f(trim(filename), H5F_ACC_RDWR_F, file_id, ierr, &
+               access_prp = fapl_id)
+          call h5gunlink_f(file_id, "MMA", ierr)
+          call h5fclose_f(file_id, ierr)
+
+       else if (mma_exists .and. .not. overwrite_flag) then
+          call neko_error('mma: HDF5 file "' // trim(filename) // &
+               '" already contains MMA group; use overwrite option to replace')
+       end if
+    end if
+
+    ! Open or create the file
+    if (file_exists) then
+       call h5fopen_f(trim(filename), H5F_ACC_RDWR_F, file_id, ierr, &
+            access_prp = fapl_id)
+    else
+       call h5fcreate_f(trim(filename), H5F_ACC_TRUNC_F, file_id, ierr, &
+            access_prp = fapl_id)
+    end if
+
     call h5gcreate_f(file_id, "MMA", mma_grp_id, ierr, &
          lcpl_id = h5p_default_f, gcpl_id = h5p_default_f, &
          gapl_id = h5p_default_f)

--- a/sources/mma/bcknd/mma_io_hdf5.f90
+++ b/sources/mma/bcknd/mma_io_hdf5.f90
@@ -502,9 +502,10 @@ contains
 
 #else
 
-  module subroutine mma_write_hdf5(this, filename)
+  module subroutine mma_write_hdf5(this, filename, overwrite)
     class(mma_t), intent(inout) :: this
     character(len=*), intent(in) :: filename
+    logical, intent(in), optional :: overwrite
     call neko_error('mma: HDF5 support not enabled rebuild with HAVE_HDF5')
   end subroutine mma_write_hdf5
 

--- a/sources/mma/bcknd/mma_io_hdf5.f90
+++ b/sources/mma/bcknd/mma_io_hdf5.f90
@@ -1,6 +1,6 @@
 !> @file mma.f90
 !! @copyright
-!! Copyright (c) 2024-2025, The Neko-TOP Authors
+!! Copyright (c) 2024-2026, The Neko-TOP Authors
 !! All rights reserved.
 !!
 !! Redistribution and use in source and binary forms, with or without

--- a/sources/mma/mma.f90
+++ b/sources/mma/mma.f90
@@ -183,9 +183,10 @@ module mma
      ! ======================================================================= !
      ! Interface for IO routines
 
-     module subroutine mma_write_hdf5(this, filename)
+     module subroutine mma_write_hdf5(this, filename, overwrite)
        class(mma_t), intent(inout) :: this
        character(len=*), intent(in) :: filename
+       logical, intent(in), optional :: overwrite
      end subroutine mma_write_hdf5
 
      module subroutine mma_read_hdf5(this, filename)

--- a/sources/mma/mma.f90
+++ b/sources/mma/mma.f90
@@ -1,6 +1,6 @@
 !> @file mma.f90
 !! @copyright
-!! Copyright (c) 2024-2025, The Neko-TOP Authors
+!! Copyright (c) 2024-2026, The Neko-TOP Authors
 !! All rights reserved.
 !!
 !! Redistribution and use in source and binary forms, with or without

--- a/tests/unit/mma/io_hdf5.pf
+++ b/tests/unit/mma/io_hdf5.pf
@@ -63,6 +63,8 @@ contains
     character(len=:), allocatable :: bcknd, subsolver
 
     character(len=256) :: fname
+    logical :: file_exists
+    integer :: file_unit
     integer(hid_t) :: H5T_NEKO_REAL, str_type
     integer(hid_t) :: plist_id, file_id, attr_id, dset_id
     integer(hsize_t), dimension(1) :: ddim
@@ -110,7 +112,14 @@ contains
          max_iter, epsimin, asyinit, asyincr, asydecr, bcknd, subsolver)
 
     fname = 'mma_test.h5'
-    call obj%write_hdf5(fname)
+    ! Delete the file if it exists
+    inquire(file=fname, exist=file_exists)
+    if (file_exists) then
+       ! Delete the file
+       open(newunit=file_unit, file=fname, status='old', action='write')
+       close(file_unit, status='delete')
+    end if
+    call obj%write_hdf5(fname, overwrite = .true.)
 
     ! ------------------------------------------------------------------------ !
     ! Read back the data
@@ -356,7 +365,10 @@ contains
     real(kind=rp) :: a0
     integer :: max_iter
 
-    character(len=:), allocatable :: bcknd, subsolver
+    character(len=:), allocatable :: bcknd, subsolver, fname
+    logical :: file_exists
+    integer :: file_unit
+
     real(kind=rp), allocatable :: x_after(:)
 
     n = 2
@@ -383,6 +395,18 @@ contains
     call optimizer%init_from_components(x_init, n, m, a0, a, c, d, xmin, xmax, &
          bcknd = bcknd, subsolver = subsolver)
 
+    fname = 'mma_restart_test.h5'
+    ! Delete the file if it exists
+    inquire(file=fname, exist=file_exists)
+    if (file_exists) then
+       ! Delete the file
+       open(newunit=file_unit, file=fname, status='old', action='write')
+       close(file_unit, status='delete')
+    end if
+
+    ! Write the initial state, this will help us test the overwrite option
+    call optimizer%write_hdf5(fname)
+
     f = 0.0_rp
     x = x_init
     call df%init(n)
@@ -396,7 +420,7 @@ contains
        call optimizer%update(iter, x, df, g, dg)
 
        if (iter .eq. max_iter / 2) then
-          call optimizer%write_hdf5('mma_restart_test.h5')
+          call optimizer%write_hdf5(fname, overwrite = .true.)
           x_50 = x
        end if
     end do
@@ -411,7 +435,7 @@ contains
     ! Now restart from HDF5 file
     call optimizer%init_from_components(x_init, n, m, a0, a, c, d, xmin, xmax, &
          bcknd = bcknd, subsolver = subsolver)
-    call optimizer%read('mma_restart_test.h5')
+    call optimizer%read(fname)
 
     x = x_50
 


### PR DESCRIPTION
The MMA checkpointing system now allows overwriting the file.

I should be noted, we actually do not remove the file.
Rather, we remove the MMA group of the file, this mean we can now extend an existing hdf5 file with the MMA object, rather than forcing a completely separate file.
This allow more flexibility in our restarts, as multiple components can be stored in the same file without conflicts.