### PR TITLE
Update copyright year to 2026

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2023-2025, The Neko-TOP Authors
+Copyright (c) 2023-2026, The Neko-TOP Authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Update the copyright notice to reflect the current year, extending it to 2026.