### PR TITLE
Remove MPI initialization in favor of Neko initialization

### DIFF
--- a/examples/rugby_verification/driver.f90
+++ b/examples/rugby_verification/driver.f90
@@ -8,16 +8,13 @@ program usrneko
   use utils, only: neko_error
   use json_utils_ext, only: json_read_file
 
-  use mpi_f08, only: MPI_Init
+  use neko, only: neko_init, neko_finalize
   implicit none
 
   ! JSON related arguments
   integer :: argc
   type(json_file) :: parameters
   character(len=256) :: parameter_file
-
-  ! MPI parameters
-  integer :: ierr
 
   !> The simulation we are working with
   type(simulation_t) :: sim
@@ -29,9 +26,9 @@ program usrneko
   class(optimizer_t), allocatable :: opt
 
   ! -------------------------------------------------------------------------- !
-  ! Initialize the MPI environment
+  ! Initialize the Neko environment
 
-  call MPI_Init(ierr)
+  call neko_init()
 
   ! -------------------------------------------------------------------------- !
   ! Read the parameters file as the first terminal argument
@@ -67,4 +64,6 @@ program usrneko
   if (allocated(des)) deallocate(des)
   if (allocated(opt)) deallocate(opt)
 
+  ! Finalize the Neko environment
+  call neko_finalize()
 end program usrneko

--- a/sources/drivers/topopt-user.f90
+++ b/sources/drivers/topopt-user.f90
@@ -33,6 +33,7 @@
 !! POSSIBILITY OF SUCH DAMAGE.
 
 program topopt_user
+  use neko, only: neko_init, neko_finalize
   use simulation_m, only: simulation_t
   use design, only: design_t, design_factory
   use problem, only: problem_t
@@ -45,17 +46,12 @@ program topopt_user
   use neko_top, only: neko_top_register_types
   use user, only: user_setup
 
-  use mpi_f08, only: MPI_Init
-
   implicit none
 
   ! JSON related arguments
   integer :: argc
   character(len=256) :: parameter_file
   type(json_file) :: parameters, design_parameters
-
-  ! MPI parameters
-  integer :: ierr
 
   !> The simulation we are working with
   type(simulation_t) :: sim
@@ -67,9 +63,9 @@ program topopt_user
   class(optimizer_t), allocatable :: opt
 
   ! -------------------------------------------------------------------------- !
-  ! Initialize the MPI environment
+  ! Initialize the Neko environment
 
-  call MPI_Init(ierr)
+  call neko_init()
   call neko_top_register_types()
 
   ! -------------------------------------------------------------------------- !
@@ -116,5 +112,8 @@ program topopt_user
 
   if (allocated(des)) deallocate(des)
   if (allocated(opt)) deallocate(opt)
+
+  ! Finalize the Neko environment
+  call neko_finalize()
 
 end program topopt_user

--- a/sources/drivers/topopt.f90
+++ b/sources/drivers/topopt.f90
@@ -33,6 +33,7 @@
 !! POSSIBILITY OF SUCH DAMAGE.
 
 program topopt
+  use neko, only: neko_init, neko_finalize
   use simulation_m, only: simulation_t
   use design, only: design_t, design_factory
   use problem, only: problem_t
@@ -44,17 +45,12 @@ program topopt
   use json_utils_ext, only: json_read_file
   use neko_top, only: neko_top_register_types
 
-  use mpi_f08, only: MPI_Init
-
   implicit none
 
   ! JSON related arguments
   integer :: argc
   character(len=256) :: parameter_file
   type(json_file) :: parameters, design_parameters
-
-  ! MPI parameters
-  integer :: ierr
 
   !> The simulation we are working with
   type(simulation_t) :: sim
@@ -66,9 +62,9 @@ program topopt
   class(optimizer_t), allocatable :: opt
 
   ! -------------------------------------------------------------------------- !
-  ! Initialize the MPI environment
+  ! Initialize the Neko environment
 
-  call MPI_Init(ierr)
+  call neko_init()
   call neko_top_register_types()
 
   ! -------------------------------------------------------------------------- !
@@ -112,5 +108,8 @@ program topopt
 
   if (allocated(des)) deallocate(des)
   if (allocated(opt)) deallocate(opt)
+
+  ! Finalize the Neko environment
+  call neko_finalize()
 
 end program topopt

--- a/sources/simulation/simulation.f90
+++ b/sources/simulation/simulation.f90
@@ -36,7 +36,7 @@
 ! Here, we simply march forward to steady state solutions
 module simulation_m
   use case, only: case_t
-  use neko, only: neko_init, neko_finalize, neko_solve
+  use neko, only: neko_solve
   use adjoint_case, only: adjoint_case_t, adjoint_init, adjoint_free
   use fluid_scheme_incompressible, only: fluid_scheme_incompressible_t
   use adjoint_fluid_scheme, only: adjoint_fluid_scheme_t
@@ -73,6 +73,7 @@ module simulation_m
   use simulation, only: simulation_init, simulation_step, simulation_finalize, &
        simulation_restart
   use simulation_checkpoint, only: simulation_checkpoint_t
+  use runtime_stats, only: neko_rt_stats
   implicit none
   private
 
@@ -138,8 +139,11 @@ contains
     integer :: i, n_scalars, unsteady_support
     logical :: unsteady
 
-    ! initialize the primal
-    call neko_init(this%neko_case)
+    ! initialize the primal Neko objects
+    call this%neko_case%init(parameters)
+    call neko_rt_stats%init(parameters)
+    call neko_simcomps%init(this%neko_case)
+
     ! initialize the adjoint
     call adjoint_init(this%adjoint_case, this%neko_case)
 
@@ -242,7 +246,10 @@ contains
 
     call this%checkpoint%free()
     call adjoint_free(this%adjoint_case)
-    call neko_finalize(this%neko_case)
+
+    call neko_simcomps%free()
+    call neko_rt_stats%free()
+    call this%neko_case%free()
 
   end subroutine simulation_free
 

--- a/tests/regression/sensitivity/problem_tester.f90
+++ b/tests/regression/sensitivity/problem_tester.f90
@@ -10,7 +10,7 @@ program problem_tester
   use json_utils_ext, only: json_read_file
   use utils, only: neko_error
   use neko_top, only: neko_top_register_types
-  use mpi_f08, only: MPI_Init
+  use neko, only: neko_init, neko_finalize
   use mask_ops, only: mask_exterior_const
   use neko_config, only: NEKO_BCKND_DEVICE
   use device, only: device_memcpy, DEVICE_TO_HOST
@@ -29,9 +29,6 @@ program problem_tester
   integer :: argc
   character(len=256) :: parameter_file
   type(json_file) :: parameters, design_parameters
-
-  ! MPI parameters
-  integer :: ierr
 
   !> The simulation we are working with
   type(simulation_t) :: sim
@@ -58,9 +55,9 @@ program problem_tester
   character(len=12) :: nobj_str, ncon_str
 
   ! -------------------------------------------------------------------------- !
-  ! Initialize the MPI environment
+  ! Initialize the Neko environment
 
-  call MPI_Init(ierr)
+  call neko_init()
   call neko_top_register_types()
 
   ! -------------------------------------------------------------------------- !
@@ -165,5 +162,8 @@ program problem_tester
   call prob%free()
   call des%free()
   call sim%free()
+
+  ! Finalize the Neko environment
+  call neko_finalize()
 
 end program problem_tester

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -100,7 +100,7 @@ foreach(pf_file ${PFUNIT_TEST_SOURCES})
     set_tests_properties(${test_name} PROPERTIES
         LABELS "unit"
         ENVIRONMENT "NEKO_LOG_FILE=${CMAKE_BINARY_DIR}/tests/unit/${test_name}.log"
-        TIMEOUT 60
+        TIMEOUT 120
     )
     add_dependencies(Unit ${test_name})
 endforeach()

--- a/tests/unit/checkpointing/driver.f90
+++ b/tests/unit/checkpointing/driver.f90
@@ -25,6 +25,7 @@ program checkpointing_test
   use problem, only: problem_t
   use simulation, only: simulation_init, simulation_step, simulation_finalize
 
+  use neko, only: neko_init, neko_finalize
   use num_types, only: dp, rp
   use json_module, only: json_file
   use utils, only: neko_error, neko_warning
@@ -45,9 +46,6 @@ program checkpointing_test
   integer :: argc
   type(json_file) :: parameters, design_parameters
   character(len=256) :: parameter_file
-
-  ! MPI parameters
-  integer :: ierr
 
   !> The simulation we are working with
   type(simulation_t) :: sim
@@ -87,9 +85,9 @@ program checkpointing_test
   real(kind=rp), parameter :: tol_p = NEKO_EPS
 
   ! -------------------------------------------------------------------------- !
-  ! Initialize the MPI environment
+  ! Initialize the Neko environment
 
-  call MPI_Init(ierr)
+  call neko_init()
   call neko_top_register_types()
 
   ! -------------------------------------------------------------------------- !
@@ -233,5 +231,8 @@ program checkpointing_test
   call prob%free()
 
   if (allocated(des)) deallocate(des)
+
+  ! Finalize the Neko environment
+  call neko_finalize()
 
 end program checkpointing_test

--- a/tests/unit/sensitivity/problem_tester.f90
+++ b/tests/unit/sensitivity/problem_tester.f90
@@ -5,12 +5,12 @@ program problem_tester
   use problem, only : problem_t
 
   ! Standard modules shared by most of our tests
+  use neko, only: neko_init, neko_finalize
   use json_module, only: json_file
   use json_utils, only: json_get
   use json_utils_ext, only: json_read_file
   use utils, only: neko_error
   use neko_top, only: neko_top_register_types
-  use mpi_f08, only: MPI_Init
   use mask_ops, only: mask_exterior_const
   use neko_config, only: NEKO_BCKND_DEVICE
   use device, only: device_memcpy, DEVICE_TO_HOST
@@ -28,9 +28,6 @@ program problem_tester
   integer :: argc
   character(len=256) :: parameter_file
   type(json_file) :: parameters, design_parameters
-
-  ! MPI parameters
-  integer :: ierr
 
   !> The simulation we are working with
   type(simulation_t) :: sim
@@ -54,9 +51,9 @@ program problem_tester
   character(len=12) :: nobj_str, ncon_str
 
   ! -------------------------------------------------------------------------- !
-  ! Initialize the MPI environment
+  ! Initialize the Neko environment
 
-  call MPI_Init(ierr)
+  call neko_init()
   call neko_top_register_types()
 
   ! -------------------------------------------------------------------------- !
@@ -142,5 +139,8 @@ program problem_tester
   call prob%free()
   call des%free()
   call sim%free()
+
+  ! Finalize the Neko environment
+  call neko_finalize()
 
 end program problem_tester


### PR DESCRIPTION
Refactor the code to replace MPI initialization with Neko initialization across various programs and modules. Update tests and examples accordingly to ensure compatibility with the new initialization method.