### PR TITLE
Field names in mapping handler

### DIFF
--- a/documentation/pages/user_guide/design_types.md
+++ b/documentation/pages/user_guide/design_types.md
@@ -37,9 +37,13 @@ Brinkman source-term coupling.
 | `dealias` | bool | No | `true` | Controls dealiasing for Brinkman source terms |
 | `verbose_design` | bool | No | `false` | Write all forward mapping stages |
 | `verbose_sensitivity` | bool | No | `false` | Write all backward sensitivity stages |
-| `output_precision` | string | No | `"sp"` | `"sp"` or `"dp"` for design/sensitivity fld output |
+| `output_precision` | string | No | `"sp"` | `"sp"` or `"dp"` for design/sensitivity field output |
+| `output_format` | string | No | `"fld"` | Field-output format, e.g. `"fld"`, `"vtkhdf"`, or `"adios2"` |
 | `mapping` | array | No | omitted | Mapping cascade definition, see [Mapping cascade](@ref mapping_cascade) |
 | `initial_distribution` | object | No | omitted | Initial design field setup (details below) |
+
+The `verbose_*`, `output_precision`, and `output_format` options control the
+intermediate forward and backward fields written by the mapping cascade.
 
 ### `initial_distribution` options {#design_types-brinkman-initial}
 

--- a/documentation/pages/user_guide/mapping_cascade.md
+++ b/documentation/pages/user_guide/mapping_cascade.md
@@ -54,6 +54,10 @@ this corresponds to applying a filter first, and then a RAMP mapping.
 \note Currently the mapping cascade is only applicable to the `"brinkman"` type
 design.
 
+\note The intermediate forward and backward mapping fields written by the
+Brinkman design use the `verbose_design`, `verbose_sensitivity`,
+`output_precision`, and `output_format` options from `optimization.design`.
+
 # Mappings {#mapping_list}
 
 The following mappings are currently implemented in `Neko-top`.

--- a/sources/design/design_types/design_brinkman.f90
+++ b/sources/design/design_types/design_brinkman.f90
@@ -319,7 +319,8 @@ contains
          call this%mapping%add(parameters, 'mapping')
          call this%mapping%init_output_fields(this%design_indicator, &
               this%brinkman_amplitude, this%sensitivity, verbose_design, &
-              verbose_sensitivity, output_precision, output_format_str)
+              verbose_sensitivity, output_precision, output_format_str, &
+              'design', 'sensitivity')
       end if
 
       if ('initial_distribution' .in. parameters) then

--- a/sources/design/design_types/design_brinkman.f90
+++ b/sources/design/design_types/design_brinkman.f90
@@ -317,9 +317,9 @@ contains
       if ('mapping' .in. parameters) then
          call this%mapping%init_base(coef)
          call this%mapping%add(parameters, 'mapping')
-         call this%mapping%init_output_fields(this%brinkman_amplitude, &
-              this%sensitivity, verbose_design, verbose_sensitivity, &
-              output_precision, output_format_str)
+         call this%mapping%init_output_fields(this%design_indicator, &
+              this%brinkman_amplitude, this%sensitivity, verbose_design, &
+              verbose_sensitivity, output_precision, output_format_str)
       end if
 
       if ('initial_distribution' .in. parameters) then

--- a/sources/design/design_types/design_brinkman.f90
+++ b/sources/design/design_types/design_brinkman.f90
@@ -266,7 +266,7 @@ contains
     type(simulation_t), intent(inout) :: simulation
     type(json_file) :: json_subdict
     character(len=:), allocatable :: domain_name, domain_type, name
-    character(len=:), allocatable :: output_precision_str
+    character(len=:), allocatable :: output_format_str, output_precision_str
     logical :: dealias, verbose_design, verbose_sensitivity
     integer :: output_precision
 
@@ -279,6 +279,8 @@ contains
          verbose_sensitivity, .false.)
     call json_get_or_default(parameters, 'output_precision', &
          output_precision_str, 'sp')
+    call json_get_or_default(parameters, 'output_format', &
+         output_format_str, 'fld')
 
     select case (trim(output_precision_str))
     case ('sp', 'SP')
@@ -317,7 +319,7 @@ contains
          call this%mapping%add(parameters, 'mapping')
          call this%mapping%init_output_fields(this%brinkman_amplitude, &
               this%sensitivity, verbose_design, verbose_sensitivity, &
-              output_precision)
+              output_precision, output_format_str)
       end if
 
       if ('initial_distribution' .in. parameters) then

--- a/sources/mapping_functions/PDE_filter_mapping.f90
+++ b/sources/mapping_functions/PDE_filter_mapping.f90
@@ -135,7 +135,7 @@ contains
     call json_get_or_default(json, 'solver', ksp_solver, "cg")
     call json_get_or_default(json, 'preconditioner', precon_type, "jacobi")
 
-    call this%init_base(json, coef)
+    call this%init_base(json, coef, "PDE_filter_mapping")
     call this%init_from_attributes(coef, r, tol, max_iter, &
          ksp_solver, precon_type)
 

--- a/sources/mapping_functions/RAMP_mapping.f90
+++ b/sources/mapping_functions/RAMP_mapping.f90
@@ -121,7 +121,7 @@ contains
     call json_get_or_default(json, 'q', q, 1.0_rp)
     call json_get_or_default(json, 'convex_up', convex_up, .false.)
 
-    call this%init_base(json, coef)
+    call this%init_base(json, coef, "RAMP_mapping")
     call this%init_from_attributes(coef, f_min, f_max, q, &
          convex_up)
 

--- a/sources/mapping_functions/SIMP_mapping.f90
+++ b/sources/mapping_functions/SIMP_mapping.f90
@@ -86,7 +86,7 @@ contains
     call json_get(json, 'f_max', f_max)
     call json_get_or_default(json, 'p', p, 1.0_rp)
 
-    call this%init_base(json, coef)
+    call this%init_base(json, coef, "SIMP_mapping")
     call this%init_from_attributes(coef, f_min, f_max, p)
 
   end subroutine SIMP_mapping_init_from_json

--- a/sources/mapping_functions/heaviside_mapping.f90
+++ b/sources/mapping_functions/heaviside_mapping.f90
@@ -92,7 +92,7 @@ contains
     call json_get(json, 'beta', beta)
     call json_get_or_default(json, 'eta', eta, 0.5_rp)
 
-    call this%init_base(json, coef)
+    call this%init_base(json, coef, "heaviside_mapping")
     call this%init_from_attributes(coef, beta, eta)
   end subroutine heaviside_mapping_init_from_json
 

--- a/sources/mapping_functions/linear_mapping.f90
+++ b/sources/mapping_functions/linear_mapping.f90
@@ -79,7 +79,7 @@ contains
     call json_get_or_default(json, 'f_min', f_min, 0.0_rp)
     call json_get(json, 'f_max', f_max)
 
-    call this%init_base(json, coef)
+    call this%init_base(json, coef, "linear_mapping")
     call linear_mapping_init_from_attributes(this, coef, f_min, f_max)
 
   end subroutine linear_mapping_init_from_json

--- a/sources/mapping_functions/mapping.f90
+++ b/sources/mapping_functions/mapping.f90
@@ -48,6 +48,8 @@ module mapping
      type(coef_t), pointer :: coef => null()
      !> A copy of the unmapped field (often used for chain rule)
      type(field_t) :: X_in
+     !> A name for the field
+     character(len=80) :: fld_name = ""
 
    contains
      !> Constructor for the mapping_t class.
@@ -147,13 +149,15 @@ module mapping
 contains
 
   !> Constructor for the `mapping_t` (base) class.
-  subroutine mapping_init_base(this, json, coef)
+  subroutine mapping_init_base(this, json, coef, fld_name)
     class(mapping_t), intent(inout) :: this
     type(json_file), intent(inout) :: json
+    character(len=*), intent(in) :: fld_name
     type(coef_t), intent(inout), target :: coef
 
     this%coef => coef
-    call this%X_in%init(coef%dof)
+    this%fld_name = fld_name
+    call this%X_in%init(coef%dof, fld_name)
 
   end subroutine mapping_init_base
 

--- a/sources/mapping_functions/mapping.f90
+++ b/sources/mapping_functions/mapping.f90
@@ -157,7 +157,8 @@ contains
 
     this%coef => coef
     this%fld_name = fld_name
-    call this%X_in%init(coef%dof, fld_name)
+    ! The mapping handler will take care of naming this field
+    call this%X_in%init(coef%dof)
 
   end subroutine mapping_init_base
 

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -518,6 +518,9 @@ contains
     integer :: i, j
     character(len=80) :: previous_name
 
+    ! Since each mapping stores their unmapped field (for chain rule purposes)
+    ! and stores the name for the mapped field, we need to loop through and
+    ! name them correctly
     previous_name = trim(this%design_in%name)
     if (allocated(this%mapping_cascade)) then
        do i = 1, size(this%mapping_cascade)
@@ -526,6 +529,7 @@ contains
        end do
     end if
 
+    ! same thing for sensitivities
     this%sensitivity_out%name = mapping_handler_derivative_name( &
          this%design_in%name)
     if (allocated(this%sensitivity_stages)) then

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -72,6 +72,7 @@ module mapping_handler
      !> Output for sensitivity and intermediate backward-mapping stages.
      type(field_output_t) :: sensitivity_output
      !> Field pointers used to initialize design/sensitivity outputs.
+     type(field_t), pointer :: design_in => null()
      type(field_t), pointer :: design_out => null()
      type(field_t), pointer :: sensitivity_out => null()
      !> Internal storage of sensitivity propagation stages.
@@ -112,6 +113,9 @@ module mapping_handler
      !> Read from the json file and initialize the mapping_cascade.
      procedure, pass(this) :: add_json_mappings => &
           mapping_handler_add_json_mappings
+     !> Set names of the stored mapping-stage fields.
+     procedure, pass(this) :: set_stage_names => &
+          mapping_handler_set_stage_names
      !> Force a field to be continuous.
      procedure, pass(this) :: make_cts => mapping_handler_make_cts
      !> Configure output fields and initialize mapping-stage writers.
@@ -143,6 +147,9 @@ contains
     end if
     if (.not. associated(this%design_out)) then
        call neko_error('Mapped design output field is not associated')
+    end if
+    if (.not. associated(this%design_in)) then
+       call neko_error('Unmapped design input field is not associated')
     end if
     if (.not. associated(this%sensitivity_out)) then
        call neko_error('Sensitivity output field is not associated')
@@ -198,7 +205,7 @@ contains
        do i = 1, n_mappings + 1
           call this%sensitivity_stages(i)%init(this%coef%dof)
        end do
-
+       call this%set_stage_names()
        call this%sensitivity_output%init('sensitivity', n_fields, &
             precision = this%output_precision, &
             format = trim(this%output_format))
@@ -209,6 +216,7 @@ contains
        call this%sensitivity_output%fields%assign_to_field(n_fields, &
             this%sensitivity_out)
     else
+       call this%set_stage_names()
        call this%sensitivity_output%init('sensitivity', 1, &
             precision = this%output_precision, &
             format = trim(this%output_format))
@@ -257,6 +265,7 @@ contains
     this%output_fields_set = .false.
     this%output_precision = sp
     this%output_format = 'fld'
+    if (associated(this%design_in)) nullify(this%design_in)
     if (associated(this%design_out)) nullify(this%design_out)
     if (associated(this%sensitivity_out)) nullify(this%sensitivity_out)
     if (associated(this%coef)) nullify(this%coef)
@@ -493,18 +502,61 @@ contains
 
   end subroutine mapping_handler_add_mapping
 
+  !> Prefix a field name to indicate a derivative with respect to it.
+  pure function mapping_handler_derivative_name(field_name) result(name)
+    character(len=*), intent(in) :: field_name
+    character(len=80) :: name
+
+    name = 'dFd_' // trim(field_name)
+
+  end function mapping_handler_derivative_name
+
+  !> Set the names of the stored mapping and sensitivity stages.
+  !! @param this The handler object.
+  subroutine mapping_handler_set_stage_names(this)
+    class(mapping_handler_t), intent(inout) :: this
+    integer :: i, j
+    character(len=80) :: previous_name
+
+    previous_name = trim(this%design_in%name)
+    if (allocated(this%mapping_cascade)) then
+       do i = 1, size(this%mapping_cascade)
+          this%mapping_cascade(i)%mapping%X_in%name = trim(previous_name)
+          previous_name = trim(this%mapping_cascade(i)%mapping%fld_name)
+       end do
+    end if
+
+    this%sensitivity_out%name = mapping_handler_derivative_name( &
+         this%design_in%name)
+    if (allocated(this%sensitivity_stages)) then
+       this%sensitivity_stages(1)%name = mapping_handler_derivative_name( &
+            this%design_out%name)
+       if (allocated(this%mapping_cascade)) then
+         do i = size(this%mapping_cascade), 1, -1
+            j = size(this%mapping_cascade) - i + 2
+            this%sensitivity_stages(j)%name = &
+                 mapping_handler_derivative_name( &
+                 this%mapping_cascade(i)%mapping%X_in%name)
+         end do
+       end if
+    end if
+
+  end subroutine mapping_handler_set_stage_names
+
   !> Configure fields used by design/sensitivity output writers.
   !! @param this The handler object.
+  !! @param design_in Initial unmapped design field.
   !! @param design_out Final mapped design field.
   !! @param sensitivity_out Final backward-mapped sensitivity field.
   !! @param[in] verbose_design If true, output all forward cascade stages.
   !! @param[in] verbose_sensitivity If true, output all backward stages.
   !! @param[in] output_precision Output precision (sp or dp).
   !! @param[in] output_format Output format for design/sensitivity fields.
-  subroutine mapping_handler_init_output_fields(this, design_out, &
+  subroutine mapping_handler_init_output_fields(this, design_in, design_out, &
        sensitivity_out, verbose_design, verbose_sensitivity, &
        output_precision, output_format)
     class(mapping_handler_t), intent(inout) :: this
+    type(field_t), target, intent(inout) :: design_in
     type(field_t), target, intent(inout) :: design_out
     type(field_t), target, intent(inout) :: sensitivity_out
     logical, intent(in) :: verbose_design
@@ -512,6 +564,7 @@ contains
     integer, intent(in) :: output_precision
     character(len=*), intent(in) :: output_format
 
+    this%design_in => design_in
     this%design_out => design_out
     this%sensitivity_out => sensitivity_out
     this%verbose_design = verbose_design

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -88,6 +88,10 @@ module mapping_handler
      integer :: output_precision = sp
      !> Format used for design/sensitivity field outputs.
      character(len=32) :: output_format = 'fld'
+     !> Base file name for forward mapping output.
+     character(len=80) :: forward_file_name = ''
+     !> Base file name for sensitivity output.
+     character(len=80) :: sensitivity_file_name = ''
 
    contains
      !> Constructor.
@@ -181,7 +185,7 @@ contains
        end if
     end if
 
-    call this%design_output%init('design', n_fields, &
+    call this%design_output%init(trim(this%forward_file_name), n_fields, &
          precision = this%output_precision, &
          format = trim(this%output_format))
     if (this%verbose_design .and. n_mappings .gt. 0) then
@@ -206,7 +210,8 @@ contains
           call this%sensitivity_stages(i)%init(this%coef%dof)
        end do
        call this%set_stage_names()
-       call this%sensitivity_output%init('sensitivity', n_fields, &
+       call this%sensitivity_output%init( &
+            trim(this%sensitivity_file_name), n_fields, &
             precision = this%output_precision, &
             format = trim(this%output_format))
        do i = 1, n_mappings + 1
@@ -217,7 +222,8 @@ contains
             this%sensitivity_out)
     else
        call this%set_stage_names()
-       call this%sensitivity_output%init('sensitivity', 1, &
+       call this%sensitivity_output%init( &
+            trim(this%sensitivity_file_name), 1, &
             precision = this%output_precision, &
             format = trim(this%output_format))
        call this%sensitivity_output%fields%assign_to_field(1, &
@@ -265,6 +271,8 @@ contains
     this%output_fields_set = .false.
     this%output_precision = sp
     this%output_format = 'fld'
+    this%forward_file_name = 'design'
+    this%sensitivity_file_name = 'sensitivity'
     if (associated(this%design_in)) nullify(this%design_in)
     if (associated(this%design_out)) nullify(this%design_out)
     if (associated(this%sensitivity_out)) nullify(this%sensitivity_out)
@@ -556,9 +564,12 @@ contains
   !! @param[in] verbose_sensitivity If true, output all backward stages.
   !! @param[in] output_precision Output precision (sp or dp).
   !! @param[in] output_format Output format for design/sensitivity fields.
+  !! @param[in] forward_file_name Base file name for forward mapping output.
+  !! @param[in] sensitivity_file_name Base file name for sensitivity output.
   subroutine mapping_handler_init_output_fields(this, design_in, design_out, &
        sensitivity_out, verbose_design, verbose_sensitivity, &
-       output_precision, output_format)
+       output_precision, output_format, forward_file_name, &
+       sensitivity_file_name)
     class(mapping_handler_t), intent(inout) :: this
     type(field_t), target, intent(inout) :: design_in
     type(field_t), target, intent(inout) :: design_out
@@ -567,6 +578,8 @@ contains
     logical, intent(in) :: verbose_sensitivity
     integer, intent(in) :: output_precision
     character(len=*), intent(in) :: output_format
+    character(len=*), intent(in) :: forward_file_name
+    character(len=*), intent(in) :: sensitivity_file_name
 
     this%design_in => design_in
     this%design_out => design_out
@@ -578,6 +591,8 @@ contains
     end if
     this%output_precision = output_precision
     this%output_format = trim(output_format)
+    this%forward_file_name = trim(forward_file_name)
+    this%sensitivity_file_name = trim(sensitivity_file_name)
     this%output_fields_set = .true.
 
     call mapping_handler_setup_outputs(this)

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -271,8 +271,8 @@ contains
     this%output_fields_set = .false.
     this%output_precision = sp
     this%output_format = 'fld'
-    this%forward_file_name = 'design'
-    this%sensitivity_file_name = 'sensitivity'
+    this%forward_file_name = ''
+    this%sensitivity_file_name = ''
     if (associated(this%design_in)) nullify(this%design_in)
     if (associated(this%design_out)) nullify(this%design_out)
     if (associated(this%sensitivity_out)) nullify(this%sensitivity_out)

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -536,12 +536,12 @@ contains
        this%sensitivity_stages(1)%name = mapping_handler_derivative_name( &
             this%design_out%name)
        if (allocated(this%mapping_cascade)) then
-         do i = size(this%mapping_cascade), 1, -1
-            j = size(this%mapping_cascade) - i + 2
-            this%sensitivity_stages(j)%name = &
-                 mapping_handler_derivative_name( &
-                 this%mapping_cascade(i)%mapping%X_in%name)
-         end do
+          do i = size(this%mapping_cascade), 1, -1
+             j = size(this%mapping_cascade) - i + 2
+             this%sensitivity_stages(j)%name = &
+                  mapping_handler_derivative_name( &
+                  this%mapping_cascade(i)%mapping%X_in%name)
+          end do
        end if
     end if
 

--- a/sources/mapping_functions/mapping_handler.f90
+++ b/sources/mapping_functions/mapping_handler.f90
@@ -39,13 +39,11 @@ module mapping_handler
   use mapping, only: mapping_wrapper_t, mapping_t, &
        mapping_factory
   use field, only: field_t
-  use fld_file_output, only: fld_file_output_t
-  use field_list, only: field_list_t
-  use json_utils, only: json_get, json_extract_item, json_get_or_default
+  use field_output, only: field_output_t
+  use json_utils, only: json_extract_item
   use json_module, only: json_file
   use coefs, only: coef_t
-  use user_intf, only: user_t
-  use field_math, only: field_rzero, field_copy
+  use field_math, only: field_copy
   use math, only: col2
   use device_math, only: device_col2
   use scratch_registry, only: neko_scratch_registry
@@ -70,9 +68,9 @@ module mapping_handler
      !> The coefficients of the (space, mesh) pair.
      type(coef_t), pointer :: coef
      !> Output for design and intermediate forward-mapping stages.
-     type(fld_file_output_t) :: design_output
+     type(field_output_t) :: design_output
      !> Output for sensitivity and intermediate backward-mapping stages.
-     type(fld_file_output_t) :: sensitivity_output
+     type(field_output_t) :: sensitivity_output
      !> Field pointers used to initialize design/sensitivity outputs.
      type(field_t), pointer :: design_out => null()
      type(field_t), pointer :: sensitivity_out => null()
@@ -85,8 +83,10 @@ module mapping_handler
      logical :: verbose_design = .false.
      !> Flag controlling output verbose sensitivity output (default = false).
      logical :: verbose_sensitivity = .false.
-     !> Precision used for design/sensitivity fld outputs.
+     !> Precision used for design/sensitivity field outputs.
      integer :: output_precision = sp
+     !> Format used for design/sensitivity field outputs.
+     character(len=32) :: output_format = 'fld'
 
    contains
      !> Constructor.
@@ -174,7 +174,9 @@ contains
        end if
     end if
 
-    call this%design_output%init(this%output_precision, 'design', n_fields)
+    call this%design_output%init('design', n_fields, &
+         precision = this%output_precision, &
+         format = trim(this%output_format))
     if (this%verbose_design .and. n_mappings .gt. 0) then
        do i = 1, n_mappings
           call this%design_output%fields%assign_to_field(i, &
@@ -197,8 +199,9 @@ contains
           call this%sensitivity_stages(i)%init(this%coef%dof)
        end do
 
-       call this%sensitivity_output%init(this%output_precision, &
-            'sensitivity', n_fields)
+       call this%sensitivity_output%init('sensitivity', n_fields, &
+            precision = this%output_precision, &
+            format = trim(this%output_format))
        do i = 1, n_mappings + 1
           call this%sensitivity_output%fields%assign_to_field(i, &
                this%sensitivity_stages(i))
@@ -206,8 +209,9 @@ contains
        call this%sensitivity_output%fields%assign_to_field(n_fields, &
             this%sensitivity_out)
     else
-       call this%sensitivity_output%init(this%output_precision, &
-            'sensitivity', 1)
+       call this%sensitivity_output%init('sensitivity', 1, &
+            precision = this%output_precision, &
+            format = trim(this%output_format))
        call this%sensitivity_output%fields%assign_to_field(1, &
             this%sensitivity_out)
     end if
@@ -252,6 +256,7 @@ contains
     this%outputs_initialized = .false.
     this%output_fields_set = .false.
     this%output_precision = sp
+    this%output_format = 'fld'
     if (associated(this%design_out)) nullify(this%design_out)
     if (associated(this%sensitivity_out)) nullify(this%sensitivity_out)
     if (associated(this%coef)) nullify(this%coef)
@@ -495,26 +500,27 @@ contains
   !! @param[in] verbose_design If true, output all forward cascade stages.
   !! @param[in] verbose_sensitivity If true, output all backward stages.
   !! @param[in] output_precision Output precision (sp or dp).
+  !! @param[in] output_format Output format for design/sensitivity fields.
   subroutine mapping_handler_init_output_fields(this, design_out, &
-       sensitivity_out, verbose_design, verbose_sensitivity, output_precision)
+       sensitivity_out, verbose_design, verbose_sensitivity, &
+       output_precision, output_format)
     class(mapping_handler_t), intent(inout) :: this
     type(field_t), target, intent(inout) :: design_out
     type(field_t), target, intent(inout) :: sensitivity_out
-    logical, intent(in), optional :: verbose_design
-    logical, intent(in), optional :: verbose_sensitivity
-    integer, intent(in), optional :: output_precision
+    logical, intent(in) :: verbose_design
+    logical, intent(in) :: verbose_sensitivity
+    integer, intent(in) :: output_precision
+    character(len=*), intent(in) :: output_format
 
     this%design_out => design_out
     this%sensitivity_out => sensitivity_out
-    if (present(verbose_design)) this%verbose_design = verbose_design
-    if (present(verbose_sensitivity)) this%verbose_sensitivity = &
-         verbose_sensitivity
-    if (present(output_precision)) then
-       if (output_precision .ne. sp .and. output_precision .ne. dp) then
-          call neko_error('output_precision must be either sp or dp')
-       end if
-       this%output_precision = output_precision
+    this%verbose_design = verbose_design
+    this%verbose_sensitivity = verbose_sensitivity
+    if (output_precision .ne. sp .and. output_precision .ne. dp) then
+       call neko_error('output_precision must be either sp or dp')
     end if
+    this%output_precision = output_precision
+    this%output_format = trim(output_format)
     this%output_fields_set = .true.
 
     call mapping_handler_setup_outputs(this)


### PR DESCRIPTION
This PR has a few quality of life features in the mapping handler
- `fld_file_output_t` -> `field_output_t` allowing different output formats
- names for various stages in the mapping handler

adding this to the rugby ball example
```
    "optimization": {
        "design": {
            "type": "brinkman",
            "dealias": false,
            "output_format": "vtkhdf",
            "verbose_design": true,
            "verbose_sensitivity": true,
```

should yield

<img width="329" height="123" alt="image" src="https://github.com/user-attachments/assets/7cd86492-cbda-4f7c-9a72-ab1ee5e05d79" />
