### PR TITLE
Improve patch handling for Neko on Cray builds

### DIFF
--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -467,6 +467,15 @@ function find_neko() {
         make install
 
         cd $CURRENT_DIR
+
+        # Revert the patches to keep the repository clean
+        if [[ -n "${CRAYPE_VERSION:-}" || "${PE_ENV:-}" == "CRAY" || -d "/opt/cray" ]]; then
+            for patch in "${cray_patches[@]}"; do
+                if git -C "$NEKO_DIR" apply --reverse --check "$patch" 2>/dev/null; then
+                    git -C "$NEKO_DIR" apply --reverse "$patch"
+                fi
+            done
+        fi
     fi
 
     NEKO_LIB=$(find $NEKO_DIR -type d -name 'lib*' \

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -388,9 +388,16 @@ function find_neko() {
 
         # Apply Cray-specific patches before building on Cray systems
         if [[ -n "${CRAYPE_VERSION:-}" || "${PE_ENV:-}" == "CRAY" || -d "/opt/cray" ]]; then
-            git -C "$NEKO_DIR" apply patches/cce_stack.patch
-            git -C "$NEKO_DIR" apply patches/cce_time_state.patch
-            git -C "$NEKO_DIR" apply patches/cce_openmp.patch
+            cray_patches=(
+                "patches/cce_stack.patch"
+                "patches/cce_time_state.patch"
+                "patches/cce_openmp.patch"
+            )
+            for patch in "${cray_patches[@]}"; do
+                if git -C "$NEKO_DIR" apply --check "$patch" 2>/dev/null; then
+                    git -C "$NEKO_DIR" apply "$patch"
+                fi
+            done
         fi
 
         # Determine available features

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -383,6 +383,14 @@ function find_neko() {
 
             git clone --depth 1 --branch $NEKO_VERSION \
                 https://github.com/ExtremeFLOW/neko.git $NEKO_DIR
+
+        fi
+
+        # Apply Cray-specific patches before building on Cray systems
+        if [[ -n "${CRAYPE_VERSION:-}" || "${PE_ENV:-}" == "CRAY" || -d "/opt/cray" ]]; then
+            git -C "$NEKO_DIR" apply patches/cce_stack.patch
+            git -C "$NEKO_DIR" apply patches/cce_time_state.patch
+            git -C "$NEKO_DIR" apply patches/cce_openmp.patch
         fi
 
         # Determine available features


### PR DESCRIPTION
Apply Cray-specific patches during the build process and ensure the repository remains clean by reverting those patches afterward.