### PR TITLE
Disable fail-fast in job strategy

### DIFF
--- a/.github/workflows/check_compile.yml
+++ b/.github/workflows/check_compile.yml
@@ -37,7 +37,7 @@ jobs:
     # ------------------------------------------------------------------------ #
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         # Default matrix
         precision: [dp]


### PR DESCRIPTION
Change the job strategy to prevent immediate failure on the first error, allowing all jobs to complete.