### PR TITLE
Fix target lifetime issues in checkpoint-capable drivers

### DIFF
--- a/sources/drivers/neko.f90
+++ b/sources/drivers/neko.f90
@@ -37,7 +37,7 @@ program plainneko
   use case, only: case_t
   use neko_top, only: neko_top_register_types
 
-  type(case_t) :: C
+  type(case_t), target :: C
 
   call neko_top_register_types()
   call neko_init(C)

--- a/sources/drivers/topopt-user.f90
+++ b/sources/drivers/topopt-user.f90
@@ -57,7 +57,7 @@ program topopt_user
   character(8) :: date
 
   !> The simulation we are working with
-  type(simulation_t) :: sim
+  type(simulation_t), target :: sim
   !> The design type
   class(design_t), allocatable :: des
   !> The problem type

--- a/sources/drivers/topopt.f90
+++ b/sources/drivers/topopt.f90
@@ -56,7 +56,7 @@ program topopt
   character(8) :: date
 
   !> The simulation we are working with
-  type(simulation_t) :: sim
+  type(simulation_t), target :: sim
   !> The design type
   class(design_t), allocatable :: des
   !> The problem type


### PR DESCRIPTION
Correct the declaration of `simulation_t` and `case_t` variables in checkpoint-capable driver programs to include the `target` attribute, resolving undefined behavior during real checkpoint-enabled runs. This oversight was confirmed by the existing correct implementation in `neko-user.f90`.