### PR TITLE
Fix CI by updating amdgpu installation URL

### DIFF
--- a/.github/workflows/check_compile.yml
+++ b/.github/workflows/check_compile.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           # Following the instructions from https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html
 
-          wget -r -np -nd -A 'amdgpu*.deb' https://repo.radeon.com/amdgpu-install/latest/ubuntu/noble/
+          wget -r -np -nd -A 'amdgpu*.deb' https://repo.radeon.com/amdgpu-install/7.2.1/ubuntu/noble/
           sudo apt install ./amdgpu-install_*.deb
           sudo apt update
           sudo apt install -y rocm-dev


### PR DESCRIPTION
Update the URL for downloading the amdgpu packages to point to the correct version, ensuring the CI process functions as intended.