### PR TITLE
Fix requirements for flint

### DIFF
--- a/.github/actions/flint/requirements-flint.txt
+++ b/.github/actions/flint/requirements-flint.txt
@@ -1,3 +1,3 @@
-setuptools
+setuptools < 82.0.0
 nobvisual
 flinter


### PR DESCRIPTION
Update the setuptools requirement to ensure compatibility with flint.