### PR TITLE
Fix premature free of runtime statistics

### DIFF
--- a/sources/simulation/simulation.f90
+++ b/sources/simulation/simulation.f90
@@ -266,7 +266,6 @@ contains
 
     ! Close global objects
     call neko_simcomps%free()
-    call neko_rt_stats%free()
 
   end subroutine simulation_free
 


### PR DESCRIPTION
Prevent the premature deallocation of runtime statistics during the simulation cleanup process.