### PR TITLE
Expand mapping unit tests

### DIFF
--- a/tests/unit/mapping/CMakeLists.txt
+++ b/tests/unit/mapping/CMakeLists.txt
@@ -1,16 +1,29 @@
 # CMakeLists.txt for the mapping-function unit tests.
 #
-# Finite-difference verification of the RAMP and Borrvall & Petersson mappings:
-# each forward mapping is central-differenced and compared against the
-# corresponding backward (chain-rule) mapping.
+# mapping_finite_difference: every pointwise mapping (linear, heaviside,
+# RAMP, Borrvall & Petersson, SIMP) is verified against a hardcoded,
+# independently-derived closed-form derivative -- both via central-difference
+# of the forward mapping and directly against the backward (chain-rule)
+# mapping.
+#
+# mapping_pde_filter: the Helmholtz-PDE based filter mapping is verified
+# against its own linearity and against the mass-weighted adjoint identity
+# the rest of Neko-TOP's sensitivity code relies on.
 
 set(CMAKE_FOLDER "Tests/Unit/Mapping")
 
 # ============================================================================ #
-# Define the test itself
+# Define the tests themselves
 
 add_pfunit_ctest(mapping_finite_difference
     TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/mapping_finite_difference.pf
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    LINK_LIBRARIES Neko-TOP::neko-top
+    MAX_PES 1
+)
+
+add_pfunit_ctest(mapping_pde_filter
+    TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/mapping_pde_filter.pf
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     LINK_LIBRARIES Neko-TOP::neko-top
     MAX_PES 1
@@ -23,9 +36,18 @@ set_tests_properties(mapping_finite_difference PROPERTIES
     TIMEOUT 120
 )
 
+set_tests_properties(mapping_pde_filter PROPERTIES
+    LABELS "unit;mapping"
+    ENVIRONMENT "NEKO_LOG_FILE=mapping_pde_filter.log"
+    TIMEOUT 120
+)
+
 # Disable treating unused-variable as error for pfunit tests
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     target_compile_options(mapping_finite_difference PRIVATE
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wno-unused-variable>
+    )
+    target_compile_options(mapping_pde_filter PRIVATE
         $<$<COMPILE_LANGUAGE:Fortran>:-Wno-unused-variable>
     )
 endif()

--- a/tests/unit/mapping/mapping_finite_difference.pf
+++ b/tests/unit/mapping/mapping_finite_difference.pf
@@ -1,17 +1,27 @@
-! Finite-difference verification of the RAMP and Borrvall & Petersson mappings.
+! Verification of the pointwise mapping types against independently derived,
+! hardcoded closed-form derivatives (not derived from the code under test).
 !
-! For a handful of representative points x strictly inside (0, 1) the forward
-! mapping is central-differenced,
-!     (f(x + eps) - f(x - eps)) / (2 eps),
-! and compared against the analytic derivative produced by the backward
-! (chain-rule) mapping (evaluated with a unit incoming sensitivity). This
-! locks in forward/backward consistency for both mapping types.
+! For a handful of representative points x strictly inside (0, 1) three things
+! are checked per mapping:
 !
-! In addition the closed-form endpoints are asserted directly:
-!   * RAMP is increasing: f(0) = f_min, f(1) = f_max.
-!   * Borrvall & Petersson is decreasing: f(0) = f_max, f(1) = f_min.
-! These endpoints differ, confirming the f_min/f_max assembly is genuinely
-! swapped between the two mappings and not merely renamed.
+!   (A) The forward mapping is central-differenced at two independent step
+!       sizes and compared against the hardcoded analytic derivative. The two
+!       step sizes are checked independently against their own tolerance --
+!       no convergence-ratio assertion is made, since for `linear_mapping`
+!       the truncation error is exactly zero and the observed error is
+!       rounding-dominated (it actually grows as h shrinks).
+!   (B) The hardcoded analytic derivative is compared against the
+!       `backward_mapping` output (evaluated with a unit incoming
+!       sensitivity), at a tight tolerance. This locks in that the coded
+!       backward (chain-rule) mapping matches the true derivative, not just
+!       that it is self-consistent with the forward mapping via finite
+!       differences.
+!   (C) For RAMP and Borrvall & Petersson the closed-form endpoints are
+!       asserted directly:
+!         * RAMP is increasing: f(0) = f_min, f(1) = f_max.
+!         * Borrvall & Petersson is decreasing: f(0) = f_max, f(1) = f_min.
+!       These endpoints differ, confirming the f_min/f_max assembly is
+!       genuinely swapped between the two mappings and not merely renamed.
 module mapping_finite_difference
   use mpi
   use pfunit
@@ -22,8 +32,11 @@ module mapping_finite_difference
   use field, only: field_t
   use coefs, only: coef_t
   use mapping, only: mapping_t
+  use linear_mapping, only: linear_mapping_t
+  use heaviside_mapping, only: heaviside_mapping_t
   use RAMP_mapping, only: RAMP_mapping_t
   use Borrvall_Petersson_mapping, only: Borrvall_Petersson_mapping_t
+  use SIMP_mapping, only: SIMP_mapping_t
   use json_module, only: json_file
   use comm, only: NEKO_COMM, pe_rank, pe_size, comm_init
   use neko_config, only: NEKO_BCKND_DEVICE
@@ -31,14 +44,24 @@ module mapping_finite_difference
        HOST_TO_DEVICE, DEVICE_TO_HOST
   implicit none
 
-  !> Central-difference step.
-  real(kind=rp), parameter :: fd_eps = 1.0e-6_rp
-  !> Relative tolerance for the finite-difference comparison.
-  real(kind=rp), parameter :: fd_tol = 1.0e-4_rp
+  !> Central-difference step sizes.
+  real(kind=rp), parameter :: fd_h1 = 1.0e-4_rp
+  real(kind=rp), parameter :: fd_h2 = 1.0e-6_rp
+  !> Relative tolerances for the two central-difference step sizes.
+  real(kind=rp), parameter :: fd_tol_h1 = 1.0e-4_rp
+  real(kind=rp), parameter :: fd_tol_h2 = 1.0e-7_rp
+  !> Relative tolerance for the analytic-vs-backward_mapping comparison.
+  real(kind=rp), parameter :: backward_rtol = 1.0e-12_rp
   !> Absolute tolerance for the closed-form endpoint comparison.
   real(kind=rp), parameter :: end_tol = 1.0e-8_rp
-  !> Polynomial order of the test space.
-  integer, parameter :: LX = 3
+  !> Polynomial order of the test space (order 7 => lx = 8).
+  integer, parameter :: LX = 8
+
+  !> Representative points strictly inside (0, 1), bounded away from 0 so
+  !! that SIMP with p < 1 (derivative singular only at x = 0) stays safe even
+  !! after subtracting fd_h1.
+  real(kind=rp), dimension(5), parameter :: x_test = &
+       [0.02_rp, 0.2_rp, 0.5_rp, 0.8_rp, 0.98_rp]
 
   @TestCase
   type, extends(MPITestCase) :: test_mapping
@@ -124,22 +147,81 @@ contains
 
   end function first_value
 
-  !> Run the finite-difference and endpoint checks for a single mapping.
+  ! ========================================================================== !
+  ! Hardcoded, independently-derived closed-form derivatives. These are
+  ! deliberately NOT computed by calling backward_mapping -- that would be
+  ! circular. All formulas below have been symbolically verified.
+
+  !> f(x) = f_min + (f_max - f_min) x ; f'(x) = f_max - f_min.
+  elemental function linear_fp_formula(x, f_min, f_max) result(fp)
+    real(kind=rp), intent(in) :: x, f_min, f_max
+    real(kind=rp) :: fp
+
+    fp = f_max - f_min
+
+  end function linear_fp_formula
+
+  !> den = tanh(beta eta) + tanh(beta (1-eta))
+  !! f(x) = (tanh(beta eta) + tanh(beta (x-eta))) / den
+  !! f'(x) = beta (1 - tanh(beta (x-eta))**2) / den
+  elemental function heaviside_fp_formula(x, beta, eta) result(fp)
+    real(kind=rp), intent(in) :: x, beta, eta
+    real(kind=rp) :: fp, den, t
+
+    den = tanh(beta * eta) + tanh(beta * (1.0_rp - eta))
+    t = tanh(beta * (x - eta))
+    fp = beta * (1.0_rp - t * t) / den
+
+  end function heaviside_fp_formula
+
+  !> f(x) = f_min + (f_max-f_min) x / (1 + q (1-x))
+  !! f'(x) = (f_max-f_min) (q+1) / (1 + q (1-x))**2
+  elemental function ramp_fp_formula(x, f_min, f_max, q) result(fp)
+    real(kind=rp), intent(in) :: x, f_min, f_max, q
+    real(kind=rp) :: fp
+
+    fp = (f_max - f_min) * (q + 1.0_rp) / &
+         (1.0_rp + q * (1.0_rp - x))**2
+
+  end function ramp_fp_formula
+
+  !> f(x) = f_max + (f_min-f_max) x (q+1) / (x+q)
+  !! f'(x) = (f_min-f_max) (q+1) q / (x+q)**2
+  elemental function bp_fp_formula(x, f_min, f_max, q) result(fp)
+    real(kind=rp), intent(in) :: x, f_min, f_max, q
+    real(kind=rp) :: fp
+
+    fp = (f_min - f_max) * (q + 1.0_rp) * q / (x + q)**2
+
+  end function bp_fp_formula
+
+  !> f(x) = f_min + (f_max-f_min) x**p ; f'(x) = (f_max-f_min) p x**(p-1)
+  elemental function simp_fp_formula(x, f_min, f_max, p) result(fp)
+    real(kind=rp), intent(in) :: x, f_min, f_max, p
+    real(kind=rp) :: fp
+
+    fp = (f_max - f_min) * p * x**(p - 1.0_rp)
+
+  end function simp_fp_formula
+
+  ! ========================================================================== !
+  ! Shared drivers.
+
+  !> Run checks (A) and (B) at every x in xs, against the corresponding
+  !! hardcoded derivative in fps.
   !! @param map The mapping under test.
   !! @param msh The mesh backing the test fields.
   !! @param Xh The function space backing the test fields.
-  !! @param f_at_0 Expected mapped value at x = 0.
-  !! @param f_at_1 Expected mapped value at x = 1.
-  subroutine run_checks(map, msh, Xh, f_at_0, f_at_1)
+  !! @param xs Representative design values.
+  !! @param fps Hardcoded analytic derivatives f'(xs).
+  subroutine run_pointwise_checks(map, msh, Xh, xs, fps)
     class(mapping_t), intent(inout) :: map
     type(mesh_t), intent(inout) :: msh
     type(space_t), intent(inout) :: Xh
-    real(kind=rp), intent(in) :: f_at_0, f_at_1
+    real(kind=rp), dimension(:), intent(in) :: xs, fps
 
     type(field_t) :: X_in, X_out_p, X_out_m, sens_in, sens_out
-    real(kind=rp), dimension(3), parameter :: x_test = &
-         [0.2_rp, 0.5_rp, 0.8_rp]
-    real(kind=rp) :: x, fd, analytic
+    real(kind=rp) :: x, fp, fd, analytic
     integer :: ip
 
     call X_in%init(msh, Xh, 'X_in')
@@ -148,34 +230,34 @@ contains
     call sens_in%init(msh, Xh, 'sens_in')
     call sens_out%init(msh, Xh, 'sens_out')
 
-    do ip = 1, size(x_test)
-       x = x_test(ip)
+    do ip = 1, size(xs)
+       x = xs(ip)
+       fp = fps(ip)
 
-       ! Analytic derivative via the backward mapping with a unit sensitivity:
-       ! sens_out = sens_in * df/dx = df/dx at x.
+       ! (B) Hardcoded analytic derivative vs. backward_mapping (unit
+       ! incoming sensitivity).
        call fill_field(X_in, x)
        call fill_field(sens_in, 1.0_rp)
        call map%backward_mapping(sens_out, sens_in, X_in)
        analytic = first_value(sens_out)
+       @assertRelativelyEqual(fp, analytic, backward_rtol)
 
-       ! Central difference of the forward mapping.
-       call fill_field(X_in, x + fd_eps)
+       ! (A) Central difference of the forward mapping, h = 1e-4.
+       call fill_field(X_in, x + fd_h1)
        call map%forward_mapping(X_out_p, X_in)
-       call fill_field(X_in, x - fd_eps)
+       call fill_field(X_in, x - fd_h1)
        call map%forward_mapping(X_out_m, X_in)
-       fd = (first_value(X_out_p) - first_value(X_out_m)) / (2.0_rp * fd_eps)
+       fd = (first_value(X_out_p) - first_value(X_out_m)) / (2.0_rp * fd_h1)
+       @assertRelativelyEqual(fp, fd, fd_tol_h1)
 
-       @assertRelativelyEqual(analytic, fd, fd_tol)
+       ! (A) Central difference of the forward mapping, h = 1e-6.
+       call fill_field(X_in, x + fd_h2)
+       call map%forward_mapping(X_out_p, X_in)
+       call fill_field(X_in, x - fd_h2)
+       call map%forward_mapping(X_out_m, X_in)
+       fd = (first_value(X_out_p) - first_value(X_out_m)) / (2.0_rp * fd_h2)
+       @assertRelativelyEqual(fp, fd, fd_tol_h2)
     end do
-
-    ! Closed-form endpoints.
-    call fill_field(X_in, 0.0_rp)
-    call map%forward_mapping(X_out_p, X_in)
-    @assertEqual(f_at_0, first_value(X_out_p), end_tol)
-
-    call fill_field(X_in, 1.0_rp)
-    call map%forward_mapping(X_out_p, X_in)
-    @assertEqual(f_at_1, first_value(X_out_p), end_tol)
 
     call X_in%free()
     call X_out_p%free()
@@ -183,7 +265,99 @@ contains
     call sens_in%free()
     call sens_out%free()
 
-  end subroutine run_checks
+  end subroutine run_pointwise_checks
+
+  !> Closed-form endpoint checks: f(0) and f(1).
+  !! @param map The mapping under test.
+  !! @param msh The mesh backing the test fields.
+  !! @param Xh The function space backing the test fields.
+  !! @param f_at_0 Expected mapped value at x = 0.
+  !! @param f_at_1 Expected mapped value at x = 1.
+  subroutine check_endpoints(map, msh, Xh, f_at_0, f_at_1)
+    class(mapping_t), intent(inout) :: map
+    type(mesh_t), intent(inout) :: msh
+    type(space_t), intent(inout) :: Xh
+    real(kind=rp), intent(in) :: f_at_0, f_at_1
+
+    type(field_t) :: X_in, X_out
+
+    call X_in%init(msh, Xh, 'X_in')
+    call X_out%init(msh, Xh, 'X_out')
+
+    call fill_field(X_in, 0.0_rp)
+    call map%forward_mapping(X_out, X_in)
+    @assertEqual(f_at_0, first_value(X_out), end_tol)
+
+    call fill_field(X_in, 1.0_rp)
+    call map%forward_mapping(X_out, X_in)
+    @assertEqual(f_at_1, first_value(X_out), end_tol)
+
+    call X_in%free()
+    call X_out%free()
+
+  end subroutine check_endpoints
+
+  ! ========================================================================== !
+  ! linear mapping: f(x) = f_min + (f_max - f_min) x.
+
+  @test(npes=[1])
+  subroutine test_linear(this)
+    class(test_mapping), intent(inout) :: this
+    type(space_t) :: Xh
+    type(mesh_t) :: msh
+    type(coef_t) :: coef
+    type(linear_mapping_t) :: map
+    real(kind=rp), parameter :: f_min = 1.0_rp, f_max = 100.0_rp
+    real(kind=rp), dimension(size(x_test)) :: fp
+    integer :: ierr
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    call gen_msh(msh)
+    call Xh%init(GLL, LX, LX, LX)
+
+    call map%init_from_attributes(coef, f_min, f_max)
+    fp = linear_fp_formula(x_test, f_min, f_max)
+    call run_pointwise_checks(map, msh, Xh, x_test, fp)
+
+    call map%free()
+    call Xh%free()
+    call msh%free()
+
+  end subroutine test_linear
+
+  ! ========================================================================== !
+  ! Smooth Heaviside mapping.
+
+  @test(npes=[1])
+  subroutine test_heaviside(this)
+    class(test_mapping), intent(inout) :: this
+    type(space_t) :: Xh
+    type(mesh_t) :: msh
+    type(coef_t) :: coef
+    type(heaviside_mapping_t) :: map
+    real(kind=rp), parameter :: beta = 8.0_rp, eta = 0.4_rp
+    real(kind=rp), dimension(size(x_test)) :: fp
+    integer :: ierr
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    call gen_msh(msh)
+    call Xh%init(GLL, LX, LX, LX)
+
+    call map%init_from_attributes(coef, beta, eta)
+    fp = heaviside_fp_formula(x_test, beta, eta)
+    call run_pointwise_checks(map, msh, Xh, x_test, fp)
+
+    call map%free()
+    call Xh%free()
+    call msh%free()
+
+  end subroutine test_heaviside
 
   ! ========================================================================== !
   ! RAMP mapping: increasing, f(0) = f_min, f(1) = f_max.
@@ -195,7 +369,8 @@ contains
     type(mesh_t) :: msh
     type(coef_t) :: coef
     type(RAMP_mapping_t) :: map
-    real(kind=rp), parameter :: f_min = 1.0_rp, f_max = 100.0_rp
+    real(kind=rp), parameter :: f_min = 1.0_rp, f_max = 100.0_rp, q = 3.0_rp
+    real(kind=rp), dimension(size(x_test)) :: fp
     integer :: ierr
 
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
@@ -206,8 +381,10 @@ contains
     call Xh%init(GLL, LX, LX, LX)
 
     ! q /= 1 so the RAMP and Borrvall & Petersson shapes are distinguishable.
-    call map%init_from_attributes(coef, f_min, f_max, 3.0_rp)
-    call run_checks(map, msh, Xh, f_min, f_max)
+    call map%init_from_attributes(coef, f_min, f_max, q)
+    fp = ramp_fp_formula(x_test, f_min, f_max, q)
+    call run_pointwise_checks(map, msh, Xh, x_test, fp)
+    call check_endpoints(map, msh, Xh, f_min, f_max)
 
     call map%free()
     call Xh%free()
@@ -217,6 +394,11 @@ contains
 
   ! ========================================================================== !
   ! Borrvall & Petersson mapping: decreasing, f(0) = f_max, f(1) = f_min.
+  !
+  ! Constructed and exercised through its own forward_mapping/backward_mapping
+  ! (which internally swap f_min/f_max when calling the shared CPU kernel) --
+  ! NOT the raw kernel with unswapped arguments, which would validate the
+  ! wrong (increasing) shape.
 
   @test(npes=[1])
   subroutine test_borrvall_petersson(this)
@@ -225,7 +407,8 @@ contains
     type(mesh_t) :: msh
     type(coef_t) :: coef
     type(Borrvall_Petersson_mapping_t) :: map
-    real(kind=rp), parameter :: f_min = 1.0_rp, f_max = 100.0_rp
+    real(kind=rp), parameter :: f_min = 1.0_rp, f_max = 100.0_rp, q = 3.0_rp
+    real(kind=rp), dimension(size(x_test)) :: fp
     integer :: ierr
 
     call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
@@ -235,15 +418,81 @@ contains
     call gen_msh(msh)
     call Xh%init(GLL, LX, LX, LX)
 
-    call map%init_from_attributes(coef, f_min, f_max, 3.0_rp)
+    call map%init_from_attributes(coef, f_min, f_max, q)
+    fp = bp_fp_formula(x_test, f_min, f_max, q)
+    call run_pointwise_checks(map, msh, Xh, x_test, fp)
     ! Note the swapped endpoints relative to RAMP.
-    call run_checks(map, msh, Xh, f_max, f_min)
+    call check_endpoints(map, msh, Xh, f_max, f_min)
 
     call map%free()
     call Xh%free()
     call msh%free()
 
   end subroutine test_borrvall_petersson
+
+  ! ========================================================================== !
+  ! SIMP mapping, p = 3 (normal penalization).
+
+  @test(npes=[1])
+  subroutine test_simp(this)
+    class(test_mapping), intent(inout) :: this
+    type(space_t) :: Xh
+    type(mesh_t) :: msh
+    type(coef_t) :: coef
+    type(SIMP_mapping_t) :: map
+    real(kind=rp), parameter :: f_min = 1.0_rp, f_max = 100.0_rp, p = 3.0_rp
+    real(kind=rp), dimension(size(x_test)) :: fp
+    integer :: ierr
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    call gen_msh(msh)
+    call Xh%init(GLL, LX, LX, LX)
+
+    call map%init_from_attributes(coef, f_min, f_max, p)
+    fp = simp_fp_formula(x_test, f_min, f_max, p)
+    call run_pointwise_checks(map, msh, Xh, x_test, fp)
+
+    call map%free()
+    call Xh%free()
+    call msh%free()
+
+  end subroutine test_simp
+
+  ! ========================================================================== !
+  ! SIMP mapping, p = 0.5 (penalty below 1). The derivative blows up only at
+  ! x = 0 exactly, which x_test never touches (min 0.02, fd_h1 <= 1e-4), so
+  ! this remains safe.
+
+  @test(npes=[1])
+  subroutine test_simp_p_lt_1(this)
+    class(test_mapping), intent(inout) :: this
+    type(space_t) :: Xh
+    type(mesh_t) :: msh
+    type(coef_t) :: coef
+    type(SIMP_mapping_t) :: map
+    real(kind=rp), parameter :: f_min = 1.0_rp, f_max = 100.0_rp, p = 0.5_rp
+    real(kind=rp), dimension(size(x_test)) :: fp
+    integer :: ierr
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    call gen_msh(msh)
+    call Xh%init(GLL, LX, LX, LX)
+
+    call map%init_from_attributes(coef, f_min, f_max, p)
+    fp = simp_fp_formula(x_test, f_min, f_max, p)
+    call run_pointwise_checks(map, msh, Xh, x_test, fp)
+
+    call map%free()
+    call Xh%free()
+    call msh%free()
+
+  end subroutine test_simp_p_lt_1
 
   ! ========================================================================== !
   ! Lock in the detection that gates the removed 'convex_up' option. The RAMP

--- a/tests/unit/mapping/mapping_finite_difference.pf
+++ b/tests/unit/mapping/mapping_finite_difference.pf
@@ -42,6 +42,7 @@ module mapping_finite_difference
   use neko_config, only: NEKO_BCKND_DEVICE
   use device, only: device_init, device_finalize, device_memcpy, &
        HOST_TO_DEVICE, DEVICE_TO_HOST
+  use field_math, only: field_cfill
   implicit none
 
   !> Central-difference step sizes.
@@ -125,15 +126,6 @@ contains
     call msh%generate_conn()
 
   end subroutine gen_msh
-
-  !> Fill a field with a uniform value (on host and device).
-  subroutine fill_field(f, val)
-    type(field_t), intent(inout) :: f
-    real(kind=rp), intent(in) :: val
-
-    f = val
-
-  end subroutine fill_field
 
   !> Read back the first entry of a field, copying from device if needed.
   function first_value(f) result(val)
@@ -236,24 +228,24 @@ contains
 
        ! (B) Hardcoded analytic derivative vs. backward_mapping (unit
        ! incoming sensitivity).
-       call fill_field(X_in, x)
-       call fill_field(sens_in, 1.0_rp)
+       call field_cfill(X_in, x)
+       call field_cfill(sens_in, 1.0_rp)
        call map%backward_mapping(sens_out, sens_in, X_in)
        analytic = first_value(sens_out)
        @assertRelativelyEqual(fp, analytic, backward_rtol)
 
        ! (A) Central difference of the forward mapping, h = 1e-4.
-       call fill_field(X_in, x + fd_h1)
+       call field_cfill(X_in, x + fd_h1)
        call map%forward_mapping(X_out_p, X_in)
-       call fill_field(X_in, x - fd_h1)
+       call field_cfill(X_in, x - fd_h1)
        call map%forward_mapping(X_out_m, X_in)
        fd = (first_value(X_out_p) - first_value(X_out_m)) / (2.0_rp * fd_h1)
        @assertRelativelyEqual(fp, fd, fd_tol_h1)
 
        ! (A) Central difference of the forward mapping, h = 1e-6.
-       call fill_field(X_in, x + fd_h2)
+       call field_cfill(X_in, x + fd_h2)
        call map%forward_mapping(X_out_p, X_in)
-       call fill_field(X_in, x - fd_h2)
+       call field_cfill(X_in, x - fd_h2)
        call map%forward_mapping(X_out_m, X_in)
        fd = (first_value(X_out_p) - first_value(X_out_m)) / (2.0_rp * fd_h2)
        @assertRelativelyEqual(fp, fd, fd_tol_h2)
@@ -284,11 +276,11 @@ contains
     call X_in%init(msh, Xh, 'X_in')
     call X_out%init(msh, Xh, 'X_out')
 
-    call fill_field(X_in, 0.0_rp)
+    call field_cfill(X_in, 0.0_rp)
     call map%forward_mapping(X_out, X_in)
     @assertEqual(f_at_0, first_value(X_out), end_tol)
 
-    call fill_field(X_in, 1.0_rp)
+    call field_cfill(X_in, 1.0_rp)
     call map%forward_mapping(X_out, X_in)
     @assertEqual(f_at_1, first_value(X_out), end_tol)
 

--- a/tests/unit/mapping/mapping_pde_filter.pf
+++ b/tests/unit/mapping/mapping_pde_filter.pf
@@ -1,0 +1,478 @@
+! Verification of PDE_filter_mapping_t (a Helmholtz-PDE based filter, solved
+! via a Krylov solve -- not a pointwise mapping) against its own linearity and
+! against the mass ("B")-weighted adjoint identity that the rest of
+! Neko-TOP's sensitivity code relies on (see design_brinkman.f90,
+! volume_constraint.f90).
+!
+! Three checks are performed, using a real, fully-initialized coef_t built on
+! a two-element hex mesh at polynomial order 7 (lx = 8):
+!
+!   1. Linearity / JVP check. The forward map is exactly linear in its input,
+!      so for any step h,
+!        (forward(X0 + h delta) - forward(X0 - h delta)) / (2h) = forward(delta)
+!      up to Krylov solver tolerance. h = 1 is used (not a tiny step) since
+!      exact linearity means no truncation error to trade off against
+!      cancellation error.
+!   2. B-weighted transpose/adjoint check (the critical, discriminating
+!      test -- it mixes forward and backward, so it can catch a bug specific
+!      to backward_mapping that a forward-only symmetry check could not):
+!        glsc3(forward(w), B, v) ~= glsc3(w, B, backward(v, X_in))
+!      for impulse fields v, w. This is exactly the mass-weighted adjoint
+!      identity assumed by the rest of the sensitivity code.
+!   3. Secondary regression guard (NOT proof of adjointness on its own):
+!      backward_mapping(v, X_in) ~= forward_mapping(v) elementwise, since
+!      PDE_filter_backward_mapping runs a structurally identical Helmholtz
+!      solve to PDE_filter_forward_mapping (it does not use its X_in argument
+!      at all -- see the comments in PDE_filter_mapping.f90 around
+!      backward_mapping, lines ~297-315).
+!
+! Two impulse-field variants are used throughout: an "interior" impulse,
+! nonzero only at a node strictly inside element 1, and an "interface"
+! impulse, nonzero (with a consistently-set value) at both local copies of a
+! shared node on the element 1 / element 2 interface.
+module mapping_pde_filter
+  use mpi
+  use pfunit
+  use num_types, only: rp
+  use mesh, only: mesh_t
+  use point, only: point_t
+  use space, only: space_t, GLL
+  use dofmap, only: dofmap_t
+  use gather_scatter, only: gs_t
+  use field, only: field_t
+  use coefs, only: coef_t
+  use math, only: glsc3
+  use field_math, only: field_copy, field_cmult, field_add2s2, field_sub3
+  use PDE_filter_mapping, only: PDE_filter_t
+  use scratch_registry, only: neko_scratch_registry
+  use comm, only: NEKO_COMM, pe_rank, pe_size, comm_init
+  use neko_config, only: NEKO_BCKND_DEVICE
+  use device, only: device_init, device_finalize, device_memcpy, &
+       HOST_TO_DEVICE, DEVICE_TO_HOST
+  implicit none
+
+  !> Polynomial order of the test space (order 7 => lx = 8).
+  integer, parameter :: LX = 8
+
+  !> Filter attributes.
+  real(kind=rp), parameter :: filter_r = 0.2_rp
+  real(kind=rp), parameter :: filter_tol = 1.0e-10_rp
+  integer, parameter :: filter_max_iter = 200
+
+  !> Base field value and impulse amplitude.
+  real(kind=rp), parameter :: x0_val = 0.5_rp
+  real(kind=rp), parameter :: impulse_amp = 1.0_rp
+
+  !> JVP step (the filter is exactly linear, so any h works up to Krylov
+  !! tolerance; a large h avoids cancellation error).
+  real(kind=rp), parameter :: jvp_h = 1.0_rp
+
+  !> Tolerances for the three checks.
+  real(kind=rp), parameter :: linearity_rtol = 1.0e-6_rp
+  real(kind=rp), parameter :: adjoint_rtol = 1.0e-6_rp
+  real(kind=rp), parameter :: regression_rtol = 1.0e-10_rp
+
+  @TestCase
+  type, extends(MPITestCase) :: test_pde_filter
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type test_pde_filter
+
+contains
+
+  subroutine setUp(this)
+    class(test_pde_filter), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_init
+    end if
+    call comm_init
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(test_pde_filter), intent(inout) :: this
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_finalize
+    end if
+  end subroutine tearDown
+
+  !> Build a minimal two-element hex mesh (copied from Neko's field test).
+  !! Element 1 spans x in [0, 1], element 2 spans x in [1, 2], sharing the
+  !! x = 1 face.
+  subroutine gen_msh(msh)
+    type(mesh_t), intent(inout) :: msh
+    type(point_t) :: p(12)
+
+    call p(1)%init(0d0, 0d0, 0d0)
+    call p(1)%set_id(1)
+    call p(2)%init(1d0, 0d0, 0d0)
+    call p(2)%set_id(2)
+    call p(3)%init(0d0, 1d0, 0d0)
+    call p(3)%set_id(4)
+    call p(4)%init(1d0, 1d0, 0d0)
+    call p(4)%set_id(3)
+    call p(5)%init(2d0, 0d0, 0d0)
+    call p(5)%set_id(5)
+    call p(6)%init(2d0, 1d0, 0d0)
+    call p(6)%set_id(6)
+    call p(7)%init(0d0, 0d0, 1d0)
+    call p(7)%set_id(7)
+    call p(8)%init(1d0, 0d0, 1d0)
+    call p(8)%set_id(8)
+    call p(9)%init(1d0, 1d0, 1d0)
+    call p(9)%set_id(9)
+    call p(10)%init(0d0, 1d0, 1d0)
+    call p(10)%set_id(10)
+    call p(11)%init(2d0, 0d0, 1d0)
+    call p(11)%set_id(11)
+    call p(12)%init(2d0, 1d0, 1d0)
+    call p(12)%set_id(12)
+
+    call msh%init(3, 2)
+    call msh%add_element(1, 1, p(1), p(2), p(4), p(3), &
+         p(7), p(8), p(9), p(10))
+    call msh%add_element(2, 2, p(2), p(5), p(6), p(4), &
+         p(8), p(11), p(12), p(9))
+    call msh%generate_conn()
+
+  end subroutine gen_msh
+
+  !> Build the full SEM coefficient chain: mesh -> space -> dofmap -> gs ->
+  !! coef, and hook up the scratch registry the filter's forward/backward
+  !! mapping relies on for temporaries.
+  subroutine build_fixture(msh, Xh, dof, gs, coef)
+    type(mesh_t), intent(inout) :: msh
+    type(space_t), intent(inout) :: Xh
+    type(dofmap_t), intent(inout) :: dof
+    type(gs_t), intent(inout) :: gs
+    type(coef_t), intent(inout) :: coef
+
+    call gen_msh(msh)
+    call Xh%init(GLL, LX, LX, LX)
+    call dof%init(msh, Xh)
+    call gs%init(dof)
+    call coef%init(gs)
+    call neko_scratch_registry%init(dof = dof)
+
+  end subroutine build_fixture
+
+  !> Attach coef to the mapping and construct it from attributes. `coef` must
+  !! be declared `target` at the call site, since PDE_filter_init_from_json's
+  !! usual `this%coef => coef` wiring (normally done by mapping_init_base) is
+  !! bypassed here in favour of calling init_from_attributes directly.
+  subroutine build_map(map, coef)
+    type(PDE_filter_t), intent(inout) :: map
+    type(coef_t), target, intent(inout) :: coef
+
+    map%coef => coef
+    call map%init_from_attributes(coef, filter_r, filter_tol, &
+         filter_max_iter, "cg", "jacobi")
+
+  end subroutine build_map
+
+  !> Fill a field with a uniform value (on host and device).
+  subroutine fill_uniform(f, val)
+    type(field_t), intent(inout) :: f
+    real(kind=rp), intent(in) :: val
+
+    f = val
+
+  end subroutine fill_uniform
+
+  !> Set a single field entry (on host and device).
+  subroutine set_point(f, i, j, k, e, val)
+    type(field_t), intent(inout) :: f
+    integer, intent(in) :: i, j, k, e
+    real(kind=rp), intent(in) :: val
+
+    f%x(i, j, k, e) = val
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_memcpy(f%x, f%x_d, f%size(), HOST_TO_DEVICE, .true.)
+    end if
+
+  end subroutine set_point
+
+  !> Interior-impulse field: nonzero only at (4,4,4,1), an interior node of
+  !! element 1, away from every face (all local indices in [2,7]).
+  subroutine make_interior_impulse(f, amp)
+    type(field_t), intent(inout) :: f
+    real(kind=rp), intent(in) :: amp
+
+    call fill_uniform(f, 0.0_rp)
+    call set_point(f, 4, 4, 4, 1, amp)
+
+  end subroutine make_interior_impulse
+
+  !> Interface-impulse field: nonzero, with a consistently-set value, at both
+  !! local copies -- (8,4,4,1) and (1,4,4,2) -- of the shared global dof at
+  !! the x = 1 face between element 1 and element 2, at a general
+  !! face-interior point (not a corner).
+  subroutine make_interface_impulse(f, amp)
+    type(field_t), intent(inout) :: f
+    real(kind=rp), intent(in) :: amp
+
+    call fill_uniform(f, 0.0_rp)
+    call set_point(f, 8, 4, 4, 1, amp)
+    call set_point(f, 1, 4, 4, 2, amp)
+
+  end subroutine make_interface_impulse
+
+  !> Assert that two fields agree to a relative tolerance under the
+  !! mass-weighted (B) L2 norm: || actual - expected ||_B / || expected ||_B.
+  subroutine assert_fields_relatively_equal(actual, expected, coef, rtol)
+    type(field_t), intent(inout) :: actual, expected
+    type(coef_t), intent(inout) :: coef
+    real(kind=rp), intent(in) :: rtol
+
+    type(field_t) :: diff
+    real(kind=rp) :: norm_diff, norm_ref
+    integer :: n
+
+    n = coef%dof%size()
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_memcpy(actual%x, actual%x_d, n, DEVICE_TO_HOST, .true.)
+       call device_memcpy(expected%x, expected%x_d, n, DEVICE_TO_HOST, .true.)
+    end if
+
+    call diff%init(coef%dof, 'diff')
+    call field_sub3(diff, actual, expected)
+
+    norm_diff = sqrt(glsc3(diff%x, coef%B, diff%x, n))
+    norm_ref = sqrt(glsc3(expected%x, coef%B, expected%x, n))
+
+    @assertEqual(0.0_rp, norm_diff / norm_ref, tolerance = rtol)
+
+    call diff%free()
+
+  end subroutine assert_fields_relatively_equal
+
+  ! ========================================================================== !
+  ! Check 1: Linearity / JVP check.
+
+  subroutine check_linearity(map, coef, delta)
+    type(PDE_filter_t), intent(inout) :: map
+    type(coef_t), intent(inout) :: coef
+    type(field_t), intent(inout) :: delta
+
+    type(field_t) :: X0, Xp, Xm, Fp, Fm, Fd, jvp
+
+    call X0%init(coef%dof, 'X0')
+    call Xp%init(coef%dof, 'Xp')
+    call Xm%init(coef%dof, 'Xm')
+    call Fp%init(coef%dof, 'Fp')
+    call Fm%init(coef%dof, 'Fm')
+    call Fd%init(coef%dof, 'Fd')
+    call jvp%init(coef%dof, 'jvp')
+
+    call fill_uniform(X0, x0_val)
+
+    call field_copy(Xp, X0)
+    call field_add2s2(Xp, delta, jvp_h)
+    call field_copy(Xm, X0)
+    call field_add2s2(Xm, delta, -jvp_h)
+
+    call map%forward_mapping(Fp, Xp)
+    call map%forward_mapping(Fm, Xm)
+    call map%forward_mapping(Fd, delta)
+
+    call field_sub3(jvp, Fp, Fm)
+    call field_cmult(jvp, 1.0_rp / (2.0_rp * jvp_h))
+
+    call assert_fields_relatively_equal(jvp, Fd, coef, linearity_rtol)
+
+    call X0%free()
+    call Xp%free()
+    call Xm%free()
+    call Fp%free()
+    call Fm%free()
+    call Fd%free()
+    call jvp%free()
+
+  end subroutine check_linearity
+
+  ! ========================================================================== !
+  ! Check 2: B-weighted transpose/adjoint check.
+
+  subroutine check_adjoint(map, coef)
+    type(PDE_filter_t), intent(inout) :: map
+    type(coef_t), intent(inout) :: coef
+
+    type(field_t) :: v, w, X0, Fw, Bv
+    real(kind=rp) :: lhs, rhs
+    integer :: n
+
+    n = coef%dof%size()
+
+    call v%init(coef%dof, 'v')
+    call w%init(coef%dof, 'w')
+    call X0%init(coef%dof, 'X0')
+    call Fw%init(coef%dof, 'Fw')
+    call Bv%init(coef%dof, 'Bv')
+
+    call make_interior_impulse(v, impulse_amp)
+    call make_interface_impulse(w, impulse_amp)
+    call fill_uniform(X0, x0_val)
+
+    ! glsc3(forward(w), B, v)
+    call map%forward_mapping(Fw, w)
+
+    ! glsc3(w, B, backward(v, X_in = X0))
+    call map%backward_mapping(Bv, v, X0)
+
+    if (NEKO_BCKND_DEVICE .eq. 1) then
+       call device_memcpy(Fw%x, Fw%x_d, n, DEVICE_TO_HOST, .true.)
+       call device_memcpy(v%x, v%x_d, n, DEVICE_TO_HOST, .true.)
+       call device_memcpy(w%x, w%x_d, n, DEVICE_TO_HOST, .true.)
+       call device_memcpy(Bv%x, Bv%x_d, n, DEVICE_TO_HOST, .true.)
+    end if
+
+    lhs = glsc3(Fw%x, coef%B, v%x, n)
+    rhs = glsc3(w%x, coef%B, Bv%x, n)
+
+    @assertRelativelyEqual(lhs, rhs, adjoint_rtol)
+
+    call v%free()
+    call w%free()
+    call X0%free()
+    call Fw%free()
+    call Bv%free()
+
+  end subroutine check_adjoint
+
+  ! ========================================================================== !
+  ! Check 3: secondary regression guard (NOT proof of adjointness on its own)
+  ! -- backward_mapping and forward_mapping run structurally identical solves,
+  ! so should agree tightly for any input.
+
+  subroutine check_regression(map, coef, v)
+    type(PDE_filter_t), intent(inout) :: map
+    type(coef_t), intent(inout) :: coef
+    type(field_t), intent(inout) :: v
+
+    type(field_t) :: X0, Fv, Bv
+
+    call X0%init(coef%dof, 'X0')
+    call Fv%init(coef%dof, 'Fv')
+    call Bv%init(coef%dof, 'Bv')
+
+    call fill_uniform(X0, x0_val)
+
+    call map%forward_mapping(Fv, v)
+    call map%backward_mapping(Bv, v, X0)
+
+    call assert_fields_relatively_equal(Bv, Fv, coef, regression_rtol)
+
+    call X0%free()
+    call Fv%free()
+    call Bv%free()
+
+  end subroutine check_regression
+
+  ! ========================================================================== !
+  ! Test entry points.
+
+  @test(npes=[1])
+  subroutine test_pde_filter_linearity(this)
+    class(test_pde_filter), intent(inout) :: this
+    type(mesh_t) :: msh
+    type(space_t) :: Xh
+    type(dofmap_t) :: dof
+    type(gs_t) :: gs
+    type(coef_t), target :: coef
+    type(PDE_filter_t) :: map
+    type(field_t) :: delta
+    integer :: ierr
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    call build_fixture(msh, Xh, dof, gs, coef)
+    call build_map(map, coef)
+
+    call delta%init(coef%dof, 'delta')
+
+    call make_interior_impulse(delta, impulse_amp)
+    call check_linearity(map, coef, delta)
+
+    call make_interface_impulse(delta, impulse_amp)
+    call check_linearity(map, coef, delta)
+
+    call delta%free()
+    call map%free()
+    call coef%free()
+    call gs%free()
+    call dof%free()
+    call Xh%free()
+    call msh%free()
+
+  end subroutine test_pde_filter_linearity
+
+  @test(npes=[1])
+  subroutine test_pde_filter_adjoint(this)
+    class(test_pde_filter), intent(inout) :: this
+    type(mesh_t) :: msh
+    type(space_t) :: Xh
+    type(dofmap_t) :: dof
+    type(gs_t) :: gs
+    type(coef_t), target :: coef
+    type(PDE_filter_t) :: map
+    integer :: ierr
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    call build_fixture(msh, Xh, dof, gs, coef)
+    call build_map(map, coef)
+
+    call check_adjoint(map, coef)
+
+    call map%free()
+    call coef%free()
+    call gs%free()
+    call dof%free()
+    call Xh%free()
+    call msh%free()
+
+  end subroutine test_pde_filter_adjoint
+
+  @test(npes=[1])
+  subroutine test_pde_filter_regression(this)
+    class(test_pde_filter), intent(inout) :: this
+    type(mesh_t) :: msh
+    type(space_t) :: Xh
+    type(dofmap_t) :: dof
+    type(gs_t) :: gs
+    type(coef_t), target :: coef
+    type(PDE_filter_t) :: map
+    type(field_t) :: v
+    integer :: ierr
+
+    call MPI_Comm_dup(this%getMpiCommunicator(), NEKO_COMM%mpi_val, ierr)
+    pe_rank = this%getProcessRank()
+    pe_size = this%getNumProcesses()
+
+    call build_fixture(msh, Xh, dof, gs, coef)
+    call build_map(map, coef)
+
+    call v%init(coef%dof, 'v')
+
+    call make_interior_impulse(v, impulse_amp)
+    call check_regression(map, coef, v)
+
+    call make_interface_impulse(v, impulse_amp)
+    call check_regression(map, coef, v)
+
+    call v%free()
+    call map%free()
+    call coef%free()
+    call gs%free()
+    call dof%free()
+    call Xh%free()
+    call msh%free()
+
+  end subroutine test_pde_filter_regression
+
+end module mapping_pde_filter

--- a/tests/unit/mapping/mapping_pde_filter.pf
+++ b/tests/unit/mapping/mapping_pde_filter.pf
@@ -49,6 +49,7 @@ module mapping_pde_filter
   use neko_config, only: NEKO_BCKND_DEVICE
   use device, only: device_init, device_finalize, device_memcpy, &
        HOST_TO_DEVICE, DEVICE_TO_HOST
+  use field_math, only: field_cfill
   implicit none
 
   !> Polynomial order of the test space (order 7 => lx = 8).
@@ -170,15 +171,6 @@ contains
 
   end subroutine build_map
 
-  !> Fill a field with a uniform value (on host and device).
-  subroutine fill_uniform(f, val)
-    type(field_t), intent(inout) :: f
-    real(kind=rp), intent(in) :: val
-
-    f = val
-
-  end subroutine fill_uniform
-
   !> Set a single field entry (on host and device).
   subroutine set_point(f, i, j, k, e, val)
     type(field_t), intent(inout) :: f
@@ -198,7 +190,7 @@ contains
     type(field_t), intent(inout) :: f
     real(kind=rp), intent(in) :: amp
 
-    call fill_uniform(f, 0.0_rp)
+    call field_cfill(f, 0.0_rp)
     call set_point(f, 4, 4, 4, 1, amp)
 
   end subroutine make_interior_impulse
@@ -211,7 +203,7 @@ contains
     type(field_t), intent(inout) :: f
     real(kind=rp), intent(in) :: amp
 
-    call fill_uniform(f, 0.0_rp)
+    call field_cfill(f, 0.0_rp)
     call set_point(f, 8, 4, 4, 1, amp)
     call set_point(f, 1, 4, 4, 2, amp)
 
@@ -265,7 +257,7 @@ contains
     call Fd%init(coef%dof, 'Fd')
     call jvp%init(coef%dof, 'jvp')
 
-    call fill_uniform(X0, x0_val)
+    call field_cfill(X0, x0_val)
 
     call field_copy(Xp, X0)
     call field_add2s2(Xp, delta, jvp_h)
@@ -312,7 +304,7 @@ contains
 
     call make_interior_impulse(v, impulse_amp)
     call make_interface_impulse(w, impulse_amp)
-    call fill_uniform(X0, x0_val)
+    call field_cfill(X0, x0_val)
 
     ! glsc3(forward(w), B, v)
     call map%forward_mapping(Fw, w)
@@ -356,7 +348,7 @@ contains
     call Fv%init(coef%dof, 'Fv')
     call Bv%init(coef%dof, 'Bv')
 
-    call fill_uniform(X0, x0_val)
+    call field_cfill(X0, x0_val)
 
     call map%forward_mapping(Fv, v)
     call map%backward_mapping(Bv, v, X0)


### PR DESCRIPTION
Extends tests/unit/mapping/mapping_finite_difference.pf to cover linear, heaviside, RAMP, Borrvall_Petersson, and SIMP (p=3 and p<1) mappings, up from RAMP/Borrvall_Petersson only. Each mapping's backward_mapping is now checked against a hand-derived, independently hardcoded closed-form derivative (not just FD-vs-backward self-consistency), at two finite-difference step sizes, on an order-7 (LX=8) mesh.

Adds tests/unit/mapping/mapping_pde_filter.pf, the first coverage for PDE_filter_mapping_t: a linearity/JVP check and a mass-weighted (B) transpose/adjoint check that mixes forward_mapping and backward_mapping. The adjoint check resolves an open question in PDE_filter_mapping.f90's backward_mapping comments about whether the coded chain rule is a true adjoint -- it is, under the mass-weighted inner product convention the rest of the sensitivity code already uses.