### PR TITLE
Align with Neko ALE PR #2244

### DIFF
--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -747,7 +747,8 @@ contains
          ! Add the RHS contributions coming from the BDF scheme.
          call makebdf%compute_fluid(ulag, vlag, wlag, f_x%x, f_y%x, f_z%x, &
               u, v, w, c_Xh%B, rho%x(1,1,1,1), dt, &
-              ext_bdf%diffusion_coeffs%x, ext_bdf%ndiff, n)
+              ext_bdf%diffusion_coeffs%x, ext_bdf%ndiff, n, &
+              c_Xh%Blag, c_Xh%Blaglag)
       end if
 
       call ulag%update()


### PR DESCRIPTION
Update the adjoint fluid PNPN step to include additional parameters for the BDF scheme as per the alignment with Neko ALE changes.