### PR TITLE
Add RAMP Mapping Visualization Notebook

### DIFF
--- a/scripts/notebooks/ramp.ipynb
+++ b/scripts/notebooks/ramp.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "03e43f61",
+   "metadata": {},
+   "source": [
+    "# RAMP Mapping Visualization\n",
+    "\n",
+    "This notebook visualizes the RAMP mapping over the input interval $[0, 1]$.\n",
+    "\n",
+    "Adjustable mapping settings (from the RAMP component):\n",
+    "- `f_min`\n",
+    "- `f_max`\n",
+    "- `q`\n",
+    "- `convex_up`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63b5dd06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "\n",
+    "def ramp_mapping(x, f_min, f_max, q, convex_up):\n",
+    "    \"\"\"Evaluate the RAMP mapping used in Neko-TOP.\"\"\"\n",
+    "    q_eff = max(float(q), 1.0e-12)\n",
+    "    if convex_up:\n",
+    "        # convex-up form used by the implementation when convex_up = True\n",
+    "        return f_min + (f_max - f_min) * x * (q_eff + 1.0) / (q_eff + x)\n",
+    "    # standard RAMP form used when convex_up = False\n",
+    "    return f_min + (f_max - f_min) * x / (1.0 + q_eff * (1.0 - x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c12ff7f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build a list of parameter sets as: (f_min, f_max, q)\n",
+    "parameter_sets = [\n",
+    "    (0.0, 1000.0, 10.0),\n",
+    "    (0.0, 10000.0, 150.0),\n",
+    "]\n",
+    "\n",
+    "# Toggle between the two RAMP forms\n",
+    "convex_up = False\n",
+    "\n",
+    "# Input interval fixed to [0, 1]\n",
+    "x = np.linspace(0.0, 1.0, 500)\n",
+    "\n",
+    "plt.figure(figsize=(9, 5))\n",
+    "for i, (f_min, f_max, q) in enumerate(parameter_sets, start=1):\n",
+    "    y = ramp_mapping(x, f_min=f_min, f_max=f_max, q=q, convex_up=convex_up)\n",
+    "    label = f'Set {i}: f_min={f_min}, f_max={f_max}, q={q}'\n",
+    "    plt.plot(x, y, linewidth=2.2, label=label)\n",
+    "\n",
+    "plt.xlim(0.0, 1.0)\n",
+    "plt.ylim(0.0, 1000.0)\n",
+    "plt.xlabel('X_in')\n",
+    "plt.ylabel('X_out')\n",
+    "plt.title(f'RAMP Mapping')\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2835c1b",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Introduce a Jupyter notebook that visualizes the RAMP mapping over the interval [0, 1], allowing users to adjust mapping parameters.