### PR TITLE
Mma/unconst

### DIFF
--- a/examples/mma/mma.case
+++ b/examples/mma/mma.case
@@ -59,7 +59,7 @@
         "solver": {
             "type": "mma",
             "max_iterations": 100,
-            "tolerance": 1.0e-4,
+            "tolerance": 1.0e-6,
             "mma": {
                 "max_iter": 100,
                 "subsolver": "dip",

--- a/sources/mma/bcknd/cpu/mma_cpu.f90
+++ b/sources/mma/bcknd/cpu/mma_cpu.f90
@@ -141,11 +141,11 @@ contains
     ! Compute the stationarity residual projected onto the box bounds
     do j = 1, this%n
        if (x(j) - this%xmin%x(j) .le. NEKO_EPS) then
-          ! At lower bound: residual is non-zero only if gradient is negative 
+          ! At lower bound: residual is non-zero only if gradient is negative
           ! (trying to decrease x further)
           rex(j) = min(0.0_rp, df0dx(j))
        else if (this%xmax%x(j) - x(j) .le. NEKO_EPS) then
-          ! At upper bound: residual is non-zero only if gradient is positive 
+          ! At upper bound: residual is non-zero only if gradient is positive
           ! (trying to increase x further)
           rex(j) = max(0.0_rp, df0dx(j))
        else
@@ -1146,7 +1146,7 @@ contains
            (sqrt(p0j) + sqrt(q0j))
 
       x = merge(alpha, x, x .lt. alpha)
-      x = merge(beta,  x, x .gt. beta)
+      x = merge(beta, x, x .gt. beta)
     end associate
 
     ! Update history

--- a/sources/mma/bcknd/cpu/mma_cpu.f90
+++ b/sources/mma/bcknd/cpu/mma_cpu.f90
@@ -70,10 +70,14 @@ contains
 
     !solve the approximation problem using interior point method
     call profiler_start_region("MMA subsolve")
-    if (this%subsolver .eq. "dip") then
+    if (this%unconstrained_problem) then
+       call mma_subsolve_unconstrained_cpu(this, x)
+    elseif (this%subsolver .eq. "dip") then
        call mma_subsolve_dip_cpu(this, x)
-    else
+    elseif (this%subsolver .eq. "dpip") then
        call mma_subsolve_dpip_cpu(this, x)
+    else
+       call neko_error("MMA subsolver is not recognised (NOT dip or dpip).")
     end if
     call profiler_end_region("MMA subsolve")
 
@@ -111,14 +115,58 @@ contains
 
     call profiler_start_region("MMA KKT computation")
 
-    if (this%subsolver .eq. "dip") then
+    if (this%unconstrained_problem) then
+       call mma_unconstrained_KKT_cpu(this, x, df0dx)
+    else if (this%subsolver .eq. "dip") then
        call mma_dip_KKT_cpu(this, x, df0dx, fval, dfdx)
-    else
+    elseif (this%subsolver .eq. "dpip") then
        call mma_dpip_KKT_cpu(this, x, df0dx, fval, dfdx)
+    else
+       call neko_error("MMA subsolver is not recognised (NOT dip or dpip).")
     end if
 
     call profiler_end_region("MMA KKT computation")
   end subroutine mma_KKT_cpu
+
+  !> Implementation of the KKT residual for unconstrained problems with box bounds.
+  module subroutine mma_unconstrained_KKT_cpu(this, x, df0dx)
+    class(mma_t), intent(inout) :: this
+    real(kind=rp), dimension(this%n), intent(in) :: x
+    real(kind=rp), dimension(this%n), intent(in) :: df0dx
+
+    real(kind=rp), dimension(this%n) :: rex
+    real(kind=rp) :: re_sq_norm
+    integer :: j, ierr
+
+    ! Compute the stationarity residual projected onto the box bounds
+    do j = 1, this%n
+       if (x(j) - this%xmin%x(j) .le. NEKO_EPS) then
+          ! At lower bound: residual is non-zero only if gradient is negative 
+          ! (trying to decrease x further)
+          rex(j) = min(0.0_rp, df0dx(j))
+       else if (this%xmax%x(j) - x(j) .le. NEKO_EPS) then
+          ! At upper bound: residual is non-zero only if gradient is positive 
+          ! (trying to increase x further)
+          rex(j) = max(0.0_rp, df0dx(j))
+       else
+          ! Strictly internal: standard unconstrained derivative must be zero
+          rex(j) = df0dx(j)
+       end if
+    end do
+
+    ! Calculate global metrics across elements/processors
+    this%residumax = maxval(abs(rex))
+    re_sq_norm = norm2(rex)**2
+
+    call MPI_Allreduce(MPI_IN_PLACE, this%residumax, 1, &
+         mpi_real_precision, MPI_MAX, neko_comm, ierr)
+
+    call MPI_Allreduce(MPI_IN_PLACE, re_sq_norm, 1, &
+         mpi_real_precision, mpi_sum, neko_comm, ierr)
+
+    this%residunorm = sqrt(re_sq_norm)
+
+  end subroutine mma_unconstrained_KKT_cpu
 
   !> Implementation of the KKT residual computation for dual primal interior
   ! point method (dpip) subsolve of MMA algorithm.
@@ -1083,5 +1131,28 @@ contains
     this%lambda%x = lambda
     this%mu%x = mu
   end subroutine mma_subsolve_dip_cpu
+
+  subroutine mma_subsolve_unconstrained_cpu(this, designx)
+    class(mma_t), intent(inout) :: this
+    real(kind=rp), dimension(this%n), intent(inout) :: designx
+    real(kind=rp), dimension(this%n) :: x
+
+    associate(p0j => this%p0j%x, q0j => this%q0j%x, &
+         low => this%low%x, upp => this%upp%x, &
+         alpha => this%alpha%x, beta => this%beta%x)
+
+      ! Closed-form primal solution for unconstrained MMA subproblem
+      x = (sqrt(p0j) * low + sqrt(q0j) * upp) / &
+           (sqrt(p0j) + sqrt(q0j))
+
+      x = merge(alpha, x, x .lt. alpha)
+      x = merge(beta,  x, x .gt. beta)
+    end associate
+
+    ! Update history
+    this%xold2%x = this%xold1%x
+    this%xold1%x = designx
+    designx = x
+  end subroutine mma_subsolve_unconstrained_cpu
 
 end submodule mma_cpu

--- a/sources/mma/bcknd/device/cuda/mma.cu
+++ b/sources/mma/bcknd/device/cuda/mma.cu
@@ -57,7 +57,20 @@ extern "C" {
   int mma_red_s = 0;
   real* mma_bufred = NULL;
   real* mma_bufred_d = NULL;
-  
+
+  void mma_unconstrained_kkt_cuda(void* rex, void* x, void* xmin, void* xmax,
+                                  void* df0dx, real* eps, int* n) {
+    const int N = *n;
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks((N + 1024 - 1) / 1024, 1, 1);
+
+    mma_unconstrained_kkt_kernel<real><<<nblcks, nthrds, 0, (cudaStream_t)glb_cmd_queue>>>(
+        (real*)rex, (const real*)x, (const real*)xmin, (const real*)xmax,
+        (const real*)df0dx, *eps, N);
+
+    CUDA_CHECK(cudaGetLastError());
+  }
+
   void mma_update_hessian_z_cuda(void* Hess, void* a, int* m) {
     const int M = *m;
     // This function is called ONLY if dot(lambda,a) > 0

--- a/sources/mma/bcknd/device/cuda/mma_kernel.h
+++ b/sources/mma/bcknd/device/cuda/mma_kernel.h
@@ -38,6 +38,34 @@
 #define MMA_CUDA_KERNEL_H
 
 template <typename T>
+__global__ void mma_unconstrained_kkt_kernel(
+    T* __restrict__ rex,
+    const T* __restrict__ x,
+    const T* __restrict__ xmin,
+    const T* __restrict__ xmax,
+    const T* __restrict__ df0dx,
+    const T eps,
+    const int n)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (j >= n) return;
+
+    if (x[j] - xmin[j] <= eps) {
+        // At lower bound: residual is non-zero only if gradient is negative
+        rex[j] = (df0dx[j] < (T)0.0) ? df0dx[j] : (T)0.0;
+    } 
+    else if (xmax[j] - x[j] <= eps) {
+        // At upper bound: residual is non-zero only if gradient is positive
+        rex[j] = (df0dx[j] > (T)0.0) ? df0dx[j] : (T)0.0;
+    } 
+    else {
+        // Strictly internal
+        rex[j] = df0dx[j];
+    }
+}
+	
+template <typename T>
 __global__ void mma_update_hessian_z_kernel(
     T* __restrict__ Hess,
     const T* __restrict__ a,

--- a/sources/mma/bcknd/device/cuda_mma_math.f90
+++ b/sources/mma/bcknd/device/cuda_mma_math.f90
@@ -40,6 +40,15 @@ module cuda_mma_math
   public
 
   interface
+     subroutine mma_unconstrained_kkt_cuda(rex, x, xmin, xmax, df0dx, eps, n) &
+          bind(c, name="mma_unconstrained_kkt_cuda")
+       import c_rp, c_ptr, c_int
+       type(c_ptr), value :: rex, x, xmin, xmax, df0dx
+       real(c_rp) :: eps
+       integer(c_int) :: n
+     end subroutine mma_unconstrained_kkt_cuda
+
+     
      subroutine mma_update_hessian_z_cuda(Hess_d, a_d, m) &
           bind(C, name="mma_update_hessian_z_cuda")
        use iso_c_binding

--- a/sources/mma/bcknd/device/cuda_mma_math.f90
+++ b/sources/mma/bcknd/device/cuda_mma_math.f90
@@ -48,7 +48,7 @@ module cuda_mma_math
        integer(c_int) :: n
      end subroutine mma_unconstrained_kkt_cuda
 
-     
+
      subroutine mma_update_hessian_z_cuda(Hess_d, a_d, m) &
           bind(C, name="mma_update_hessian_z_cuda")
        use iso_c_binding

--- a/sources/mma/bcknd/device/device_mma_math.f90
+++ b/sources/mma/bcknd/device/device_mma_math.f90
@@ -46,7 +46,7 @@ module device_mma_math
        mma_gensub3_cuda, mma_gensub4_cuda, mattrans_v_mul_cuda, &
        mma_dipsolvesub1_cuda, mma_Ljjxinv_cuda, cuda_Hess, delta_1dbeam_cuda, &
        cuSOLVER_wrapper, mma_prepare_hessian_cuda, mma_prepare_aa_matrix_cuda, &
-       cuda_custom_solver, mma_update_hessian_z_cuda
+       cuda_custom_solver, mma_update_hessian_z_cuda, mma_unconstrained_kkt_cuda
   use hip_mma_math, only: hip_mma_max, hip_max2, hip_rex, hip_lcsc2, &
        hip_relambda, hip_sub2cons2, hip_maxval, hip_norm, hip_delx, &
        hip_add2inv2, hip_GG, hip_diagx, hip_bb, hip_updatebb, hip_AA, &
@@ -55,7 +55,8 @@ module device_mma_math
        mma_gensub3_hip, mma_gensub4_hip, mattrans_v_mul_hip, &
        mma_dipsolvesub1_hip, mma_Ljjxinv_hip, hip_Hess, delta_1dbeam_hip, &
        hip_custom_solver, mma_prepare_hessian_hip, &
-       mma_prepare_aa_matrix_hip, hipSOLVER_wrapper, mma_update_hessian_z_hip
+       mma_prepare_aa_matrix_hip, hipSOLVER_wrapper, mma_update_hessian_z_hip!, &
+      ! mma_unconstrained_kkt_hip
 
   implicit none
   private
@@ -70,9 +71,25 @@ module device_mma_math
        device_kkt_rex, device_mattrans_v_mul, device_mma_dipsolvesub1, &
        device_mma_Ljjxinv, device_Hess, device_delta_1dbeam, &
        device_solve_linear_system, device_prepare_hessian, &
-       device_prepare_aa_matrix, device_update_hessian_z
+       device_prepare_aa_matrix, device_update_hessian_z, device_unconstrained_kkt
 
 contains
+  !> Compute the stationarity residual projected onto the box bounds on device
+  subroutine device_unconstrained_kkt(rex_d, x_d, xmin_d, xmax_d, df0dx_d, eps, n)
+    type(c_ptr), intent(in) :: rex_d, x_d, xmin_d, xmax_d, df0dx_d
+    real(c_rp), intent(in) :: eps
+    integer, value :: n
+#if HAVE_HIP
+    !call mma_unconstrained_kkt_hip(rex_d, x_d, xmin_d, xmax_d, df0dx_d, eps, n)
+#elif HAVE_CUDA
+    call mma_unconstrained_kkt_cuda(rex_d, x_d, xmin_d, xmax_d, df0dx_d, eps, n)
+#elif HAVE_OPENCL
+    call neko_error('Unconstrained KKT not implemented for OpenCL')
+#else
+    call neko_error('No device backend configured for Unconstrained KKT')
+#endif
+  end subroutine device_unconstrained_kkt
+
   !> Update Hessian for dual solver with z-term contribution: Hess -= a * a^T
   subroutine device_update_hessian_z(Hess_d, a_d, m)
     use iso_c_binding

--- a/sources/mma/bcknd/device/device_mma_math.f90
+++ b/sources/mma/bcknd/device/device_mma_math.f90
@@ -55,8 +55,8 @@ module device_mma_math
        mma_gensub3_hip, mma_gensub4_hip, mattrans_v_mul_hip, &
        mma_dipsolvesub1_hip, mma_Ljjxinv_hip, hip_Hess, delta_1dbeam_hip, &
        hip_custom_solver, mma_prepare_hessian_hip, &
-       mma_prepare_aa_matrix_hip, hipSOLVER_wrapper, mma_update_hessian_z_hip!, &
-      ! mma_unconstrained_kkt_hip
+       mma_prepare_aa_matrix_hip, hipSOLVER_wrapper, mma_update_hessian_z_hip, &
+       mma_unconstrained_kkt_hip
 
   implicit none
   private
@@ -80,7 +80,7 @@ contains
     real(c_rp), intent(in) :: eps
     integer, value :: n
 #if HAVE_HIP
-    !call mma_unconstrained_kkt_hip(rex_d, x_d, xmin_d, xmax_d, df0dx_d, eps, n)
+    call mma_unconstrained_kkt_hip(rex_d, x_d, xmin_d, xmax_d, df0dx_d, eps, n)
 #elif HAVE_CUDA
     call mma_unconstrained_kkt_cuda(rex_d, x_d, xmin_d, xmax_d, df0dx_d, eps, n)
 #elif HAVE_OPENCL

--- a/sources/mma/bcknd/device/hip/mma.hip
+++ b/sources/mma/bcknd/device/hip/mma.hip
@@ -56,6 +56,21 @@ int mma_red_s = 0;
 real * mma_bufred = NULL;
 real * mma_bufred_d = NULL;
 
+void mma_unconstrained_kkt_hip(void* rex, void* x, void* xmin, void* xmax, 
+                               void* df0dx, real* eps, int* n) {
+    const int N = *n;
+    const dim3 nthrds(1024, 1, 1);
+    const dim3 nblcks((N + 1024 - 1) / 1024, 1, 1);
+    const hipStream_t stream = (hipStream_t)glb_cmd_queue;
+
+    hipLaunchKernelGGL(
+        mma_unconstrained_kkt_kernel<real>, nblcks, nthrds, 0, stream,
+        (real*)rex, (const real*)x, (const real*)xmin, (const real*)xmax, 
+        (const real*)df0dx, *eps, N);
+
+    HIP_CHECK(hipGetLastError());
+}
+
 void mma_update_hessian_z_hip(void* Hess, void* a, int m) {
     const int M = m;
     const int total = M * M;

--- a/sources/mma/bcknd/device/hip/mma_kernel.h
+++ b/sources/mma/bcknd/device/hip/mma_kernel.h
@@ -38,6 +38,34 @@
 #define MMA_HIP_KERNEL_H
 
 template <typename T>
+__global__ void mma_unconstrained_kkt_kernel(
+    T* __restrict__ rex,
+    const T* __restrict__ x,
+    const T* __restrict__ xmin,
+    const T* __restrict__ xmax,
+    const T* __restrict__ df0dx,
+    const T eps,
+    const int n)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (j >= n) return;
+
+    if (x[j] - xmin[j] <= eps) {
+        // At lower bound: residual is non-zero only if gradient is negative
+        rex[j] = (df0dx[j] < (T)0.0) ? df0dx[j] : (T)0.0;
+    }
+    else if (xmax[j] - x[j] <= eps) {
+        // At upper bound: residual is non-zero only if gradient is positive
+        rex[j] = (df0dx[j] > (T)0.0) ? df0dx[j] : (T)0.0;
+    }
+    else {
+        // Strictly internal
+        rex[j] = df0dx[j];
+    }
+}
+
+template <typename T>
 __global__ void mma_update_hessian_z_kernel(
     T* __restrict__ Hess,
     const T* __restrict__ a,

--- a/sources/mma/bcknd/device/hip_mma_math.f90
+++ b/sources/mma/bcknd/device/hip_mma_math.f90
@@ -40,6 +40,14 @@ module hip_mma_math
   public
 
   interface
+     subroutine mma_unconstrained_kkt_hip(rex, x, xmin, xmax, df0dx, eps, n) &
+          bind(c, name="mma_unconstrained_kkt_hip")
+       import c_rp, c_ptr, c_int
+       type(c_ptr), value :: rex, x, xmin, xmax, df0dx
+       real(c_rp) :: eps
+       integer(c_int) :: n
+     end subroutine mma_unconstrained_kkt_hip
+
      subroutine mma_update_hessian_z_hip(Hess_d, a_d, m) &
           bind(C, name="mma_update_hessian_z_hip")
        use iso_c_binding

--- a/sources/mma/bcknd/device/mma_device.f90
+++ b/sources/mma/bcknd/device/mma_device.f90
@@ -1100,7 +1100,7 @@ contains
     class(mma_t), intent(inout) :: this
     type(c_ptr), intent(in) :: designx_d
     type(vector_t), pointer :: x
-    integer :: info, ind(1)
+    integer :: ind(1)
 
     call this%scratch%request(x, ind(1), this%n, .false.)
     associate(p0j => this%p0j, q0j => this%q0j, &

--- a/sources/mma/bcknd/device/mma_device.f90
+++ b/sources/mma/bcknd/device/mma_device.f90
@@ -84,7 +84,7 @@ contains
 
     !solve the approximation problem using interior point method
     call profiler_start_region("MMA subsolve")
-    
+
     if (this%unconstrained_problem) then
        call mma_subsolve_unconstrained_device(this, x)
     elseif (this%subsolver .eq. "dip") then
@@ -146,7 +146,7 @@ contains
 
     ! Release scratch memory
     call this%scratch%relinquish(ind)
-  end subroutine mma_unconstrained_KKT_device  
+  end subroutine mma_unconstrained_KKT_device
 
   !> Implementation of the KKT residual computation for dual interior
   ! point method (dip) subsolve of MMA algorithm.
@@ -1109,7 +1109,7 @@ contains
       call device_mma_dipsolvesub1(x%x_d, p0j%x_d, q0j%x_d, &
            low%x_d, upp%x_d, alpha%x_d, beta%x_d, this%n)
       ! Closed-form primal solution for unconstrained MMA subproblem
-      
+
     end associate
 
     ! Save the new designx

--- a/sources/mma/bcknd/device/mma_device.f90
+++ b/sources/mma/bcknd/device/mma_device.f90
@@ -119,12 +119,12 @@ contains
     type(c_ptr), intent(in) :: x, df0dx
 
     type(vector_t), pointer :: rex
-    integer :: ind(1)
+    integer :: ind
     real(kind=rp) :: re_sq_norm
     integer :: ierr
 
     ! Request temporary scratch space for rex on the device
-    call this%scratch%request(rex, ind(1), this%n, .false.)
+    call this%scratch%request(rex, ind, this%n, .false.)
 
     ! Launch the custom element-wise KKT kernel via our abstraction layer
     call device_unconstrained_kkt(rex%x_d, x, this%xmin%x_d, this%xmax%x_d, &
@@ -1100,9 +1100,9 @@ contains
     class(mma_t), intent(inout) :: this
     type(c_ptr), intent(in) :: designx_d
     type(vector_t), pointer :: x
-    integer :: ind(1)
+    integer :: ind
 
-    call this%scratch%request(x, ind(1), this%n, .false.)
+    call this%scratch%request(x, ind, this%n, .false.)
     associate(p0j => this%p0j, q0j => this%q0j, &
          low => this%low, upp => this%upp, &
          alpha => this%alpha, beta => this%beta)

--- a/sources/mma/bcknd/device/mma_device.f90
+++ b/sources/mma/bcknd/device/mma_device.f90
@@ -46,13 +46,15 @@ submodule (mma) mma_device
        device_dy, device_dxsi, device_deta, device_kkt_rex, &
        device_mma_gensub2, device_mattrans_v_mul, device_mma_dipsolvesub1, &
        device_mma_Ljjxinv, device_Hess, device_solve_linear_system, &
-       device_prepare_hessian, device_prepare_aa_matrix, device_update_hessian_z
+       device_prepare_hessian, device_prepare_aa_matrix, device_update_hessian_z, &
+       device_unconstrained_kkt
 
   use neko_config, only: NEKO_BCKND_DEVICE, NEKO_DEVICE_MPI
   use device, only: DEVICE_TO_HOST
   use comm, only: neko_comm, pe_rank, mpi_real_precision
   use mpi_f08, only: MPI_IN_PLACE, MPI_MAX, MPI_MIN
   use profiler, only: profiler_start_region, profiler_end_region
+  use math, only: NEKO_EPS
 
   implicit none
 
@@ -82,7 +84,10 @@ contains
 
     !solve the approximation problem using interior point method
     call profiler_start_region("MMA subsolve")
-    if (this%subsolver .eq. "dip") then
+    
+    if (this%unconstrained_problem) then
+       call mma_subsolve_unconstrained_device(this, x)
+    elseif (this%subsolver .eq. "dip") then
        call mma_subsolve_dip_device(this, x)
     else if (this%subsolver .eq. "dpip") then
        call mma_subsolve_dpip_device(this, x)
@@ -98,12 +103,50 @@ contains
     class(mma_t), intent(inout) :: this
     type(c_ptr), intent(in) :: x, df0dx, fval, dfdx
 
-    if (this%subsolver .eq. "dip") then
+    if (this%unconstrained_problem) then
+       call mma_unconstrained_KKT_device(this, x, df0dx)
+    elseif (this%subsolver .eq. "dip") then
        call mma_dip_KKT_device(this, x, df0dx, fval, dfdx)
-    else
+    elseif (this%subsolver .eq. "dpip") then
        call mma_dpip_KKT_device(this, x, df0dx, fval, dfdx)
+    else
+       call neko_error("MMA subsolver is not recognised (NOT dip or dpip).")
     end if
   end subroutine mma_KKT_device
+
+  module subroutine mma_unconstrained_KKT_device(this, x, df0dx)
+    class(mma_t), intent(inout) :: this
+    type(c_ptr), intent(in) :: x, df0dx
+
+    type(vector_t), pointer :: rex
+    integer :: ind(1)
+    real(kind=rp) :: re_sq_norm
+    integer :: ierr
+
+    ! Request temporary scratch space for rex on the device
+    call this%scratch%request(rex, ind(1), this%n, .false.)
+
+    ! Launch the custom element-wise KKT kernel via our abstraction layer
+    call device_unconstrained_kkt(rex%x_d, x, this%xmin%x_d, this%xmax%x_d, &
+         df0dx, NEKO_EPS, this%n)
+
+    ! Compute global metrics using your existing library routines
+    ! (Assuming device_maxval returns maxval(abs(a)) and device_norm returns sum(a^2))
+    this%residumax = device_maxval(rex%x_d, this%n)
+    re_sq_norm = device_norm(rex%x_d, this%n)
+
+    ! Global MPI Reductions across nodes
+    call MPI_Allreduce(MPI_IN_PLACE, this%residumax, 1, &
+         mpi_real_precision, MPI_MAX, neko_comm, ierr)
+
+    call MPI_Allreduce(MPI_IN_PLACE, re_sq_norm, 1, &
+         mpi_real_precision, mpi_sum, neko_comm, ierr)
+
+    this%residunorm = sqrt(re_sq_norm)
+
+    ! Release scratch memory
+    call this%scratch%relinquish(ind)
+  end subroutine mma_unconstrained_KKT_device  
 
   !> Implementation of the KKT residual computation for dual interior
   ! point method (dip) subsolve of MMA algorithm.
@@ -1052,5 +1095,28 @@ contains
 
     call this%scratch%relinquish(ind)
   end subroutine mma_subsolve_dip_device
+
+  subroutine mma_subsolve_unconstrained_device(this, designx_d)
+    class(mma_t), intent(inout) :: this
+    type(c_ptr), intent(in) :: designx_d
+    type(vector_t), pointer :: x
+    integer :: info, ind(1)
+
+    call this%scratch%request(x, ind(1), this%n, .false.)
+    associate(p0j => this%p0j, q0j => this%q0j, &
+         low => this%low, upp => this%upp, &
+         alpha => this%alpha, beta => this%beta)
+      call device_mma_dipsolvesub1(x%x_d, p0j%x_d, q0j%x_d, &
+           low%x_d, upp%x_d, alpha%x_d, beta%x_d, this%n)
+      ! Closed-form primal solution for unconstrained MMA subproblem
+      
+    end associate
+
+    ! Save the new designx
+    call device_copy(this%xold2%x_d, this%xold1%x_d, this%n)
+    call device_copy(this%xold1%x_d, designx_d, this%n)
+    call device_copy(designx_d, x%x_d, this%n)
+    call this%scratch%relinquish(ind)
+  end subroutine mma_subsolve_unconstrained_device
 
 end submodule mma_device

--- a/sources/mma/mma.f90
+++ b/sources/mma/mma.f90
@@ -96,6 +96,7 @@ module mma
      type(vector_t) :: xold1, xold2, low, upp, alpha, beta, a, c, d, xmax, xmin
      logical :: is_initialized = .false.
      logical :: is_updated = .false.
+     logical :: unconstrained_problem = .false.
      type(scratch_registry_t) :: scratch
      character(len=:), allocatable :: subsolver, bcknd
 
@@ -225,7 +226,8 @@ contains
   ! Initializers and destructors
 
   !> Read attributes from the case file, and calling the init function
-  subroutine mma_init_from_json(this, x, n, m, json, scale, auto_scale)
+  subroutine mma_init_from_json(this, x, n, m, json, scale, auto_scale, &
+       unconstrained_problem)
     ! ----------------------------------------------------- !
     ! Initializing the mma object and all the parameters    !
     ! required for MMA method. (a_i, c_i, d_i, ...)         !
@@ -246,6 +248,7 @@ contains
     ! Read the scaling info for fval and dfdx from json
     real(kind=rp), intent(out) :: scale
     logical, intent(out) :: auto_scale
+    logical, intent(in) :: unconstrained_problem
     ! -------------------------------------------------------------------!
     !      Internal parameters for MMA                                   !
     !      Minimize  f_0(x) + a_0*z + sum( c_i*y_i + 0.5*d_i*(y_i)^2 )   !
@@ -312,7 +315,7 @@ contains
 
     call this%init(x, n, m, a0, a, c, d, xmin, xmax, &
          max_iter, epsimin, asyinit, asyincr, asydecr, bcknd, subsolver, &
-         move_limit)
+         move_limit, unconstrained_problem)
 
   end subroutine mma_init_from_json
 
@@ -353,7 +356,7 @@ contains
   !> Initialize the mma object based on the attributes from the json file
   subroutine mma_init_from_components(this, x, n, m, a0, a, c, d, xmin, xmax, &
        max_iter, epsimin, asyinit, asyincr, asydecr, bcknd, subsolver, &
-       move_limit)
+       move_limit, unconstrained_problem)
     ! ----------------------------------------------------- !
     ! Initializing the mma object and all the parameters    !
     ! required for MMA method. (a_i, c_i, d_i, ...)         !
@@ -382,12 +385,14 @@ contains
     real(kind=rp), intent(in), optional :: epsimin, asyinit, asyincr, asydecr
     real(kind=rp), intent(in), optional :: move_limit
     character(len=*), intent(in), optional :: bcknd, subsolver
+    logical, intent(in) :: unconstrained_problem
     character(len=256) :: log_msg
     integer :: i, ierr
 
     call this%free()
     call this%scratch%init()
 
+    this%unconstrained_problem = unconstrained_problem
     this%n = n
     this%m = m
 

--- a/sources/optimizer/mma_optimizer.f90
+++ b/sources/optimizer/mma_optimizer.f90
@@ -166,7 +166,7 @@ contains
     this%unconstrained_problem = problem%get_n_constraints() .eq. 0
     if (this%unconstrained_problem) then
        call neko_log%message('Unconstrained problem detected. ' // &
-            'Adding a dummy constraint to enable MMA optimization.')
+            'Switching to explicit closed-form MMA subsolver and KKT.')
 
        allocate(dummy_constraint_t::dummy_con)
        select type (con => dummy_con)
@@ -184,7 +184,8 @@ contains
 
     call design%get_values(x)
     call this%mma%init(x, design%size(), problem%get_n_constraints(), &
-         solver_parameters, this%scale, this%auto_scale)
+         solver_parameters, this%scale, this%auto_scale, &
+         this%unconstrained_problem)
 
     call neko_scratch_registry%relinquish(ind)
 


### PR DESCRIPTION
This adds an explicit MMA update and convergence check for unconstrained problems using the two following references:

1.  Da Silva GA, Aage N, Beck AT, Sigmund O. Local versus global stress constraint strategies in topology optimization: A comparative study. Int J Numer Methods Eng. 2021;122:6003–6036. https://doi.org/10.1002/nme.6781
2. Giraldo-Londoño, O., Paulino, G.H. PolyStress: a Matlab implementation for local stress-constrained topology optimization using the augmented Lagrangian method. Struct Multidisc Optim 63, 2065–2097 (2021). https://doi.org/10.1007/s00158-020-02760-8