### PR TITLE
Fix permissions for cleanup job in GitHub Actions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,10 +16,7 @@ jobs:
     name: Cleanup Caches
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
       actions: write
-    if: github.event.pull_request.merged == true
     steps:
       - name: Remove Cache from merged Pull Request
         env:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,6 +15,10 @@ jobs:
   cleanup:
     name: Cleanup Caches
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
     if: github.event.pull_request.merged == true
     steps:
       - name: Remove Cache from merged Pull Request


### PR DESCRIPTION
Update permissions for the cleanup job to ensure it has the necessary access to read write actions.