### PR TITLE
Update velocity solver type to cg

### DIFF
--- a/examples/wiggles/uniform_1.case
+++ b/examples/wiggles/uniform_1.case
@@ -24,7 +24,7 @@
                 "value": [ 1.0, 0.0, 0.0 ]
             },
             "velocity_solver": {
-                "type": "fused_coupled_cg",
+                "type": "cg",
                 "preconditioner": {
                     "type": "jacobi"
                 },

--- a/examples/wiggles/uniform_1_mask.case
+++ b/examples/wiggles/uniform_1_mask.case
@@ -24,7 +24,7 @@
                 "value": [ 1.0, 0.0, 0.0 ]
             },
             "velocity_solver": {
-                "type": "fused_coupled_cg",
+                "type": "cg",
                 "preconditioner": {
                     "type": "jacobi"
                 },


### PR DESCRIPTION
Change the velocity solver type from `fused_coupled_cg` to `cg` for improved support.