### PR TITLE
Fix double HDF5 link causing SIGSEGV in checkpoint tests

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -106,8 +106,6 @@ target_link_libraries(neko-top PUBLIC
     $<$<BOOL:${CUDAToolkit_FOUND}>:CUDA::cudart>
     $<$<BOOL:${hipblas_FOUND}>:roc::hipblas>
     $<$<BOOL:${hipsolver_FOUND}>:roc::hipsolver>
-    $<$<BOOL:${HDF5_PKG_FOUND}>:PkgConfig::hdf5>
-    $<$<BOOL:${HDF5_FOUND}>:HDF5::HDF5>
 )
 
 # ============================================================================ #


### PR DESCRIPTION
Resolve a SIGSEGV issue in checkpoint tests by removing redundant HDF5 library links, ensuring only the correct parallel HDF5 library is used. This change addresses the root cause of crashes during HDF5 initialization.