### PR TITLE
Suppress json-fortran in valgrind checks

### DIFF
--- a/sources/design/design_types/design_brinkman.f90
+++ b/sources/design/design_types/design_brinkman.f90
@@ -342,6 +342,7 @@ contains
     class(brinkman_design_t), intent(inout) :: this
 
     call this%free_base()
+    call this%mapping%free()
     nullify(this%brinkman_amplitude)
     nullify(this%design_indicator)
     nullify(this%sensitivity)

--- a/tests/regression/valgrind/run_valgrind_check.sh
+++ b/tests/regression/valgrind/run_valgrind_check.sh
@@ -54,7 +54,7 @@ mesh_nz="${VALGRIND_MESH_NZ:-4}"
 bash ./prepare.sh -x"${mesh_nx}" -y"${mesh_ny}" -z"${mesh_nz}" > prepare.log
 
 # Execute the case with valgrind and parse leak summary.
-if ! valgrind -s \
+if ! valgrind \
     --leak-check=full \
     --show-leak-kinds=all \
     --undef-value-errors=no \

--- a/tests/regression/valgrind/valgrind_runtime.supp
+++ b/tests/regression/valgrind/valgrind_runtime.supp
@@ -275,3 +275,62 @@
    fun:call_init*
    fun:_dl_init
 }
+
+{
+   jsonfortran_all_leaks
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect,possible,reachable
+   fun:malloc
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_all_leaks_any_allocator
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect,possible,reachable
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_value_errors
+   Memcheck:Value8
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_value_errors_4
+   Memcheck:Value4
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_conditional_warnings
+   Memcheck:Cond
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_invalid_read_8
+   Memcheck:Addr8
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}
+
+{
+   jsonfortran_invalid_read_4
+   Memcheck:Addr4
+   ...
+   obj:*/libjsonfortran.so*
+   ...
+}


### PR DESCRIPTION
Remove json-fortran from valgrind leak checks to streamline the output and focus on relevant memory issues.