### PR TITLE
Update GitHub Action to latest version

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload artifact
         id: deployment
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: documentation/html/
 


### PR DESCRIPTION
Upgrade the `upload-pages-artifact` action from version 4 to version 5 to ensure compatibility and access to the latest features.