### PR TITLE
`MPI_COMM_WORLD` -> `NEKO_COMM`

### DIFF
--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -90,8 +90,8 @@ module adjoint_fluid_pnpn
   use dong_outflow, only: dong_outflow_t
   use time_state, only: time_state_t
   use vector, only: vector_t
-  use device_math, only: device_glsc3, device_cmult, device_col2
-  use math, only: glsc3, cmult, col2
+  use device_math, only: device_vlsc3, device_cmult, device_col2
+  use math, only: vlsc3, cmult, col2
   use, intrinsic :: iso_c_binding, only: c_ptr, C_NULL_PTR, c_associated
   use comm, only: NEKO_COMM, MPI_REAL_PRECISION
   use mpi_f08, only: mpi_sum, mpi_max, mpi_allreduce, MPI_INTEGER, &
@@ -1440,7 +1440,10 @@ contains
 
     real(kind=rp) :: norm
 
-    norm = glsc3(x, x, B, n) + glsc3(y, y, B, n) + glsc3(z, z, B, n)
+    norm = vlsc3(x, x, B, n) + vlsc3(y, y, B, n) + vlsc3(z, z, B, n)
+
+    call mpi_allreduce(MPI_IN_PLACE, norm, 1, &
+         MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM)
 
     norm = sqrt(norm / volume)
   end function norm
@@ -1455,9 +1458,12 @@ contains
 
     real(kind=rp) :: device_norm
 
-    device_norm = device_glsc3(x_d, x_d, B_d, n) + &
-         device_glsc3(y_d, y_d, B_d, n) + &
-         device_glsc3(z_d, z_d, B_d, n)
+    device_norm = device_vlsc3(x_d, x_d, B_d, n) + &
+         device_vlsc3(y_d, y_d, B_d, n) + &
+         device_vlsc3(z_d, z_d, B_d, n)
+
+    call mpi_allreduce(MPI_IN_PLACE, device_norm, 1, &
+         MPI_REAL_PRECISION, MPI_SUM, NEKO_COMM)
 
     device_norm = sqrt(device_norm / volume)
 

--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -90,12 +90,12 @@ module adjoint_fluid_pnpn
   use dong_outflow, only: dong_outflow_t
   use time_state, only: time_state_t
   use vector, only: vector_t
-  use device_math, only: device_vlsc3, device_cmult, device_col2
-  use math, only: vlsc3, cmult, col2
+  use device_math, only: device_glsc3, device_cmult, device_col2
+  use math, only: glsc3, cmult, col2
   use, intrinsic :: iso_c_binding, only: c_ptr, C_NULL_PTR, c_associated
   use comm, only: NEKO_COMM, MPI_REAL_PRECISION
-  use mpi_f08, only: mpi_sum, mpi_max, mpi_allreduce, MPI_COMM_WORLD, &
-       MPI_INTEGER, MPI_LOGICAL, MPI_LOR
+  use mpi_f08, only: mpi_sum, mpi_max, mpi_allreduce, MPI_INTEGER, &
+     MPI_LOGICAL, MPI_LOR
   use operators, only : opgrad, curl, grad
   use normal_vec_bcs, only: normal_vec_bcs_t
 
@@ -1440,10 +1440,7 @@ contains
 
     real(kind=rp) :: norm
 
-    norm = vlsc3(x, x, B, n) + vlsc3(y, y, B, n) + vlsc3(z, z, B, n)
-
-    call mpi_allreduce(MPI_IN_PLACE, norm, 1, &
-         MPI_REAL_PRECISION, MPI_SUM, MPI_COMM_WORLD)
+    norm = glsc3(x, x, B, n) + glsc3(y, y, B, n) + glsc3(z, z, B, n)
 
     norm = sqrt(norm / volume)
   end function norm
@@ -1458,12 +1455,9 @@ contains
 
     real(kind=rp) :: device_norm
 
-    device_norm = device_vlsc3(x_d, x_d, B_d, n) + &
-         device_vlsc3(y_d, y_d, B_d, n) + &
-         device_vlsc3(z_d, z_d, B_d, n)
-
-    call mpi_allreduce(MPI_IN_PLACE, device_norm, 1, &
-         MPI_REAL_PRECISION, MPI_SUM, MPI_COMM_WORLD)
+    device_norm = device_glsc3(x_d, x_d, B_d, n) + &
+         device_glsc3(y_d, y_d, B_d, n) + &
+         device_glsc3(z_d, z_d, B_d, n)
 
     device_norm = sqrt(device_norm / volume)
 

--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -95,7 +95,7 @@ module adjoint_fluid_pnpn
   use, intrinsic :: iso_c_binding, only: c_ptr, C_NULL_PTR, c_associated
   use comm, only: NEKO_COMM, MPI_REAL_PRECISION
   use mpi_f08, only: mpi_sum, mpi_max, mpi_allreduce, MPI_INTEGER, &
-     MPI_LOGICAL, MPI_LOR
+       MPI_LOGICAL, MPI_LOR
   use operators, only : opgrad, curl, grad
   use normal_vec_bcs, only: normal_vec_bcs_t
 

--- a/sources/neko_ext/json_utils_ext.f90
+++ b/sources/neko_ext/json_utils_ext.f90
@@ -133,8 +133,7 @@ contains
        call MPI_Bcast(length, 1, MPI_INTEGER, 0, NEKO_COMM, ierr)
 
        if (rank .ne. 0) allocate(character(len=length) :: json_buffer)
-       call MPI_Bcast(json_buffer, length, MPI_CHARACTER, 0, NEKO_COMM, &
-            ierr)
+       call MPI_Bcast(json_buffer, length, MPI_CHARACTER, 0, NEKO_COMM, ierr)
 
        if (rank .ne. 0) then
           call json%load_from_string(json_buffer)

--- a/sources/neko_ext/json_utils_ext.f90
+++ b/sources/neko_ext/json_utils_ext.f90
@@ -33,7 +33,8 @@
 !! POSSIBILITY OF SUCH DAMAGE.
 module json_utils_ext
   use mpi_f08, only: MPI_Comm_rank, MPI_Initialized, MPI_Bcast, &
-       MPI_COMM_WORLD, MPI_INTEGER, MPI_CHARACTER
+       MPI_INTEGER, MPI_CHARACTER
+  use comm, only: NEKO_COMM
   use json_file_module, only: json_file
   use json_value_module, only: json_value
   use utils, only: neko_error, filename_suffix
@@ -117,7 +118,7 @@ contains
 
     ! Check if MPI is initialized and get the rank if it is.
     call MPI_Initialized(mpi_is_initialized, ierr)
-    if (mpi_is_initialized) call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
+    if (mpi_is_initialized) call MPI_Comm_rank(NEKO_COMM, rank, ierr)
 
     ! Read the json file and broadcast it to all ranks.
     if (rank .eq. 0) then
@@ -129,10 +130,10 @@ contains
        if (rank .eq. 0) call json%print_to_string(json_buffer)
 
        length = len(json_buffer)
-       call MPI_Bcast(length, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+       call MPI_Bcast(length, 1, MPI_INTEGER, 0, NEKO_COMM, ierr)
 
        if (rank .ne. 0) allocate(character(len=length) :: json_buffer)
-       call MPI_Bcast(json_buffer, length, MPI_CHARACTER, 0, MPI_COMM_WORLD, &
+       call MPI_Bcast(json_buffer, length, MPI_CHARACTER, 0, NEKO_COMM, &
             ierr)
 
        if (rank .ne. 0) then


### PR DESCRIPTION
This bug was discovered in `pySEMTools/checkpointing` and blocks if trying to use ADIOS2 etc.