### PR TITLE
Force user to specify CUDA architecture

### DIFF
--- a/documentation/pages/user_guide/installation.md
+++ b/documentation/pages/user_guide/installation.md
@@ -74,6 +74,7 @@ custom install locations for the given dependencies.
 | `NEK5000_DIR`      | Nek5000, primarily used for meshing and for GSLib.                   | external/Nek5000      |
 | `PFUNIT_DIR`       | Unit testing library used in Neko.                                   | -                     |
 | `CUDA_DIR`         | Location of the CUDA library folders, needed for Nvidia GPU support. | -                     |
+| `CUDA_ARCH`        | CUDA architecture for GPU builds (for example `80` for sm_80).       | Required for CUDA     |
 
 These can be defined either on the command line by the user or in a
 `prepare.env` file which is loaded by the setup script if it exists in the root
@@ -90,8 +91,12 @@ An example of a `prepare.env` file is shown below:
 module load cuda/10.1
 
 export CUDA_DIR=$CUDA_HOME
+export CUDA_ARCH=80
 export NEKO_DIR=$HOME/neko
 ```
+
+For CUDA builds, `CUDA_ARCH` must be explicitly specified before running
+`setup.sh` (for example `export CUDA_ARCH=80`).
 
 Additional examples of the preparation script for specific systems can be seen
 in the section on clusters: \subpage clusters.

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,14 @@ cd neko-top
 ./setup.sh
 ```
 
+For CUDA builds, `CUDA_ARCH` must be set explicitly before running setup, for
+example:
+
+```sh
+export CUDA_ARCH=80
+./setup.sh -d CUDA
+```
+
 ## Example execution
 
 The run.sh script is the main driver for managing example execution. The run

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -424,6 +424,16 @@ function find_neko() {
                 error "the CUDA installation."
                 exit 1
             fi
+
+            if [ -n "$NEKO_CUDA_ARCH" ]; then
+                FEATURES+=" CUDA_ARCH=$NEKO_CUDA_ARCH"
+            elif [ -n "$CUDA_ARCH" ]; then
+                FEATURES+=" CUDA_ARCH=-arch=sm_$CUDA_ARCH"
+            else
+                error "CUDA architecture not set."
+                exit 1
+            fi
+
         elif [ "$DEVICE_TYPE" == "HIP" ]; then
             if [ -d "$HIP_DIR" ]; then
                 FEATURES+=" --with-hip=$HIP_DIR"

--- a/setup.sh
+++ b/setup.sh
@@ -102,6 +102,7 @@ if [ -z "$MPICXX" ]; then export MPICXX=$(which mpicxx); else export MPICXX; fi
 # Device specific compilers
 if [ "$DEVICE_TYPE" == "CUDA" ]; then
     if [ -z "$NVCC" ]; then export NVCC=$(which nvcc); else export NVCC; fi
+    if [ -z "$CUDA_ARCH" ]; then echo >&2 "CUDA_ARCH is not set."; exit 1; fi
 elif [ "$DEVICE_TYPE" == "HIP" ]; then
     if [ -z "$HIPCC" ]; then export HIPCC=$(which hipcc); else export HIPCC; fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,7 @@ function help() {
     echo -e "\tPFUNIT_DIR        The directory where PFUnit is installed"
     echo -e "\tGSLIB_DIR         The directory where GSLIB is installed"
     echo -e "\tCUDA_DIR          The directory where CUDA is installed"
+    echo -e "\tCUDA_ARCH         CUDA architecture (required for --device CUDA, e.g. 80)"
     echo -e "\tHIP_DIR           The directory where HIP is installed"
     echo -e "\tBLAS_DIR          The directory where BLAS is installed"
     echo -e "\tCMAKE_VARIABLES   Additional variables to pass to CMake"

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -14,6 +14,13 @@ if (${DEVICE_TYPE} STREQUAL "CUDA")
     enable_language(CUDA)
     add_compile_definitions(HAVE_CUDA=1)
     find_package(CUDAToolkit REQUIRED)
+
+    if(DEFINED ENV{CUDA_ARCH})
+        set(CMAKE_CUDA_ARCHITECTURES "$ENV{CUDA_ARCH}")
+    endif()
+
+    message(STATUS "CUDA architecture(s) set to: ${CMAKE_CUDA_ARCHITECTURES}")
+
 elseif(${DEVICE_TYPE} STREQUAL "HIP")
     enable_language(HIP)
     enable_language(C)


### PR DESCRIPTION
Require users to explicitly set the CUDA architecture before running the setup script. Update documentation to reflect this change and provide examples for clarity.