### PR TITLE
Align with neko PR #2267: ortho deprecation

### DIFF
--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -83,7 +83,8 @@ module adjoint_fluid_pnpn
   use field_math, only: field_add2, field_copy
   use bc, only: bc_t
   use file, only: file_t
-  ! use operators, only: ortho
+  use operators, only: ortho
+  use opr_device, only: device_ortho
   use inflow, only: inflow_t
   use field_dirichlet, only: field_dirichlet_t
   use blasius, only: blasius_t

--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -83,7 +83,7 @@ module adjoint_fluid_pnpn
   use field_math, only: field_add2, field_copy
   use bc, only: bc_t
   use file, only: file_t
-  use operators, only: ortho
+  ! use operators, only: ortho
   use inflow, only: inflow_t
   use field_dirichlet, only: field_dirichlet_t
   use blasius, only: blasius_t
@@ -770,7 +770,11 @@ contains
            mu, rho, event)
 
       ! De-mean the pressure residual when no strong pressure boundaries present
-      if (.not. this%prs_dirichlet) call ortho(p_res%x, this%glb_n_points, n)
+      if (.not. this%prs_dirichlet .and. NEKO_BCKND_DEVICE .eq. 1) then
+         call device_ortho(p_res%x_d, this%glb_n_points, n)
+      else if (.not. this%prs_dirichlet) then
+         call ortho(p_res%x, this%glb_n_points, n)
+      end if
 
       call gs_Xh%op(p_res, GS_OP_ADD, event)
       call device_event_sync(event)
@@ -802,7 +806,11 @@ contains
 
       ! Update the pressure with the increment. Demean if necessary.
       call field_add2(p, dp, n)
-      if (.not. this%prs_dirichlet) call ortho(p%x, this%glb_n_points, n)
+      if (.not. this%prs_dirichlet .and. NEKO_BCKND_DEVICE .eq. 1) then
+         call device_ortho(p%x_d, this%glb_n_points, n)
+      else if (.not. this%prs_dirichlet) then
+         call ortho(p%x, this%glb_n_points, n)
+      end if
 
       ! Compute velocity residual.
       call profiler_start_region('Adjoint_velocity_residual')


### PR DESCRIPTION
Update the pressure residual handling to conditionally use device-specific operations based on the backend device. This change improves compatibility and performance with the NEKO backend.

Align with Neko PR [#2267](https://github.com/ExtremeFLOW/neko/pull/2267)