### PR TITLE
Verbose mapping cascade

### DIFF
--- a/documentation/pages/user_guide.md
+++ b/documentation/pages/user_guide.md
@@ -11,6 +11,7 @@ writing JSON files, and the PFUnit library, which is used for unit testing.
   - [Cluster Guides](@ref clusters)
 - \subpage configuration
   - [Case file structure](@ref configuration-case-file)
+  - [Design types](@ref design_types)
 - \subpage examples
   - [Running the examples](@ref examples-running)
   - [Creating a new case](@ref examples-new)

--- a/documentation/pages/user_guide/configuration.md
+++ b/documentation/pages/user_guide/configuration.md
@@ -68,6 +68,7 @@ section of the case file.
 The individual components are described in greater detail in the linked
 sections.
 
+- \subpage design_types
 - \subpage mapping_cascade
 - \subpage objectives_and_constraints
 - \subpage simulation_components

--- a/documentation/pages/user_guide/design_types.md
+++ b/documentation/pages/user_guide/design_types.md
@@ -1,0 +1,134 @@
+# Design Types {#design_types}
+
+\tableofcontents
+
+This page documents the JSON options for `optimization.design`.
+
+## Overview {#design_types-overview}
+
+The design section always lives under:
+
+```json
+"optimization": {
+  "design": {
+    "type": "..."
+  }
+}
+```
+
+Currently supported design types are:
+
+- `"brinkman"`
+- `"simple"`
+
+## Brinkman Design {#design_types-brinkman}
+
+`"type": "brinkman"` is the main design used with the mapping cascade and
+Brinkman source-term coupling.
+
+### JSON keys {#design_types-brinkman-keys}
+
+| Key | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `type` | string | Yes | - | Must be `"brinkman"` |
+| `name` | string | No | `"Brinkman Design"` | Design name |
+| `domain.type` | string | No | `"full"` | `"full"` or `"point_zone"` |
+| `domain.zone_name` | string | Cond. | - | Required when `domain.type = "point_zone"` |
+| `dealias` | bool | No | `true` | Controls dealiasing for Brinkman source terms |
+| `verbose_design` | bool | No | `false` | Write all forward mapping stages |
+| `verbose_sensitivity` | bool | No | `false` | Write all backward sensitivity stages |
+| `output_precision` | string | No | `"sp"` | `"sp"` or `"dp"` for design/sensitivity fld output |
+| `mapping` | array | No | omitted | Mapping cascade definition, see [Mapping cascade](@ref mapping_cascade) |
+| `initial_distribution` | object | No | omitted | Initial design field setup (details below) |
+
+### `initial_distribution` options {#design_types-brinkman-initial}
+
+If omitted, the design is initialized to zero.
+
+#### Uniform
+
+```json
+"initial_distribution": {
+  "type": "uniform",
+  "value": 0.0
+}
+```
+
+| Key | Type | Required | Default |
+|---|---|---|---|
+| `type` | string | Yes | - |
+| `value` | real | Yes | - |
+
+#### Point zone
+
+```json
+"initial_distribution": {
+  "type": "point_zone",
+  "base_value": 0.0,
+  "zone_name": "my_zone",
+  "zone_value": 1.0
+}
+```
+
+| Key | Type | Required | Default |
+|---|---|---|---|
+| `type` | string | Yes | - |
+| `base_value` | real | Yes | - |
+| `zone_name` | string | Yes | - |
+| `zone_value` | real | Yes | - |
+
+#### Field file
+
+```json
+"initial_distribution": {
+  "type": "field",
+  "file_name": "design0.f00001",
+  "interpolate": false,
+  "tolerance": 1.0e-6,
+  "mesh_file_name": "none"
+}
+```
+
+| Key | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `type` | string | Yes | - | Must be `"field"` |
+| `file_name` | string | Yes | - | Field sample file (e.g. `design0.f00001`) |
+| `interpolate` | bool | No | `false` | Enable interpolation from another mesh |
+| `tolerance` | real | No | `1.0e-6` | Interpolation tolerance |
+| `mesh_file_name` | string | No | `"none"` | Optional mesh/source field file for interpolation |
+
+## Simple Design {#design_types-simple}
+
+`"type": "simple"` is a lightweight design representation.
+
+\note `simple` design currently supports only single-rank execution.
+\warning In the current implementation, the `box` sizing keys are read with the
+fully-qualified paths `optimization.design.domain.nx/ny/nz/limits`.
+
+### JSON keys {#design_types-simple-keys}
+
+| Key | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `type` | string | Yes | - | Must be `"simple"` |
+| `name` | string | No | `"Simple Design"` | Design name |
+| `domain.type` | string | Yes | - | Currently supports `"box"` |
+| `domain.nx` | integer | Yes | - | Number of cells in x-direction |
+| `domain.ny` | integer | Yes | - | Number of cells in y-direction |
+| `domain.nz` | integer | Yes | - | Number of cells in z-direction |
+| `domain.limits` | real[6] | Yes | - | `[xmin, xmax, ymin, ymax, zmin, zmax]` |
+
+Example:
+
+```json
+"design": {
+  "type": "simple",
+  "name": "Simple Design",
+  "domain": {
+    "type": "box",
+    "nx": 16,
+    "ny": 16,
+    "nz": 16,
+    "limits": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+  }
+}
+```

--- a/examples/rugby_ball/prepare.sh
+++ b/examples/rugby_ball/prepare.sh
@@ -24,7 +24,7 @@ function help() {
 }
 
 # Handle options
-N=10
+N=20
 for arg in "$@"; do
     if [ "${arg:0:2}" == "--" ]; then
         case ${arg:2} in

--- a/examples/rugby_ball/prepare.sh
+++ b/examples/rugby_ball/prepare.sh
@@ -24,7 +24,7 @@ function help() {
 }
 
 # Handle options
-N=20
+N=10
 for arg in "$@"; do
     if [ "${arg:0:2}" == "--" ]; then
         case ${arg:2} in

--- a/sources/design/design_types/design_brinkman.f90
+++ b/sources/design/design_types/design_brinkman.f90
@@ -34,14 +34,13 @@
 
 ! Implements the `brinkman_design_t` type.
 module brinkman_design
-  use num_types, only: rp, sp, dp
+  use num_types, only: rp
   use field, only: field_t
   use json_module, only: json_file
   use mapping_handler, only: mapping_handler_t
   use coefs, only: coef_t
   use adjoint_fluid_pnpn, only: adjoint_fluid_pnpn_t
   use scratch_registry, only: neko_scratch_registry
-  use fld_file_output, only: fld_file_output_t
   use point_zone_registry, only: neko_point_zone_registry
   use point_zone, only: point_zone_t
   use mask_ops, only: mask_exterior_const
@@ -179,9 +178,6 @@ module brinkman_design
      ! you also had logicals for convergence etc,
      ! I feel they should live in "problem"
 
-     ! afield writer would be nice too
-     type(fld_file_output_t), private :: output
-
    contains
 
      ! ----------------------------------------------------------------------- !
@@ -252,11 +248,15 @@ contains
     type(simulation_t), intent(inout) :: simulation
     type(json_file) :: json_subdict
     character(len=:), allocatable :: domain_name, domain_type, name
-    logical :: dealias
+    logical :: dealias, verbose_design, verbose_sensitivity
 
     call json_get_or_default(parameters, 'name', name, 'Brinkman Design')
     call json_get_or_default(parameters, 'domain.type', domain_type, 'full')
     call json_get_or_default(parameters, 'dealias', dealias, .true.)
+    call json_get_or_default(parameters, 'verbose_design', verbose_design, &
+         .false.)
+    call json_get_or_default(parameters, 'verbose_sensitivity', &
+         verbose_sensitivity, .false.)
 
     select case (trim(domain_type))
     case ('full')
@@ -283,6 +283,8 @@ contains
       if ('mapping' .in. parameters) then
          call this%mapping%init_base(coef)
          call this%mapping%add(parameters, 'mapping')
+         call this%mapping%init_output_fields(this%brinkman_amplitude, &
+              this%sensitivity, verbose_design, verbose_sensitivity)
       end if
 
       if ('initial_distribution' .in. parameters) then
@@ -371,20 +373,6 @@ contains
        call mask_exterior_const(this%design_indicator, &
             this%optimization_domain, 0.0_rp)
     end if
-
-    ! a field writer would be nice to output
-    ! - design indicator (\rho)
-    ! - mapped design (\chi)
-    ! - sensitivity (dF/d\chi)
-    ! TODO
-    ! do this properly with JSON
-    ! TODO
-    ! obviously when we do the mappings properly, to many coeficients,
-    ! we'll also have to modify this
-    call this%output%init(sp, 'design', 3)
-    call this%output%fields%assign_to_field(1, this%design_indicator)
-    call this%output%fields%assign_to_field(2, this%brinkman_amplitude)
-    call this%output%fields%assign_to_field(3, this%sensitivity)
 
     n = this%design_indicator%dof%size()
     call this%init_base(name, n)
@@ -625,7 +613,8 @@ contains
     class(brinkman_design_t), intent(inout) :: this
     integer, intent(in) :: idx
 
-    call this%output%sample(real(idx, kind=rp))
+    call this%mapping%write_design(idx)
+    call this%mapping%write_sensitivity(idx)
 
   end subroutine brinkman_design_write
 

--- a/sources/design/design_types/design_brinkman.f90
+++ b/sources/design/design_types/design_brinkman.f90
@@ -34,7 +34,7 @@
 
 ! Implements the `brinkman_design_t` type.
 module brinkman_design
-  use num_types, only: rp
+  use num_types, only: rp, sp, dp
   use field, only: field_t
   use json_module, only: json_file
   use mapping_handler, only: mapping_handler_t
@@ -248,7 +248,9 @@ contains
     type(simulation_t), intent(inout) :: simulation
     type(json_file) :: json_subdict
     character(len=:), allocatable :: domain_name, domain_type, name
+    character(len=:), allocatable :: output_precision_str
     logical :: dealias, verbose_design, verbose_sensitivity
+    integer :: output_precision
 
     call json_get_or_default(parameters, 'name', name, 'Brinkman Design')
     call json_get_or_default(parameters, 'domain.type', domain_type, 'full')
@@ -257,6 +259,18 @@ contains
          .false.)
     call json_get_or_default(parameters, 'verbose_sensitivity', &
          verbose_sensitivity, .false.)
+    call json_get_or_default(parameters, 'output_precision', &
+         output_precision_str, 'sp')
+
+    select case (trim(output_precision_str))
+    case ('sp', 'SP')
+       output_precision = sp
+    case ('dp', 'DP')
+       output_precision = dp
+    case default
+       call neko_error('Invalid output_precision in design.brinkman. ' // &
+            'Expected ''sp'' or ''dp''.')
+    end select
 
     select case (trim(domain_type))
     case ('full')
@@ -284,7 +298,8 @@ contains
          call this%mapping%init_base(coef)
          call this%mapping%add(parameters, 'mapping')
          call this%mapping%init_output_fields(this%brinkman_amplitude, &
-              this%sensitivity, verbose_design, verbose_sensitivity)
+              this%sensitivity, verbose_design, verbose_sensitivity, &
+              output_precision)
       end if
 
       if ('initial_distribution' .in. parameters) then

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -145,61 +145,61 @@ contains
     call this%sensitivity_output%free()
 
     if (allocated(this%sensitivity_stages)) then
-      do i = 1, size(this%sensitivity_stages)
-        call this%sensitivity_stages(i)%free()
-      end do
-      deallocate(this%sensitivity_stages)
+       do i = 1, size(this%sensitivity_stages)
+          call this%sensitivity_stages(i)%free()
+       end do
+       deallocate(this%sensitivity_stages)
     end if
 
     n_mappings = 0
     if (allocated(this%mapping_cascade)) n_mappings = size(this%mapping_cascade)
 
     if (this%verbose_design) then
-      ! all mapping inputs + mapped output
-      n_fields = n_mappings + 1
-      if (n_fields .le. 0) n_fields = 1
+       ! all mapping inputs + mapped output
+       n_fields = n_mappings + 1
+       if (n_fields .le. 0) n_fields = 1
     else
-      ! only first unmapped stage and mapped output
-      if (n_mappings .gt. 0) then
-        n_fields = 2
-      else
-        n_fields = 1
-      end if
+       ! only first unmapped stage and mapped output
+       if (n_mappings .gt. 0) then
+          n_fields = 2
+       else
+          n_fields = 1
+       end if
     end if
 
     call this%design_output%init(sp, 'design', n_fields)
     if (this%verbose_design .and. n_mappings .gt. 0) then
-      do i = 1, n_mappings
-        call this%design_output%fields%assign_to_field(i, &
-             this%mapping_cascade(i)%mapping%X_in)
-      end do
-      call this%design_output%fields%assign_to_field(n_fields, this%design_out)
+       do i = 1, n_mappings
+          call this%design_output%fields%assign_to_field(i, &
+               this%mapping_cascade(i)%mapping%X_in)
+       end do
+       call this%design_output%fields%assign_to_field(n_fields, this%design_out)
     else if (n_mappings .gt. 0) then
-      call this%design_output%fields%assign_to_field(1, &
-           this%mapping_cascade(1)%mapping%X_in)
-      call this%design_output%fields%assign_to_field(2, this%design_out)
+       call this%design_output%fields%assign_to_field(1, &
+            this%mapping_cascade(1)%mapping%X_in)
+       call this%design_output%fields%assign_to_field(2, this%design_out)
     else
-      call this%design_output%fields%assign_to_field(1, this%design_out)
+       call this%design_output%fields%assign_to_field(1, this%design_out)
     end if
 
     if (this%verbose_sensitivity) then
-      ! sensitivity_in + chain-rule stages + final sensitivity
-      n_fields = n_mappings + 2
-      allocate(this%sensitivity_stages(n_mappings + 1))
-      do i = 1, n_mappings + 1
-        call this%sensitivity_stages(i)%init(this%coef%dof)
-      end do
+       ! sensitivity_in + chain-rule stages + final sensitivity
+       n_fields = n_mappings + 2
+       allocate(this%sensitivity_stages(n_mappings + 1))
+       do i = 1, n_mappings + 1
+          call this%sensitivity_stages(i)%init(this%coef%dof)
+       end do
 
-      call this%sensitivity_output%init(sp, 'sensitivity', n_fields)
-      do i = 1, n_mappings + 1
-        call this%sensitivity_output%fields%assign_to_field(i, &
-             this%sensitivity_stages(i))
-      end do
-      call this%sensitivity_output%fields%assign_to_field(n_fields, &
-           this%sensitivity_out)
+       call this%sensitivity_output%init(sp, 'sensitivity', n_fields)
+       do i = 1, n_mappings + 1
+          call this%sensitivity_output%fields%assign_to_field(i, &
+               this%sensitivity_stages(i))
+       end do
+       call this%sensitivity_output%fields%assign_to_field(n_fields, &
+            this%sensitivity_out)
     else
-      call this%sensitivity_output%init(sp, 'sensitivity', 1)
-      call this%sensitivity_output%fields%assign_to_field(1, this%sensitivity_out)
+       call this%sensitivity_output%init(sp, 'sensitivity', 1)
+       call this%sensitivity_output%fields%assign_to_field(1, this%sensitivity_out)
     end if
 
     this%outputs_initialized = .true.
@@ -340,7 +340,7 @@ contains
     ! cascade.
     call field_copy(tmp_fld_out, sens_in)
     if (allocated(this%sensitivity_stages)) then
-      call field_copy(this%sensitivity_stages(1), sens_in)
+       call field_copy(this%sensitivity_stages(1), sens_in)
     end if
 
     ! enforce continuity in the field

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -35,10 +35,11 @@
 !> Implements the `mapping_handler_t` type.
 module mapping_handler
   use neko_config, only: NEKO_BCKND_DEVICE
-  use num_types, only: rp
+  use num_types, only: rp, sp
   use mapping, only: mapping_wrapper_t, mapping_t, &
        mapping_factory
   use field, only: field_t
+  use fld_file_output, only: fld_file_output_t
   use field_list, only: field_list_t
   use json_utils, only: json_get, json_extract_item, json_get_or_default
   use json_module, only: json_file
@@ -48,7 +49,7 @@ module mapping_handler
   use math, only: col2
   use device_math, only: device_col2
   use scratch_registry, only: neko_scratch_registry
-  use utils, only: neko_warning
+  use utils, only: neko_warning, neko_error
   use vector, only:vector_t
   use neko_ext, only: field_to_vector, vector_to_field
   use gather_scatter, only : gs_op_add
@@ -68,6 +69,20 @@ module mapping_handler
      class(mapping_wrapper_t), allocatable :: mapping_cascade(:)
      !> The coefficients of the (space, mesh) pair.
      type(coef_t), pointer :: coef
+     !> Output for design and intermediate forward-mapping stages.
+     type(fld_file_output_t) :: design_output
+     !> Output for sensitivity and intermediate backward-mapping stages.
+     type(fld_file_output_t) :: sensitivity_output
+     !> Field pointers used to initialize design/sensitivity outputs.
+     type(field_t), pointer :: design_out => null()
+     type(field_t), pointer :: sensitivity_out => null()
+     !> Internal storage of sensitivity propagation stages.
+     type(field_t), allocatable :: sensitivity_stages(:)
+     !> Flags controlling output initialization.
+     logical :: output_fields_set = .false.
+     logical :: outputs_initialized = .false.
+     logical :: verbose_design = .false.
+     logical :: verbose_sensitivity = .false.
 
    contains
      !> Constructor.
@@ -95,9 +110,100 @@ module mapping_handler
           mapping_handler_add_json_mappings
      !> Force a field to be continuous.
      procedure, pass(this) :: make_cts => mapping_handler_make_cts
+     !> Configure output fields and initialize mapping-stage writers.
+     procedure, pass(this) :: init_output_fields => &
+          mapping_handler_init_output_fields
+     !> Write design and forward-mapping stages.
+     procedure, pass(this) :: write_design => mapping_handler_write_design
+     !> Write sensitivity and backward-mapping stages.
+     procedure, pass(this) :: write_sensitivity => &
+          mapping_handler_write_sensitivity
   end type mapping_handler_t
 
 contains
+
+  !> Setup output objects after mappings are known.
+  subroutine mapping_handler_setup_outputs(this)
+    class(mapping_handler_t), intent(inout) :: this
+    integer :: i, n_mappings, n_fields
+
+    if (.not. this%output_fields_set) then
+       call neko_error('Mapping output fields have not been configured')
+    end if
+    if (.not. associated(this%coef)) then
+       call neko_error('Mapping handler coefficients are not initialized')
+    end if
+    if (.not. associated(this%design_out)) then
+       call neko_error('Mapped design output field is not associated')
+    end if
+    if (.not. associated(this%sensitivity_out)) then
+       call neko_error('Sensitivity output field is not associated')
+    end if
+
+    call this%design_output%free()
+    call this%sensitivity_output%free()
+
+    if (allocated(this%sensitivity_stages)) then
+      do i = 1, size(this%sensitivity_stages)
+        call this%sensitivity_stages(i)%free()
+      end do
+      deallocate(this%sensitivity_stages)
+    end if
+
+    n_mappings = 0
+    if (allocated(this%mapping_cascade)) n_mappings = size(this%mapping_cascade)
+
+    if (this%verbose_design) then
+      ! all mapping inputs + mapped output
+      n_fields = n_mappings + 1
+      if (n_fields .le. 0) n_fields = 1
+    else
+      ! only first unmapped stage and mapped output
+      if (n_mappings .gt. 0) then
+        n_fields = 2
+      else
+        n_fields = 1
+      end if
+    end if
+
+    call this%design_output%init(sp, 'design', n_fields)
+    if (this%verbose_design .and. n_mappings .gt. 0) then
+      do i = 1, n_mappings
+        call this%design_output%fields%assign_to_field(i, &
+             this%mapping_cascade(i)%mapping%X_in)
+      end do
+      call this%design_output%fields%assign_to_field(n_fields, this%design_out)
+    else if (n_mappings .gt. 0) then
+      call this%design_output%fields%assign_to_field(1, &
+           this%mapping_cascade(1)%mapping%X_in)
+      call this%design_output%fields%assign_to_field(2, this%design_out)
+    else
+      call this%design_output%fields%assign_to_field(1, this%design_out)
+    end if
+
+    if (this%verbose_sensitivity) then
+      ! sensitivity_in + chain-rule stages + final sensitivity
+      n_fields = n_mappings + 2
+      allocate(this%sensitivity_stages(n_mappings + 1))
+      do i = 1, n_mappings + 1
+        call this%sensitivity_stages(i)%init(this%coef%dof)
+      end do
+
+      call this%sensitivity_output%init(sp, 'sensitivity', n_fields)
+      do i = 1, n_mappings + 1
+        call this%sensitivity_output%fields%assign_to_field(i, &
+             this%sensitivity_stages(i))
+      end do
+      call this%sensitivity_output%fields%assign_to_field(n_fields, &
+           this%sensitivity_out)
+    else
+      call this%sensitivity_output%init(sp, 'sensitivity', 1)
+      call this%sensitivity_output%fields%assign_to_field(1, this%sensitivity_out)
+    end if
+
+    this%outputs_initialized = .true.
+
+  end subroutine mapping_handler_setup_outputs
 
   !> Constructor.
   subroutine mapping_handler_init_base(this, coef)
@@ -122,6 +228,21 @@ contains
        end do
        deallocate(this%mapping_cascade)
     end if
+    if (allocated(this%sensitivity_stages)) then
+       do i = 1, size(this%sensitivity_stages)
+          call this%sensitivity_stages(i)%free()
+       end do
+       deallocate(this%sensitivity_stages)
+    end if
+    if (this%outputs_initialized) then
+       call this%design_output%free()
+       call this%sensitivity_output%free()
+    end if
+    this%outputs_initialized = .false.
+    this%output_fields_set = .false.
+    nullify(this%design_out)
+    nullify(this%sensitivity_out)
+    nullify(this%coef)
 
   end subroutine mapping_handler_free
 
@@ -217,6 +338,9 @@ contains
     ! Start by copying the first sens_in into the tmp_fld_out to begin the
     ! cascade.
     call field_copy(tmp_fld_out, sens_in)
+    if (allocated(this%sensitivity_stages)) then
+      call field_copy(this%sensitivity_stages(1), sens_in)
+    end if
 
     ! enforce continuity in the field
     call this%make_cts(tmp_fld_out)
@@ -232,6 +356,10 @@ contains
           ! internally by each mapping
           call this%mapping_cascade(i)%mapping%apply_backward(tmp_fld_out, &
                tmp_fld_in)
+          if (allocated(this%sensitivity_stages)) then
+             call field_copy(this%sensitivity_stages(size(this%mapping_cascade) - &
+                  i + 2), tmp_fld_out)
+          end if
 
        end do
 
@@ -317,6 +445,7 @@ contains
           call mapping_factory(this%mapping_cascade(i + i0)%mapping, &
                mapping_subdict, this%coef)
        end do
+       if (this%output_fields_set) call mapping_handler_setup_outputs(this)
     else
        ! I was considering an error, but maybe a warning is more appropriate
        call neko_warning("No mappings selected")
@@ -350,8 +479,53 @@ contains
     end if
 
     this%mapping_cascade(n_mappings + 1)%mapping = mapping
+    if (this%output_fields_set) call mapping_handler_setup_outputs(this)
 
   end subroutine mapping_handler_add_mapping
+
+  !> Configure fields used by design/sensitivity output writers.
+  subroutine mapping_handler_init_output_fields(this, design_out, &
+       sensitivity_out, verbose_design, verbose_sensitivity)
+    class(mapping_handler_t), intent(inout) :: this
+    type(field_t), target, intent(inout) :: design_out
+    type(field_t), target, intent(inout) :: sensitivity_out
+    logical, intent(in), optional :: verbose_design
+    logical, intent(in), optional :: verbose_sensitivity
+
+    this%design_out => design_out
+    this%sensitivity_out => sensitivity_out
+    if (present(verbose_design)) this%verbose_design = verbose_design
+    if (present(verbose_sensitivity)) this%verbose_sensitivity = &
+         verbose_sensitivity
+    this%output_fields_set = .true.
+
+    call mapping_handler_setup_outputs(this)
+
+  end subroutine mapping_handler_init_output_fields
+
+  !> Write design-related output fields.
+  subroutine mapping_handler_write_design(this, idx)
+    class(mapping_handler_t), intent(inout) :: this
+    integer, intent(in) :: idx
+
+    if (.not. this%outputs_initialized) then
+       call neko_error('Mapping design output is not initialized')
+    end if
+    call this%design_output%sample(real(idx, kind=rp))
+
+  end subroutine mapping_handler_write_design
+
+  !> Write sensitivity-related output fields.
+  subroutine mapping_handler_write_sensitivity(this, idx)
+    class(mapping_handler_t), intent(inout) :: this
+    integer, intent(in) :: idx
+
+    if (.not. this%outputs_initialized) then
+       call neko_error('Mapping sensitivity output is not initialized')
+    end if
+    call this%sensitivity_output%sample(real(idx, kind=rp))
+
+  end subroutine mapping_handler_write_sensitivity
 
   !> Force a field to be continuous.
   !! This can be done in many ways, here it is a simple average.

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -123,6 +123,7 @@ module mapping_handler
 contains
 
   !> Setup output objects after mappings are known.
+  !! @param this The handler object.
   subroutine mapping_handler_setup_outputs(this)
     class(mapping_handler_t), intent(inout) :: this
     integer :: i, n_mappings, n_fields
@@ -484,6 +485,11 @@ contains
   end subroutine mapping_handler_add_mapping
 
   !> Configure fields used by design/sensitivity output writers.
+  !! @param this The handler object.
+  !! @param design_out Final mapped design field.
+  !! @param sensitivity_out Final backward-mapped sensitivity field.
+  !! @param[in] verbose_design If true, output all forward cascade stages.
+  !! @param[in] verbose_sensitivity If true, output all backward stages.
   subroutine mapping_handler_init_output_fields(this, design_out, &
        sensitivity_out, verbose_design, verbose_sensitivity)
     class(mapping_handler_t), intent(inout) :: this
@@ -504,6 +510,8 @@ contains
   end subroutine mapping_handler_init_output_fields
 
   !> Write design-related output fields.
+  !! @param this The handler object.
+  !! @param[in] idx Output sample index.
   subroutine mapping_handler_write_design(this, idx)
     class(mapping_handler_t), intent(inout) :: this
     integer, intent(in) :: idx
@@ -516,6 +524,8 @@ contains
   end subroutine mapping_handler_write_design
 
   !> Write sensitivity-related output fields.
+  !! @param this The handler object.
+  !! @param[in] idx Output sample index.
   subroutine mapping_handler_write_sensitivity(this, idx)
     class(mapping_handler_t), intent(inout) :: this
     integer, intent(in) :: idx

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -249,9 +249,9 @@ contains
     this%outputs_initialized = .false.
     this%output_fields_set = .false.
     this%output_precision = sp
-    nullify(this%design_out)
-    nullify(this%sensitivity_out)
-    nullify(this%coef)
+    if (associated(this%design_out)) nullify(this%design_out)
+    if (associated(this%sensitivity_out)) nullify(this%sensitivity_out)
+    if (associated(this%coef)) nullify(this%coef)
 
   end subroutine mapping_handler_free
 

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -81,7 +81,9 @@ module mapping_handler
      !> Flags controlling output initialization.
      logical :: output_fields_set = .false.
      logical :: outputs_initialized = .false.
+     !> Flag controlling output verbose design output (default = false).
      logical :: verbose_design = .false.
+     !> Flag controlling output verbose sensitivity output (default = false).
      logical :: verbose_sensitivity = .false.
 
    contains

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -199,7 +199,8 @@ contains
             this%sensitivity_out)
     else
        call this%sensitivity_output%init(sp, 'sensitivity', 1)
-       call this%sensitivity_output%fields%assign_to_field(1, this%sensitivity_out)
+       call this%sensitivity_output%fields%assign_to_field(1, &
+            this%sensitivity_out)
     end if
 
     this%outputs_initialized = .true.
@@ -358,8 +359,8 @@ contains
           call this%mapping_cascade(i)%mapping%apply_backward(tmp_fld_out, &
                tmp_fld_in)
           if (allocated(this%sensitivity_stages)) then
-             call field_copy(this%sensitivity_stages(size(this%mapping_cascade) - &
-                  i + 2), tmp_fld_out)
+             call field_copy(this%sensitivity_stages( &
+                  size(this%mapping_cascade) - i + 2), tmp_fld_out)
           end if
 
        end do

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -35,7 +35,7 @@
 !> Implements the `mapping_handler_t` type.
 module mapping_handler
   use neko_config, only: NEKO_BCKND_DEVICE
-  use num_types, only: rp, sp
+  use num_types, only: rp, sp, dp
   use mapping, only: mapping_wrapper_t, mapping_t, &
        mapping_factory
   use field, only: field_t
@@ -83,6 +83,8 @@ module mapping_handler
      logical :: outputs_initialized = .false.
      logical :: verbose_design = .false.
      logical :: verbose_sensitivity = .false.
+     !> Precision used for design/sensitivity fld outputs.
+     integer :: output_precision = sp
 
    contains
      !> Constructor.
@@ -167,7 +169,7 @@ contains
        end if
     end if
 
-    call this%design_output%init(sp, 'design', n_fields)
+    call this%design_output%init(this%output_precision, 'design', n_fields)
     if (this%verbose_design .and. n_mappings .gt. 0) then
        do i = 1, n_mappings
           call this%design_output%fields%assign_to_field(i, &
@@ -190,7 +192,8 @@ contains
           call this%sensitivity_stages(i)%init(this%coef%dof)
        end do
 
-       call this%sensitivity_output%init(sp, 'sensitivity', n_fields)
+       call this%sensitivity_output%init(this%output_precision, &
+            'sensitivity', n_fields)
        do i = 1, n_mappings + 1
           call this%sensitivity_output%fields%assign_to_field(i, &
                this%sensitivity_stages(i))
@@ -198,7 +201,8 @@ contains
        call this%sensitivity_output%fields%assign_to_field(n_fields, &
             this%sensitivity_out)
     else
-       call this%sensitivity_output%init(sp, 'sensitivity', 1)
+       call this%sensitivity_output%init(this%output_precision, &
+            'sensitivity', 1)
        call this%sensitivity_output%fields%assign_to_field(1, &
             this%sensitivity_out)
     end if
@@ -242,6 +246,7 @@ contains
     end if
     this%outputs_initialized = .false.
     this%output_fields_set = .false.
+    this%output_precision = sp
     nullify(this%design_out)
     nullify(this%sensitivity_out)
     nullify(this%coef)
@@ -492,18 +497,25 @@ contains
   !! @param[in] verbose_design If true, output all forward cascade stages.
   !! @param[in] verbose_sensitivity If true, output all backward stages.
   subroutine mapping_handler_init_output_fields(this, design_out, &
-       sensitivity_out, verbose_design, verbose_sensitivity)
+       sensitivity_out, verbose_design, verbose_sensitivity, output_precision)
     class(mapping_handler_t), intent(inout) :: this
     type(field_t), target, intent(inout) :: design_out
     type(field_t), target, intent(inout) :: sensitivity_out
     logical, intent(in), optional :: verbose_design
     logical, intent(in), optional :: verbose_sensitivity
+    integer, intent(in), optional :: output_precision
 
     this%design_out => design_out
     this%sensitivity_out => sensitivity_out
     if (present(verbose_design)) this%verbose_design = verbose_design
     if (present(verbose_sensitivity)) this%verbose_sensitivity = &
          verbose_sensitivity
+    if (present(output_precision)) then
+       if (output_precision .ne. sp .and. output_precision .ne. dp) then
+          call neko_error('output_precision must be either sp or dp')
+       end if
+       this%output_precision = output_precision
+    end if
     this%output_fields_set = .true.
 
     call mapping_handler_setup_outputs(this)

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -496,6 +496,7 @@ contains
   !! @param sensitivity_out Final backward-mapped sensitivity field.
   !! @param[in] verbose_design If true, output all forward cascade stages.
   !! @param[in] verbose_sensitivity If true, output all backward stages.
+  !! @param[in] output_precision Output precision (sp or dp).
   subroutine mapping_handler_init_output_fields(this, design_out, &
        sensitivity_out, verbose_design, verbose_sensitivity, output_precision)
     class(mapping_handler_t), intent(inout) :: this


### PR DESCRIPTION
This PR allows intermediate fields in the mapping cascade to be be visualized. It is not default behavior, because I view this more as a debugging option.

**NOTE**

This does change the output even in the default case. We used to have `design0.f****` holding 
u. unmapped
v. mapped
w. sensitivity
(which was not super clear even to begin with)

Now we have
`design0.f****`
p. unmapped
t. mapped

`sensitivity0.f****`
p. sensitivity

or, if you use the flags for verbose, then they will come in order, same thing for chain ruling backwards
