### PR TITLE
Fix regression CMake files for OpenMP builds

### DIFF
--- a/tests/regression/sensitivity/CMakeLists.txt
+++ b/tests/regression/sensitivity/CMakeLists.txt
@@ -12,41 +12,20 @@ add_custom_target(reg_sensitivity_test_prepare ALL
 )
 
 # --------------------------------------------------------------------------- #
-# Regression sensitivity utilities (Fortran modules)
-add_library(reg_sensitivity_utils
-    ${CMAKE_CURRENT_SOURCE_DIR}/sensitivity.f90
-    ${CMAKE_CURRENT_SOURCE_DIR}/user.f90
-)
-
 # Use a private .mod folder to avoid clashes with unit targets
 set(LOCAL_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/modules)
-set_target_properties(reg_sensitivity_utils
-    PROPERTIES Fortran_MODULE_DIRECTORY ${LOCAL_MOD_DIR})
-
-# Make both NEKO and this target's .mod directory visible to dependents
-target_include_directories(reg_sensitivity_utils
-    PUBLIC
-        ${NEKO_TOP_MOD_DIR}
-        ${LOCAL_MOD_DIR}
-)
-
-target_link_libraries(reg_sensitivity_utils
-    PUBLIC
-        Neko-TOP::neko-top
-        PkgConfig::neko
-        PkgConfig::json-fortran
-        MPI::MPI_Fortran
-        $<$<BOOL:${BLAS_FOUND}>:BLAS::BLAS>
-        $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK>
-)
+set(CMAKE_Fortran_MODULE_DIRECTORY ${LOCAL_MOD_DIR} CACHE PATH
+    "Fortran module directory" FORCE)
 
 # --------------------------------------------------------------------------- #
 # Build the single driver executable for regression
 add_executable(reg_problem_tester_sensitivity_bin
+    ${CMAKE_CURRENT_SOURCE_DIR}/sensitivity.f90
+    ${CMAKE_CURRENT_SOURCE_DIR}/user.f90
     ${CMAKE_CURRENT_SOURCE_DIR}/problem_tester.f90
 )
 target_link_libraries(reg_problem_tester_sensitivity_bin
-    reg_sensitivity_utils
+    PRIVATE Neko-TOP::neko-top
 )
 
 # The driver must also see the regression .mod directory
@@ -62,5 +41,8 @@ set_target_properties(reg_problem_tester_sensitivity_bin
 
 # Let the umbrella target trigger both build+prepare steps (if present)
 add_dependencies(Regression reg_problem_tester_sensitivity_bin)
+
+set(CMAKE_Fortran_MODULE_DIRECTORY ${NEKO_TOP_MOD_DIR} CACHE PATH
+    "Fortran module directory" FORCE)
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/sensitivity/CMakeLists.txt
+++ b/tests/unit/sensitivity/CMakeLists.txt
@@ -11,30 +11,16 @@ set(test_list
 set(SENSITIVITY_DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/problem_tester.f90)
 
 # ============================================================================ #
-# Ensure the neko library is found correctly
-get_target_property(NEKO_TOP_MODDIR neko-top Fortran_MODULE_DIRECTORY)
+# Use a private .mod folder to avoid clashes with regression targets
+set(LOCAL_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/modules)
+set(CMAKE_Fortran_MODULE_DIRECTORY ${LOCAL_MOD_DIR} CACHE PATH
+    "Fortran module directory" FORCE)
 
 # ============================================================================ #
 # Preparation target
 add_custom_target(sensitivity_test_prepare
     COMMENT "Preparing sensitivity test files"
 )
-
-# Sensitivity utils library
-add_library(sensitivity_utils EXCLUDE_FROM_ALL
-    ${CMAKE_CURRENT_SOURCE_DIR}/sensitivity.f90
-)
-target_include_directories(sensitivity_utils PUBLIC ${NEKO_TOP_MODDIR})
-target_link_libraries(sensitivity_utils
-    PUBLIC
-        Neko-TOP::neko-top
-        PkgConfig::neko
-        PkgConfig::json-fortran
-        MPI::MPI_Fortran
-        $<$<BOOL:${BLAS_FOUND}>:BLAS::BLAS>
-        $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK>
-)
-add_dependencies(sensitivity_test_prepare sensitivity_utils)
 
 # ============================================================================ #
 # Neko environment
@@ -63,12 +49,18 @@ add_dependencies(sensitivity_test_prepare sensitivity_prepare_script)
 # ============================================================================ #
 # Build the single driver executable
 add_executable(problem_tester_sensitivity_bin EXCLUDE_FROM_ALL
+    ${CMAKE_CURRENT_SOURCE_DIR}/sensitivity.f90
     ${SENSITIVITY_DRIVER}
 )
 target_link_libraries(problem_tester_sensitivity_bin
-    sensitivity_utils
+    PRIVATE Neko-TOP::neko-top
 )
+target_include_directories(problem_tester_sensitivity_bin
+    PRIVATE ${LOCAL_MOD_DIR})
 add_dependencies(Unit problem_tester_sensitivity_bin)
+
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/modules CACHE PATH
+    "Fortran module directory" FORCE)
 
 # ============================================================================ #
 # Loop over all case files and create tests


### PR DESCRIPTION
Correct CMake configurations to ensure proper handling of Fortran module directories and dependencies for regression tests. This update resolves issues with the previous setup that affected OpenMP builds.