### PR TITLE
Eliminate shadowing in module names

### DIFF
--- a/sources/mapping_functions/PDE_filter_mapping.f90
+++ b/sources/mapping_functions/PDE_filter_mapping.f90
@@ -33,7 +33,7 @@
 !! POSSIBILITY OF SUCH DAMAGE.
 !
 !> A PDE based filter
-module PDE_filter
+module PDE_filter_mapping
   use num_types, only: rp
   use json_module, only: json_file
   use registry, only: neko_registry
@@ -418,4 +418,4 @@ contains
 
   end subroutine filter_precon_factory
 
-end module PDE_filter
+end module PDE_filter_mapping

--- a/sources/mapping_functions/mapping_fctry.f90
+++ b/sources/mapping_functions/mapping_fctry.f90
@@ -36,7 +36,7 @@
 submodule (mapping) mapping_fctry
   use utils, only: neko_type_error
   use linear_mapping, only : linear_mapping_t
-  use PDE_filter, only: PDE_filter_t
+  use PDE_filter_mapping, only: PDE_filter_t
   use RAMP_mapping, only: RAMP_mapping_t
   use heaviside_mapping, only: heaviside_mapping_t
   use SIMP_mapping, only: SIMP_mapping_t


### PR DESCRIPTION
Rename the `PDE_filter` module to `PDE_filter_mapping` to avoid name shadowing and ensure clarity in module usage. This change updates all relevant references accordingly.