### PR TITLE
Add continuation support for objective weighting

### DIFF
--- a/sources/problem/objectives/brinkman_dissipation_objective.f90
+++ b/sources/problem/objectives/brinkman_dissipation_objective.f90
@@ -62,6 +62,7 @@ module brinkman_dissipation_objective
   use device_math, only: device_copy, device_glsc2, device_col2, device_invcol2
   use math_ext, only: glsc2_mask
   use field_math, only: field_col3, field_addcol3, field_cmult, field_col2
+  use continuation_scheduler, only: nekotop_continuation
   implicit none
   private
 
@@ -141,7 +142,9 @@ contains
     real(kind=rp) :: weight
     logical :: dealias_sensitivity, dealias_forcing
 
-    call json_get_or_default(json, "weight", weight, 1.0_rp)
+    weight = 1.0_rp
+    call nekotop_continuation%json_get_or_register(json, 'weight', &
+         this%weight, weight)
     call json_get_or_default(json, "mask_name", mask_name, "")
     call json_get_or_default(json, "name", name, "Out of plane stresses")
     call json_get_or_default(json, "dealias_sensitivity", &

--- a/sources/problem/objectives/scalar_mixing_objective_function.f90
+++ b/sources/problem/objectives/scalar_mixing_objective_function.f90
@@ -56,6 +56,7 @@ module scalar_mixing_objective
   use neko_ext, only: get_scalar_indicies
   ! delete after the simulation computes u u_adj
   use field_math, only: field_addcol3, field_col3
+  use continuation_scheduler, only: nekotop_continuation
   implicit none
   private
 
@@ -119,7 +120,9 @@ contains
     character(len=:), allocatable :: mask_name
     character(len=:), allocatable :: scalar_name
 
-    call json_get_or_default(json, "weight", weight, 1.0_rp)
+    weight = 1.0_rp
+    call nekotop_continuation%json_get_or_register(json, 'weight', &
+         this%weight, weight)
     call json_get_or_default(json, "mask_name", mask_name, "")
     call json_get_or_default(json, "target_concentration", phi_ref, 0.5_rp)
     call json_get_or_default(json, "name", name, "Scalar Mixing")

--- a/sources/problem/objectives/viscous_dissipation_objective.f90
+++ b/sources/problem/objectives/viscous_dissipation_objective.f90
@@ -89,6 +89,7 @@ module viscous_dissipation_objective
   use utils, only: neko_error
   use json_module, only: json_file
   use json_utils, only: json_get_or_default
+  use continuation_scheduler, only: nekotop_continuation
   implicit none
   private
 
@@ -151,7 +152,9 @@ contains
     character(len=:), allocatable :: mask_name
     real(kind=rp) :: weight
 
-    call json_get_or_default(json, "weight", weight, 1.0_rp)
+    weight = 1.0_rp
+    call nekotop_continuation%json_get_or_register(json, 'weight', &
+         this%weight, weight)
     call json_get_or_default(json, "mask_name", mask_name, "")
     call json_get_or_default(json, "name", name, "Dissipation")
 


### PR DESCRIPTION
Add continuation support for objective weighting for the following predefined objectives:
1. brinkman_dissipation_objective
2. scalar_mixing_objective_function
3. viscous_dissipation_objective