### PR TITLE
Update handling of masked copies

### DIFF
--- a/sources/neko_ext/mask_ops.f90
+++ b/sources/neko_ext/mask_ops.f90
@@ -41,8 +41,7 @@ module mask_ops
   use point_zone, only: point_zone_t
   use scratch_registry, only: neko_scratch_registry
   use field_math, only: field_cfill, field_copy, field_rone
-  use device_math_ext, only: device_copy_mask
-  use device_math, only: device_copy, device_glsc2
+  use device_math, only: device_copy, device_glsc2, device_masked_copy_0
   use math_ext, only: copy_mask
   use math, only: copy, glsc2
   use vector, only: vector_t
@@ -94,8 +93,8 @@ contains
 
     ! copy the fld in the masked region
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_copy_mask(work%x_d, vec%x_d, work%size(), zone%mask%get_d(), &
-            zone%size)
+       call device_masked_copy_0(work%x_d, vec%x_d, &
+            zone%mask%get_d(), work%size(), zone%size)
     else
        do i = 1, zone%size
           work%x(zone%mask%get(i), 1, 1, 1) = vec%x(zone%mask%get(i))
@@ -131,8 +130,8 @@ contains
 
     ! copy the fld in the masked region
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_copy_mask(work%x_d, fld%x_d, fld%size(), zone%mask%get_d(), &
-            zone%size)
+       call device_masked_copy_0(work%x_d, fld%x_d, &
+            zone%mask%get_d(), fld%size(), zone%size)
     else
        call copy_mask(work%x, fld%x, fld%size(), zone%mask%get(), zone%size)
     end if
@@ -162,8 +161,8 @@ contains
 
     ! copy the fld in the masked region
     if (NEKO_BCKND_DEVICE .eq. 1) then
-       call device_copy_mask(work%x_d, fld%x_d, fld%size(), zone%mask%get_d(), &
-            zone%size)
+       call device_masked_copy_0(work%x_d, fld%x_d, &
+            zone%mask%get_d(), fld%size(), zone%size)
     else
        call copy_mask(work%x, fld%x, fld%size(), zone%mask%get(), zone%size)
     end if

--- a/sources/neko_ext/math/bcknd/device/hip/math_ext.hip
+++ b/sources/neko_ext/math/bcknd/device/hip/math_ext.hip
@@ -52,20 +52,6 @@
 
 extern "C" {
 
-/** Fortran wrapper for copy_mask
- * Copy a vector \f$ a_i = b_i, for i \in mask \f$
- */
-void hip_copy_mask(void* a, void* b, int* size, int* mask, int* mask_size) {
-    const dim3 nthrds(1024, 1, 1);
-    const dim3 nblcks(((*mask_size) + 1024 - 1) / 1024, 1, 1);
-
-    if(*mask_size == 0) return;
-    hipLaunchKernelGGL(copy_mask_kernel<real>, nblcks, nthrds, 0,
-         (hipStream_t)glb_cmd_queue,
-         (real*)a, (real*)b, *size, mask, *mask_size);
-    HIP_CHECK(hipGetLastError());
-}
-
 /** Fortran wrapper for cadd_mask
  * Add a scalar to vector \f$ a_i = a_i + s, for i \in mask \f$
  */

--- a/sources/neko_ext/math/bcknd/device_math_ext.f90
+++ b/sources/neko_ext/math/bcknd/device_math_ext.f90
@@ -41,17 +41,6 @@ module device_math_ext
 #if HAVE_HIP
 
   interface
-     subroutine hip_copy_mask(a_d, b_d, size, mask_d, mask_size) &
-          bind(c, name = 'hip_copy_mask')
-       import c_rp, c_int, c_ptr
-       type(c_ptr), value :: a_d
-       type(c_ptr), value :: b_d
-       integer(c_int) :: size
-       type(c_ptr), value :: mask_d
-       integer(c_int) :: mask_size
-     end subroutine hip_copy_mask
-  end interface
-  interface
      subroutine hip_cadd_mask(a_d, c, size, mask_d, mask_size) &
           bind(c, name = 'hip_cadd_mask')
        import c_rp, c_int, c_ptr
@@ -110,17 +99,6 @@ module device_math_ext
 
 #elif HAVE_CUDA
 
-  interface
-     subroutine cuda_copy_mask(a_d, b_d, size, mask_d, mask_size) &
-          bind(c, name = 'cuda_copy_mask')
-       import c_rp, c_int, c_ptr
-       type(c_ptr), value :: a_d
-       type(c_ptr), value :: b_d
-       integer(c_int) :: size
-       type(c_ptr), value :: mask_d
-       integer(c_int) :: mask_size
-     end subroutine cuda_copy_mask
-  end interface
   interface
      subroutine cuda_cadd_mask(a_d, c, size, mask_d, mask_size) &
           bind(c, name = 'cuda_cadd_mask')
@@ -183,21 +161,6 @@ module device_math_ext
 #endif
 
 contains
-
-  subroutine device_copy_mask(a_d, b_d, size, mask_d, mask_size)
-    type(c_ptr) :: a_d
-    type(c_ptr) :: b_d
-    integer :: size
-    type(c_ptr) :: mask_d
-    integer :: mask_size
-#if HAVE_HIP
-    call hip_copy_mask(a_d, b_d, size, mask_d, mask_size)
-#elif HAVE_CUDA
-    call cuda_copy_mask(a_d, b_d, size, mask_d, mask_size)
-#else
-    call neko_error('No device backend configured for device_copy_mask')
-#endif
-  end subroutine device_copy_mask
 
   subroutine device_cadd_mask(a_d, c, size, mask_d, mask_size)
     type(c_ptr) :: a_d

--- a/sources/problem/constraints/volume_constraint.f90
+++ b/sources/problem/constraints/volume_constraint.f90
@@ -252,14 +252,12 @@ contains
     class(design_t), intent(in) :: design
     !> Sensitivity field
     type(field_t), pointer :: unmapped, mapped
-    integer :: temp_indices(2)
+    integer :: idx(2)
 
     if (this%if_mapping) then
        ! Recompute and map backward
-       call neko_scratch_registry%request(unmapped, temp_indices(1), &
-            .false.)
-       call neko_scratch_registry%request(mapped, temp_indices(2), &
-            .false.)
+       call neko_scratch_registry%request(unmapped, idx(1), .false.)
+       call neko_scratch_registry%request(mapped, idx(2), .false.)
        call field_cfill(unmapped, -1.0_rp / this%volume_domain)
        if (this%is_max) then
           call field_cmult(unmapped, -1.0_rp)
@@ -270,9 +268,12 @@ contains
        end if
        ! map backwards
        call this%mapping%apply_backward(mapped, unmapped)
+       if (this%has_mask) then
+          call mask_exterior_const(mapped, this%mask, 0.0_rp)
+       end if
        call field_to_vector(this%sensitivity, mapped)
 
-       call neko_scratch_registry%relinquish(temp_indices)
+       call neko_scratch_registry%relinquish(idx)
 
     else
        ! Sensitivity is just a constant so it should not be updated


### PR DESCRIPTION
Refactor the handling of masked copies to improve performance and clarity. Replace the deprecated `device_copy_mask` with `device_masked_copy_0` for better efficiency in copying data within masked regions. Remove unnecessary Fortran wrappers and streamline the code for better maintainability.