### PR TITLE
Fix scalar boundary condition type for passive scalar case

### DIFF
--- a/tests/regression/sensitivity/cases/passive_scalar.case
+++ b/tests/regression/sensitivity/cases/passive_scalar.case
@@ -65,7 +65,7 @@
             },
             "boundary_conditions": [
                 {
-                    "type": "user",
+                    "type": "user_dirichlet",
                     "zone_indices": [ 1 ]
                 },
                 {


### PR DESCRIPTION
Correct the boundary condition type from "user" to "user_dirichlet" in the scalar boundary condition factory to prevent initialization errors. This change aligns the semantics with the fluid side's boundary conditions.