### PR TITLE
Support OpenMP in our code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ find_package(LAPACK QUIET)
 
 # Check for the optional libraries.
 find_package(MPI REQUIRED)
+find_package(OpenMP REQUIRED COMPONENTS Fortran)
 
 # We need PKG Config to find the JSON-Fortran and Neko libraries
 find_package(PkgConfig REQUIRED)

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(neko-top PUBLIC
     PkgConfig::neko
     PkgConfig::json-fortran
     MPI::MPI_Fortran
+    OpenMP::OpenMP_Fortran
     $<$<BOOL:${BLAS_FOUND}>:BLAS::BLAS>
     $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK>
     $<$<BOOL:${CUDAToolkit_FOUND}>:CUDA::cusolver>


### PR DESCRIPTION
Integrate OpenMP support by finding the OpenMP package and linking it to the Fortran target.