### PR TITLE
Add missing frees

### DIFF
--- a/sources/adjoint/adjoint_fluid_pnpn.f90
+++ b/sources/adjoint/adjoint_fluid_pnpn.f90
@@ -603,7 +603,17 @@ contains
     call this%bc_prs_surface%free()
     call this%bc_sym_surface%free()
     call this%bc_curl_curl%free()
+
+    call this%bc_vel_res%free()
+    call this%bc_du%free()
+    call this%bc_dv%free()
+    call this%bc_dw%free()
+    call this%bc_dp%free()
+
     call this%bclst_vel_res%free()
+    call this%bclst_du%free()
+    call this%bclst_dv%free()
+    call this%bclst_dw%free()
     call this%bclst_dp%free()
     call this%proj_prs%free()
     call this%proj_vel%free()

--- a/sources/adjoint/adjoint_fluid_scheme_incompressible.f90
+++ b/sources/adjoint/adjoint_fluid_scheme_incompressible.f90
@@ -388,8 +388,10 @@ contains
   !> Deallocate a fluid formulation
   subroutine adjoint_fluid_scheme_free(this)
     class(adjoint_fluid_scheme_incompressible_t), intent(inout) :: this
+    class(bc_t), pointer :: bc
+    integer :: i
 
-    call this%Xh%free()
+    bc => null()
 
     if (allocated(this%ksp_vel)) then
        call this%ksp_vel%free()
@@ -411,11 +413,35 @@ contains
        deallocate(this%pc_prs)
     end if
 
+    do i = 1, this%bcs_vel%size()
+       bc => this%bcs_vel%get(i)
+       if (associated(bc)) then
+          call bc%free()
+          deallocate(bc)
+       end if
+    end do
+    call this%bcs_vel%free()
+
+    do i = 1, this%bcs_prs%size()
+       bc => this%bcs_prs%get(i)
+       if (associated(bc)) then
+          call bc%free()
+          deallocate(bc)
+       end if
+    end do
+    call this%bcs_prs%free()
+
     call this%source_term%free()
+
+    call this%GLL_to_GL%free()
 
     call this%gs_Xh%free()
 
+    call this%gs_Xh_GL%free()
+
     call this%c_Xh%free()
+
+    call this%c_Xh_GL%free()
 
     call this%scratch_GL%free()
 
@@ -435,14 +461,17 @@ contains
 
     if (associated(this%f_adj_x)) then
        call this%f_adj_x%free()
+       deallocate(this%f_adj_x)
     end if
 
     if (associated(this%f_adj_y)) then
        call this%f_adj_y%free()
+       deallocate(this%f_adj_y)
     end if
 
     if (associated(this%f_adj_z)) then
        call this%f_adj_z%free()
+       deallocate(this%f_adj_z)
     end if
 
     nullify(this%f_adj_x)
@@ -451,6 +480,13 @@ contains
 
     call this%rho%free()
     call this%mu%free()
+    call this%dm_Xh%free()
+    call this%dm_Xh_GL%free()
+    call this%Xh%free()
+    call this%Xh_GL%free()
+
+    nullify(this%msh)
+    nullify(bc)
 
   end subroutine adjoint_fluid_scheme_free
 

--- a/sources/adjoint/adjoint_scalar_pnpn.f90
+++ b/sources/adjoint/adjoint_scalar_pnpn.f90
@@ -314,6 +314,7 @@ contains
     call this%scheme_free()
 
     call this%bclst_ds%free()
+    call this%bc_res%free()
     call this%proj_s%free()
 
     call this%s_adj_res%free()

--- a/sources/adjoint/adjoint_scalar_scheme.f90
+++ b/sources/adjoint/adjoint_scalar_scheme.f90
@@ -399,6 +399,10 @@ contains
   !> Deallocate a scalar formulation
   subroutine adjoint_scalar_scheme_free(this)
     class(adjoint_scalar_scheme_t), intent(inout) :: this
+    class(bc_t), pointer :: bc
+    integer :: i
+
+    bc => null()
 
     nullify(this%Xh)
     nullify(this%dm_Xh)
@@ -418,11 +422,27 @@ contains
 
     call this%source_term%free()
 
+    if (associated(this%f_Xh)) then
+       call this%f_Xh%free()
+       deallocate(this%f_Xh)
+       nullify(this%f_Xh)
+    end if
+
+    do i = 1, this%bcs%size()
+       bc => this%bcs%get(i)
+       if (associated(bc)) then
+          call bc%free()
+          deallocate(bc)
+       end if
+    end do
+
     call this%bcs%free()
 
     call this%cp%free()
     call this%lambda%free()
     call this%s_adj_lag%free()
+
+    nullify(bc)
 
   end subroutine adjoint_scalar_scheme_free
 

--- a/sources/adjoint/simulation_adjoint.f90
+++ b/sources/adjoint/simulation_adjoint.f90
@@ -45,6 +45,7 @@ module simulation_adjoint
   use time_state, only : time_state_t
   use time_step_controller, only: time_step_controller_t
   use adjoint_case, only: adjoint_case_t
+  use scratch_registry, only: neko_scratch_registry
   use device_math, only: device_glsc3
   use math, only: glsc3
   use vector, only: vector_t
@@ -283,9 +284,9 @@ contains
   subroutine simulation_adjoint_norm_output(C, time_output)
     type(adjoint_case_t), intent(inout) :: C
     type(time_state_t), intent(in) :: time_output
-    type(vector_t) :: data_line
+    type(vector_t), pointer :: data_line
     real(kind=rp) :: norm_l2
-    integer :: n
+    integer :: n, idx
 
     if (.not. C%norm_output_enabled) return
     if (.not. C%norm_output_ctrl%check(time_output)) return
@@ -309,10 +310,10 @@ contains
 
     norm_l2 = sqrt(norm_l2) / C%fluid_adj%c_Xh%volume
 
-    call data_line%init(1)
+    call neko_scratch_registry%request(data_line, idx, 1, .false.)
     data_line%x = [norm_l2]
     call C%norm_output_file%write(data_line, time_output%t)
-    call data_line%free()
+    call neko_scratch_registry%relinquish(idx)
     call C%norm_output_ctrl%register_execution()
   end subroutine simulation_adjoint_norm_output
 


### PR DESCRIPTION
Ensure proper memory management by adding missing deallocation calls in various subroutines. This improves resource handling and prevents potential memory leaks.