### PR TITLE
Add continuation for RAMP_mapping and linear_mapping

### DIFF
--- a/sources/mapping_functions/RAMP_mapping.f90
+++ b/sources/mapping_functions/RAMP_mapping.f90
@@ -50,6 +50,7 @@ module RAMP_mapping
        convex_up_RAMP_mapping_apply_backward_cpu
   use json_utils, only: json_get, json_get_or_default
   use logger, only: neko_log
+  use continuation_scheduler, only: nekotop_continuation
   implicit none
   private
 
@@ -117,8 +118,11 @@ contains
     logical :: convex_up
 
     call json_get_or_default(json, 'f_min', f_min, 0.0_rp)
-    call json_get(json, 'f_max', f_max)
-    call json_get_or_default(json, 'q', q, 1.0_rp)
+    f_max = 1.0_rp
+    call nekotop_continuation%json_get_or_register(json, 'f_max', this%f_max, &
+         f_max)
+    q = 1.0_rp
+    call nekotop_continuation%json_get_or_register(json, 'q', this%q, q)
     call json_get_or_default(json, 'convex_up', convex_up, .false.)
 
     call this%init_base(json, coef, "RAMP_mapping")

--- a/sources/mapping_functions/linear_mapping.f90
+++ b/sources/mapping_functions/linear_mapping.f90
@@ -42,6 +42,7 @@ module linear_mapping
   use field, only: field_t
   use coefs, only: coef_t
   use json_utils, only: json_get, json_get_or_default
+  use continuation_scheduler, only: nekotop_continuation
   implicit none
   private
 
@@ -77,7 +78,9 @@ contains
     real(kind=rp) :: f_min, f_max
 
     call json_get_or_default(json, 'f_min', f_min, 0.0_rp)
-    call json_get(json, 'f_max', f_max)
+    f_max = 1.0_rp
+    call nekotop_continuation%json_get_or_register(json, 'f_max', this%f_max, &
+         f_max)
 
     call this%init_base(json, coef, "linear_mapping")
     call linear_mapping_init_from_attributes(this, coef, f_min, f_max)


### PR DESCRIPTION
This PR adds continuation strategy for `f_max` and `q` in the `RAMP_mapping` and `f_max` in `linear_mapping`.