### PR TITLE
Change design/simulation output counter

### DIFF
--- a/sources/design/design.f90
+++ b/sources/design/design.f90
@@ -120,7 +120,9 @@ module design
      procedure, public, pass(this) :: save_checkpoint => design_save_checkpoint
      !> Load the design from a checkpoint file
      procedure, public, pass(this) :: load_checkpoint => design_load_checkpoint
-
+     !> Set the design output counter
+     procedure, public, pass(this) :: set_output_counter => &
+          design_set_output_counter
      ! ----------------------------------------------------------------------- !
      ! Methods
 
@@ -208,6 +210,12 @@ module design
        class(design_t), intent(inout) :: this
        integer, intent(in) :: idx
      end subroutine design_write
+
+     subroutine set_output_counter(this, idx)
+       import design_t
+       class(design_t), intent(inout) :: this
+       integer, intent(in) :: idx
+     end subroutine set_output_counter
   end interface
 
   ! ========================================================================== !
@@ -328,6 +336,14 @@ contains
     end select
 
   end subroutine design_load_checkpoint
+
+  !> Set design output counters.
+  !! Default implementation is a no-op.
+  subroutine design_set_output_counter(this, idx)
+    class(design_t), intent(inout) :: this
+    integer, intent(in) :: idx
+
+  end subroutine design_set_output_counter
 
   ! ========================================================================== !
   ! Getter methods

--- a/sources/design/design_types/design_brinkman.f90
+++ b/sources/design/design_types/design_brinkman.f90
@@ -229,6 +229,9 @@ module brinkman_design
 
      ! a writer being called from outside would be nice
      procedure, pass(this) :: write => brinkman_design_write
+     !> Reset output counters after a restart.
+     procedure, pass(this) :: set_output_counter => &
+          brinkman_design_set_output_counter
 
      !> Destructor
      procedure, pass(this) :: free => brinkman_design_free
@@ -632,5 +635,13 @@ contains
     call this%mapping%write_sensitivity(idx)
 
   end subroutine brinkman_design_write
+
+  subroutine brinkman_design_set_output_counter(this, idx)
+    class(brinkman_design_t), intent(inout) :: this
+    integer, intent(in) :: idx
+
+    call this%mapping%set_output_counter(idx)
+
+  end subroutine brinkman_design_set_output_counter
 
 end module brinkman_design

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -122,6 +122,9 @@ module mapping_handler
      !> Write sensitivity and backward-mapping stages.
      procedure, pass(this) :: write_sensitivity => &
           mapping_handler_write_sensitivity
+     !> Reset design and sensitivity output counters.
+     procedure, pass(this) :: set_output_counter => &
+          mapping_handler_set_output_counter
   end type mapping_handler_t
 
 contains
@@ -552,6 +555,20 @@ contains
     call this%sensitivity_output%sample(real(idx, kind=rp))
 
   end subroutine mapping_handler_write_sensitivity
+
+  !> Reset design-related output counters.
+  !! @param this The handler object.
+  !! @param[in] idx Output sample index.
+  subroutine mapping_handler_set_output_counter(this, idx)
+    class(mapping_handler_t), intent(inout) :: this
+    integer, intent(in) :: idx
+
+    if (.not. this%outputs_initialized) return
+
+    call this%design_output%set_counter(idx)
+    call this%sensitivity_output%set_counter(idx)
+
+  end subroutine mapping_handler_set_output_counter
 
   !> Force a field to be continuous.
   !! This can be done in many ways, here it is a simple average.

--- a/sources/optimizer/optimizer.f90
+++ b/sources/optimizer/optimizer.f90
@@ -409,6 +409,14 @@ contains
        end if
     end if
 
+    ! compute potential internals for for a potential restart
+    if (this%current_iteration .ne. 0) then
+       call design%set_output_counter(this%current_iteration)
+       if (present(simulation)) then
+          call simulation%set_output_counter(this%current_iteration)
+       end if
+    end if
+
     ! Prepare the problem state before starting the optimization
     call this%initialize(problem, design, simulation)
 

--- a/sources/optimizer/optimizer.f90
+++ b/sources/optimizer/optimizer.f90
@@ -411,9 +411,9 @@ contains
 
     ! compute potential internals for for a potential restart
     if (this%current_iteration .ne. 0) then
-       call design%set_output_counter(this%current_iteration)
+       call design%set_output_counter(this%current_iteration - 1)
        if (present(simulation)) then
-          call simulation%set_output_counter(this%current_iteration)
+          call simulation%set_output_counter(this%current_iteration - 1)
        end if
     end if
 

--- a/sources/simulation/simulation.f90
+++ b/sources/simulation/simulation.f90
@@ -122,6 +122,9 @@ module simulation_m
      procedure, pass(this) :: run_backward => simulation_run_backward
      !> Reset the simulation
      procedure, pass(this) :: reset => simulation_reset
+     !> Set simulation output counters.
+     procedure, pass(this) :: set_output_counter => &
+          simulation_set_output_counter
      !> Write current state of the simulation to disk
      procedure, pass(this) :: write => simulation_write
      !> Write current state of the forward simulation to disk
@@ -331,6 +334,15 @@ contains
     call this%checkpoint%reset()
 
   end subroutine simulation_reset
+
+  subroutine simulation_set_output_counter(this, idx)
+    class(simulation_t), intent(inout) :: this
+    integer, intent(in) :: idx
+
+    call this%output_forward%set_counter(idx)
+    call this%output_adjoint%set_counter(idx)
+
+  end subroutine simulation_set_output_counter
 
   !> Write current state of the simulation to disk
   subroutine simulation_write(this, idx)


### PR DESCRIPTION
If you restart from a simulation, the fld_output will reset to 0 making visualizing the data awkward and in the worst case, overwrite data.