### PR TITLE
Call neko_job_info in topopt_user and topopt programs

### DIFF
--- a/sources/drivers/topopt-user.f90
+++ b/sources/drivers/topopt-user.f90
@@ -33,7 +33,7 @@
 !! POSSIBILITY OF SUCH DAMAGE.
 
 program topopt_user
-  use neko, only: neko_init, neko_finalize
+  use neko, only: neko_init, neko_finalize, neko_job_info
   use simulation_m, only: simulation_t
   use design, only: design_t, design_factory
   use problem, only: problem_t
@@ -53,6 +53,8 @@ program topopt_user
   integer :: argc
   character(len=256) :: parameter_file
   type(json_file) :: parameters, design_parameters
+  character(10) :: time
+  character(8) :: date
 
   !> The simulation we are working with
   type(simulation_t) :: sim
@@ -66,7 +68,9 @@ program topopt_user
   ! -------------------------------------------------------------------------- !
   ! Initialize the Neko environment
 
+  call date_and_time(time = time, date = date)
   call neko_init()
+  call neko_job_info(date, time)
   call neko_top_register_types()
 
   ! -------------------------------------------------------------------------- !

--- a/sources/drivers/topopt.f90
+++ b/sources/drivers/topopt.f90
@@ -33,7 +33,7 @@
 !! POSSIBILITY OF SUCH DAMAGE.
 
 program topopt
-  use neko, only: neko_init, neko_finalize
+  use neko, only: neko_init, neko_finalize, neko_job_info
   use simulation_m, only: simulation_t
   use design, only: design_t, design_factory
   use problem, only: problem_t
@@ -52,6 +52,8 @@ program topopt
   integer :: argc
   character(len=256) :: parameter_file
   type(json_file) :: parameters, design_parameters
+  character(10) :: time
+  character(8) :: date
 
   !> The simulation we are working with
   type(simulation_t) :: sim
@@ -65,7 +67,9 @@ program topopt
   ! -------------------------------------------------------------------------- !
   ! Initialize the Neko environment
 
+  call date_and_time(time = time, date = date)
   call neko_init()
+  call neko_job_info(date, time)
   call neko_top_register_types()
 
   ! -------------------------------------------------------------------------- !


### PR DESCRIPTION
Integrate the `neko_job_info` call into the initialization process of both the `topopt_user` and `topopt` programs to enhance job information handling.